### PR TITLE
Default PMM-Server version set to dev-latest, if not provided explicitly

### DIFF
--- a/pmm-tests/pmm-framework.sh
+++ b/pmm-tests/pmm-framework.sh
@@ -303,6 +303,10 @@ do
     --dev )
     shift
     dev=1
+    if [[ -z $pmm_server_version ]];then
+    	pmm_server_version="dev-latest"
+    	PMM_VERSION=$pmm_server_version
+    fi
     ;;
     --with-proxysql )
     shift


### PR DESCRIPTION
When **--pmm-server-version** option is not explicitly used to provide version, and also if the **--dev** option is provided then PMM-Server version will be set to **dev-latest** 

Note: dev-latest Docker tag works only for perconalab/pmm-server repository on Dockerhub.
@puneet0191 Please review. 