### PR TITLE
PMM-5551 PMM-5527 support for Maria DB, Workload

### DIFF
--- a/pmm-tests/pmm-framework.sh
+++ b/pmm-tests/pmm-framework.sh
@@ -1247,8 +1247,8 @@ add_clients(){
       else
         dbdeployer deploy multiple $VERSION_ACCURATE --sandbox-binary $WORKDIR/mysql --nodes $ADDCLIENTS_COUNT --force
         node_port=`dbdeployer sandboxes --header | grep $VERSION_ACCURATE | grep 'multiple' | awk -F'[' '{print $2}' | awk -F' ' '{print $1}'`
-        mysql -h 127.0.0.1 -u msandbox -pmsandbox --port $node_port -e "ALTER USER 'msandbox'@'localhost' IDENTIFIED WITH mysql_native_password BY 'msandbox';"
         for j in `seq 1  ${ADDCLIENTS_COUNT}`;do
+          mysql -h 127.0.0.1 -u msandbox -pmsandbox --port $node_port -e "ALTER USER 'msandbox'@'localhost' IDENTIFIED WITH mysql_native_password BY 'msandbox';"
           #node_port=`dbdeployer sandboxes --header | grep $VERSION_ACCURATE | grep 'multiple' | awk -F'[' '{print $2}' | awk -v var="$j" -F' ' '{print $var}'`
           if [[ "${query_source}" == "slowlog" ]]; then
             mysql -h 127.0.0.1 -u msandbox -pmsandbox --port $node_port -e "SET GLOBAL slow_query_log='ON';"

--- a/pmm-tests/pmm-framework.sh
+++ b/pmm-tests/pmm-framework.sh
@@ -1991,7 +1991,9 @@ run_workload() {
   export MYSQL_PORT=$4
   export MYSQL_DATABASE=$5
   echo $6
-  (nohup bash -c 'php $SCRIPT_PWD/schema_table_query.php 2> /dev/null &')
+  touch $6.log
+  nohup bash -c 'php $SCRIPT_PWD/schema_table_query.php > $6.log 2>&1 &'
+  echo "Load Triggered check nohup.out"
 }
 
 if [ ! -z $wipe_clients ]; then

--- a/pmm-tests/pmm-framework.sh
+++ b/pmm-tests/pmm-framework.sh
@@ -89,12 +89,13 @@ usage () {
   echo " --setup-alertmanager           Start alert-manager on aws instance which runs on port 9093"
   echo " --compare-query-count          This will help us to compare the query count between PMM client instance and PMM QAN/Metrics page"
   echo " --disable-tablestats           Disable table statistics collection (only works with PS Node)"
+  echo " --run-load-pmm2             Run Load Tests on Percona Server Instances with PMM2"
 }
 
 # Check if we have a functional getopt(1)
 if ! getopt --test
   then
-  go_out="$(getopt --options=u: --longoptions=addclient:,replcount:,pmm-server:,ami-image:,key-name:,pmm2-server-ip:,ova-image:,ova-memory:,pmm-server-version:,dev-fb:,link-client:,pmm-port:,package-name:,pmm-server-memory:,pmm-docker-memory:,pmm-server-username:,pmm-server-password:,query-source:,setup,pmm2,disable-tablestats,dbdeployer,install-client,skip-docker-setup,with-replica,with-sharding,download,ps-version:,modb-version:,ms-version:,pgsql-version:,md-version:,pxc-version:,mysqld-startup-options:,mo-version:,add-docker-client,list,wipe-clients,wipe-pmm2-clients,delete-package,wipe-docker-clients,wipe-server,is-bats-run,disable-ssl,create-pgsql-user,upgrade-server,upgrade-client,wipe,setup-alertmanager,dev,with-proxysql,sysbench-data-load,sysbench-oltp-run,mongo-sysbench,storage-engine:,mongo-storage-engine:,compare-query-count,help \
+  go_out="$(getopt --options=u: --longoptions=addclient:,replcount:,pmm-server:,ami-image:,key-name:,pmm2-server-ip:,ova-image:,ova-memory:,pmm-server-version:,dev-fb:,link-client:,pmm-port:,package-name:,pmm-server-memory:,pmm-docker-memory:,pmm-server-username:,pmm-server-password:,query-source:,setup,pmm2,disable-tablestats,dbdeployer,install-client,skip-docker-setup,with-replica,with-sharding,download,ps-version:,modb-version:,ms-version:,pgsql-version:,md-version:,pxc-version:,mysqld-startup-options:,mo-version:,add-docker-client,list,wipe-clients,wipe-pmm2-clients,run-load-pmm2,delete-package,wipe-docker-clients,wipe-server,is-bats-run,disable-ssl,create-pgsql-user,upgrade-server,upgrade-client,wipe,setup-alertmanager,dev,with-proxysql,sysbench-data-load,sysbench-oltp-run,mongo-sysbench,storage-engine:,mongo-storage-engine:,compare-query-count,help \
   --name="$(basename "$0")" -- "$@")"
   test $? -eq 0 || exit 1
   eval set -- $go_out
@@ -266,6 +267,10 @@ do
     --wipe-pmm2-clients )
     shift
     wipe_pmm2_clients=1
+    ;;
+    --run-load-pmm2 )
+    shift
+    run_load_pmm2=1
     ;;
     --setup-alertmanager )
     shift
@@ -490,7 +495,7 @@ if [[ -z "${ps_version}" ]]; then ps_version="5.7"; fi
 if [[ -z "${modb_version}" ]]; then modb_version="4.2.0"; fi
 if [[ -z "${pxc_version}" ]]; then pxc_version="5.7"; fi
 if [[ -z "${ms_version}" ]]; then ms_version="8.0"; fi
-if [[ -z "${md_version}" ]]; then md_version="10.3"; fi
+if [[ -z "${md_version}" ]]; then md_version="10.4"; fi
 if [[ -z "${mo_version}" ]]; then mo_version="4.0"; fi
 if [[ -z "${REPLCOUNT}" ]]; then REPLCOUNT="1"; fi
 if [[ -z "${ova_memory}" ]]; then ova_memory="2048";fi
@@ -1266,7 +1271,9 @@ add_clients(){
         if [[ "$query_source" != "perfschema" ]]; then
           mysql -h 127.0.0.1 -u root -pps --port $PS_PORT -e "SET GLOBAL slow_query_log='ON';"
           mysql -h 127.0.0.1 -u root -pps --port $PS_PORT -e "SET GLOBAL long_query_time=0;"
+          mysql -h 127.0.0.1 -u root -pps --port $PS_PORT -e "SET GLOBAL log_slow_rate_limit=1;"
           mysql -h 127.0.0.1 -u root -pps --port $PS_PORT -e "SET GLOBAL slow_query_log_file='/var/log/ps_${j}_slowlog.log';"
+
         fi
         if [ $(( ${j} % 2 )) -eq 0 ]; then
           pmm-admin add mysql --query-source=$query_source --username=root --password=ps --environment=ps-prod --cluster=ps-prod-cluster --replication-set=ps-repl2 ps_${ps_version}_${IP_ADDRESS}_$j --debug 127.0.0.1:$PS_PORT
@@ -1277,6 +1284,27 @@ add_clients(){
           pmm-admin add mysql --query-source=$query_source --username=root --password=ps --environment=ps-prod --disable-tablestats ps_dts_node_$j --debug 127.0.0.1:$PS_PORT
         fi
         PS_PORT=$((PS_PORT+j))
+      done
+    elif [[ "${CLIENT_NAME}" == "md" && ! -z $PMM2 ]]; then
+      MD_PORT=53306
+      docker pull mariadb/server:${md_version}
+      for j in `seq 1  ${ADDCLIENTS_COUNT}`;do
+        check_port $MD_PORT percona
+        sudo chmod 777 -R /var/log
+        docker run --name md_${md_version}_${IP_ADDRESS}_$j -v /var/log:/var/log -p $MD_PORT:3306 -e MYSQL_ROOT_PASSWORD=md -d mariadb/server:${md_version}
+        sleep 20
+        if [[ "$query_source" != "perfschema" ]]; then
+          mysql -h 127.0.0.1 -u root -pmd --port $MD_PORT -e "SET GLOBAL slow_query_log='ON';"
+          mysql -h 127.0.0.1 -u root -pmd --port $MD_PORT -e "SET GLOBAL long_query_time=0;"
+          mysql -h 127.0.0.1 -u root -pmd --port $MD_PORT -e "SET GLOBAL log_slow_rate_limit=1;"
+          mysql -h 127.0.0.1 -u root -pmd --port $MD_PORT -e "SET GLOBAL slow_query_log_file='/var/log/md_${j}_slowlog.log';"
+        fi
+        if [ $(( ${j} % 2 )) -eq 0 ]; then
+          pmm-admin add mysql --query-source=$query_source --username=root --password=md --environment=md-prod --cluster=md-prod-cluster --replication-set=md-repl2 md_${md_version}_${IP_ADDRESS}_$j --debug 127.0.0.1:$MD_PORT
+        else
+          pmm-admin add mysql --query-source=$query_source --username=root --password=md --environment=md-dev --cluster=md-dev-cluster --replication-set=md-repl1 md_${md_version}_${IP_ADDRESS}_$j --debug 127.0.0.1:$MD_PORT
+        fi
+        MD_PORT=$((MD_PORT+j))
       done
     elif [[ "${CLIENT_NAME}" == "modb" && ! -z $PMM2 ]]; then
       MODB_PORT=27017
@@ -1294,7 +1322,7 @@ add_clients(){
         fi
         MODB_PORT=$((MODB_PORT+j+3))
       done
-    elif [[ "${CLIENT_NAME}" == "pxc" && ! -z $PMM2 ]] || [[ "${CLIENT_NAME}" == "md" && ! -z $PMM2 ]]; then
+    elif [[ "${CLIENT_NAME}" == "pxc" && ! -z $PMM2 ]]; then
       if [ -r ${BASEDIR}/lib/mysql/plugin/ha_tokudb.so ]; then
         TOKUDB_STARTUP="--plugin-load-add=tokudb=ha_tokudb.so --tokudb-check-jemalloc=0"
       else
@@ -1864,11 +1892,62 @@ sysbench_prepare(){
   done
 }
 
+load_instances() {
+  export WORKDIR=$PWD
+  mkdir $WORKDIR/logs/
+  if [[ ! -e $(which mysql 2> /dev/null) ]] ;then
+    MYSQL_CLIENT=$(find . -type f -name mysql | head -n1)
+  else
+    MYSQL_CLIENT=$(which mysql)
+  fi
+  if [[ -z "$MYSQL_CLIENT" ]];then
+   echo "ERROR! 'mysql' is currently not installed. Please install mysql. Terminating."
+   exit 1
+  fi
+  if [[ $(pmm-admin list | grep "MySQL" | grep "ps" | awk -F" " '{print $2}') ]]; then
+    #Initiate sysbench data load on all mysql client instances
+    for i in $(pmm-admin list | grep "MySQL" | grep "ps" | awk -F" " '{print $3}' | awk -F":" '{print $2}') ; do
+      DB_NAME="sbtest_ps_${i}"
+      touch $WORKDIR/logs/sysbench_prepare_ps_${i}.txt
+      $MYSQL_CLIENT --user=root --port=${i} -pps -h 127.0.0.1 -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'ps';"
+      $MYSQL_CLIENT --user=root --port=${i} -pps -h 127.0.0.1 -e "drop database if exists ${DB_NAME};create database ${DB_NAME};"
+      sysbench /usr/share/sysbench/oltp_insert.lua --table-size=10000 --tables=16 --mysql-db=${DB_NAME} --mysql-user=root --mysql-password=ps --mysql-host=127.0.0.1 --mysql-port=${i} --mysql-storage-engine=$storage_engine  --threads=16 --db-driver=mysql prepare  > $WORKDIR/logs/sysbench_prepare_ps_${i}.txt 2>&1
+      check_script $? "Failed to run sysbench dataload"
+    done
+
+    for i in $(pmm-admin list | grep "MySQL" | grep "ps" | awk -F" " '{print $3}' | awk -F":" '{print $2}') ; do
+      DB_NAME="sbtest_ps_${i}"
+      touch $WORKDIR/logs/sysbench_run_ps_${i}.txt
+      sysbench /usr/share/sysbench/oltp_read_write.lua --table-size=10000 --tables=16 --mysql-db=${DB_NAME} --mysql-user=root --mysql-password=ps --mysql-host=127.0.0.1 --mysql-port=${i} --mysql-storage-engine=$storage_engine --threads=16 --time=3600 --events=1870000000 --db-driver=mysql --db-ps-mode=disable run  > $WORKDIR/logs/sysbench_run_ps_${i}.txt 2>&1 &
+      check_script $? "Failed to run sysbench oltp"
+    done
+  fi
+
+  if [[ $(pmm-admin list | grep "MySQL" | grep "mysql" | awk -F" " '{print $2}') ]]; then
+    #Initiate sysbench data load on all mysql client instances
+    for i in $(pmm-admin list | grep "MySQL" | grep "mysql" | awk -F" " '{print $3}' | awk -F":" '{print $2}') ; do
+      DB_NAME="sbtest_mysql_${i}"
+      touch $WORKDIR/logs/sysbench_prepare_mysql_${i}.txt
+      $MYSQL_CLIENT --user=msandbox --port=${i} -pmsandbox -h 127.0.0.1 -e "ALTER USER 'msandbox'@'localhost' IDENTIFIED WITH mysql_native_password BY 'msandbox';"
+      $MYSQL_CLIENT --user=msandbox --port=${i} -pmsandbox -h 127.0.0.1 -e "drop database if exists ${DB_NAME};create database ${DB_NAME};"
+      sysbench /usr/share/sysbench/oltp_insert.lua --table-size=10000 --tables=16 --mysql-db=${DB_NAME} --mysql-user=msandbox --mysql-password=msandbox --mysql-host=127.0.0.1 --mysql-port=${i} --mysql-storage-engine=$storage_engine  --threads=16 --db-driver=mysql prepare  > $WORKDIR/logs/sysbench_prepare_mysql_${i}.txt 2>&1
+      check_script $? "Failed to run sysbench dataload"
+    done
+
+    for i in $(pmm-admin list | grep "MySQL" | grep "mysql" | awk -F" " '{print $3}' | awk -F":" '{print $2}') ; do
+      DB_NAME="sbtest_mysql_${i}"
+      touch $WORKDIR/logs/sysbench_run_mysql_${i}.txt
+      sysbench /usr/share/sysbench/oltp_read_write.lua --table-size=10000 --tables=16 --mysql-db=${DB_NAME} --mysql-user=msandbox --mysql-password=msandbox --mysql-host=127.0.0.1 --mysql-port=${i} --mysql-storage-engine=$storage_engine --threads=16 --time=3600 --events=1870000000 --db-driver=mysql --db-ps-mode=disable run  > $WORKDIR/logs/sysbench_run_mysql_${i}.txt 2>&1 &
+      check_script $? "Failed to run sysbench oltp"
+    done
+  fi
+}
+
 sysbench_run(){
   #Initiate sysbench oltp run on all mysql client instances
   for i in $(sudo pmm-admin list | grep "mysql:metrics[ \t].*_NODE-" | awk -F[\(\)] '{print $2}'  | sort -r) ; do
     DB_NAME=$(echo ${i}  | awk -F[\/\.] '{print $3}')
-	DB_NAME="${DB_NAME}_${storage_engine}"
+	   DB_NAME="${DB_NAME}_${storage_engine}"
     sysbench /usr/share/sysbench/oltp_read_write.lua --table-size=10000 --tables=16 --mysql-db=${DB_NAME} --mysql-user=root  --mysql-storage-engine=$storage_engine --threads=16 --time=3600 --events=1870000000 --db-driver=mysql --db-ps-mode=disable --mysql-socket=${i} run  > $WORKDIR/logs/sysbench_run_${DB_NAME}.txt 2>&1 &
     check_script $? "Failed to run sysbench oltp"
   done
@@ -1883,10 +1962,10 @@ check_dbdeployer(){
 }
 
 install_dbdeployer(){
-  wget https://github.com/datacharmer/dbdeployer/releases/download/v1.28.1/dbdeployer-1.28.1.linux.tar.gz
-  tar -xzf dbdeployer-1.28.1.linux.tar.gz
-  chmod +x dbdeployer-1.28.1.linux
-  sudo mv dbdeployer-1.28.1.linux /usr/local/bin/dbdeployer
+  wget https://github.com/datacharmer/dbdeployer/releases/download/v1.45.0/dbdeployer-1.45.0.linux.tar.gz
+  tar -xzf dbdeployer-1.45.0.linux.tar.gz
+  chmod +x dbdeployer-1.45.0.linux
+  sudo mv dbdeployer-1.45.0.linux /usr/local/bin/dbdeployer
 }
 
 setup_alertmanager() {
@@ -1980,6 +2059,10 @@ fi
 if [ ! -z $add_docker_client ]; then
   sanity_check
   pmm_docker_client_startup
+fi
+
+if [ ! -z $run_load_pmm2 ]; then
+  load_instances
 fi
 
 exit 0

--- a/pmm-tests/pmm-framework.sh
+++ b/pmm-tests/pmm-framework.sh
@@ -1992,7 +1992,8 @@ run_workload() {
   export MYSQL_DATABASE=$5
   echo $6
   touch $6.log
-  nohup php $SCRIPT_PWD/schema_table_query.php > $6.log 2>&1 &
+  export JENKINS_NODE_COOKIE=dontKillMe
+  JENKINS_NODE_COOKIE=dontKillMe nohup php $SCRIPT_PWD/schema_table_query.php > $6.log 2>&1 &
   echo "Load Triggered check nohup.out"
 }
 

--- a/pmm-tests/pmm-framework.sh
+++ b/pmm-tests/pmm-framework.sh
@@ -1991,7 +1991,7 @@ run_workload() {
   export MYSQL_PORT=$4
   export MYSQL_DATABASE=$5
   echo $6
-  (nohup php $SCRIPT_PWD/schema_table_query.php 2> /dev/null &)
+  (nohup bash -c 'php $SCRIPT_PWD/schema_table_query.php 2> /dev/null &')
 }
 
 if [ ! -z $wipe_clients ]; then

--- a/pmm-tests/pmm-framework.sh
+++ b/pmm-tests/pmm-framework.sh
@@ -1992,7 +1992,7 @@ run_workload() {
   export MYSQL_DATABASE=$5
   echo $6
   touch $6.log
-  nohup php $SCRIPT_PWD/schema_table_query.php > $6.log 2>&1 &
+  exec nohup php $SCRIPT_PWD/schema_table_query.php > $6.log 2>&1 &
   echo "Load Triggered check nohup.out"
 }
 

--- a/pmm-tests/pmm-framework.sh
+++ b/pmm-tests/pmm-framework.sh
@@ -1992,7 +1992,7 @@ run_workload() {
   export MYSQL_DATABASE=$5
   echo $6
   touch $6.log
-  (nohup bash -c php $SCRIPT_PWD/schema_table_query.php > $6.log 2>&1 &)
+  (nohup php $SCRIPT_PWD/schema_table_query.php > $6.log 2>&1 &)
   echo "Load Triggered check nohup.out"
 }
 

--- a/pmm-tests/pmm-framework.sh
+++ b/pmm-tests/pmm-framework.sh
@@ -1992,7 +1992,7 @@ run_workload() {
   export MYSQL_DATABASE=$5
   echo $6
   touch $6.log
-  (nohup php $SCRIPT_PWD/schema_table_query.php > $6.log 2>&1 &)
+  nohup php $SCRIPT_PWD/schema_table_query.php > $6.log 2>&1 &
   echo "Load Triggered check nohup.out"
 }
 

--- a/pmm-tests/pmm-framework.sh
+++ b/pmm-tests/pmm-framework.sh
@@ -1992,7 +1992,11 @@ run_workload() {
   export MYSQL_DATABASE=$5
   echo $6
   touch $6.log
-  exec nohup php $SCRIPT_PWD/schema_table_query.php > $6.log 2>&1 &
+  sleep 5
+  exec nohup php $SCRIPT_PWD/schema_table_query.php &> $6.log &
+  PHP_PID=$!
+  echo $PHP_PID
+  jobs -l
   echo "Load Triggered check nohup.out"
 }
 

--- a/pmm-tests/pmm-framework.sh
+++ b/pmm-tests/pmm-framework.sh
@@ -1992,7 +1992,7 @@ run_workload() {
   export MYSQL_DATABASE=$5
   echo $6
   touch $6.log
-  nohup bash -c 'php $SCRIPT_PWD/schema_table_query.php > $6.log 2>&1 &'
+  (nohup bash -c php $SCRIPT_PWD/schema_table_query.php > $6.log 2>&1 &)
   echo "Load Triggered check nohup.out"
 }
 

--- a/pmm-tests/pmm-framework.sh
+++ b/pmm-tests/pmm-framework.sh
@@ -1992,8 +1992,7 @@ run_workload() {
   export MYSQL_DATABASE=$5
   echo $6
   touch $6.log
-  export JENKINS_NODE_COOKIE=dontKillMe
-  JENKINS_NODE_COOKIE=dontKillMe nohup php $SCRIPT_PWD/schema_table_query.php > $6.log 2>&1 &
+  nohup php $SCRIPT_PWD/schema_table_query.php > $6.log 2>&1 &
   echo "Load Triggered check nohup.out"
 }
 


### PR DESCRIPTION
This PR covers 

1. Support for MariaDB latest version with Docker MariaDB image
2. Support for the latest version of DB deployer 
3. Support for PMM Workload scripts, with minor modifications for compatibility with php 5.3.x version on ec2 instances.
4. Workload support is added to PS/MS/MD instances, with distinct queries. 