### PR TITLE
Refactored: pmm2-client-setup.sh

### DIFF
--- a/pmm-tests/pmm2-client-setup.sh
+++ b/pmm-tests/pmm2-client-setup.sh
@@ -5,42 +5,89 @@ function jsonval {
     echo ${temp##*|}
 }
 
-display_usage() { 
-	echo "Please make sure to pass atleast pmm_server, db, db_server, db_user"
-	echo "1) pmm_server ------------------localhost:80"
-	echo "2) which_db   ------------------mysql/mongodb/postgresql"
-	echo "3) db_server  ------------------localhost:3306"
-	echo "4) db_user    ------------------root"
-	echo "5) db_password------------------secret"
+usage(){
+  echo "Usage: [ options ]"
+  echo "Please make sure to pass atleast pmm_server, which_db, db_server, db_user"
+  echo " --pmm-server-url               Pass pmm-server url (eg. localhost:80)"
+  echo " --which-db                     Specify DB: mysql/mongodb/postgresql"
+  echo " --db-server                    Pass db_server url (eg. localhost:3306)"
+  echo " --db-user                      Pass DB username (eg. root)"
+  echo " --db-password                  Pass DB password"
+  echo " --install-client               Install PMM2-client"
+  echo " --dev                          This will install from development release repository"
+  echo " --client-version               Pass specific PMM2-client version"
+  echo " --help                         Display usage"
 }
 
-# check whether user had supplied -h or --help . If yes display usage 
-if [[ ( $# == "--help") ||  $# == "-h" ]] 
-then 
-	display_usage
-	exit 0
-fi
-if [ "$#" -lt 4 ]; then
-    display_usage
-    exit 1;
+# Check if we have a functional getopt(1)
+if ! getopt --test
+  then
+  go_out="$(getopt --options=u: --longoptions=pmm-server-url:,which-db:,db-server:,db-user:,db-password:,install-client,dev,client-version:,help \
+  --name="$(basename "$0")" -- "$@")"
+  test $? -eq 0 || exit 1
+  eval set -- $go_out
 fi
 
-STR=$1
-IFS=’:’ read -ra pmm_serer_with_port <<< "$STR" 
-MSTR=$3
-IFS=’:’ read -ra db_server_with_port <<< "$MSTR"
-pmm_server=${pmm_serer_with_port[0]}
-pmm_server_port=${pmm_serer_with_port[1]}
-db_server=${db_server_with_port[0]}
-db_server_port=${db_server_with_port[1]}
-db_user=$4
-db_password=$5
-which_db=$2
+if [[ $go_out == " --" ]];then
+  usage
+  exit 1
+fi
+
+for arg
+do
+  case "$arg" in
+    -- ) shift; break;;
+    --pmm-server-url )
+    STR=$2
+    IFS=’:’ read -ra pmm_server_with_port <<< "$STR" 
+    pmm_server=${pmm_server_with_port[0]}
+    pmm_server_port=${pmm_server_with_port[1]}
+    shift 2
+    ;;
+    --which-db )
+    which_db="$2"
+    shift 2
+    ;;
+    --db-server )
+    MSTR=$2
+    IFS=’:’ read -ra db_server_with_port <<< "$MSTR"
+    db_server=${db_server_with_port[0]}
+    db_server_port=${db_server_with_port[1]}
+    shift 2
+    ;;
+    --db-user )
+    db_user="$2"
+    shift 2
+    ;;
+    --db-password )
+    db_password="$2"
+    shift 2
+    ;;
+    --install-client )
+    install_client=1
+    shift 2
+    ;;
+    --dev )
+    shift
+    dev=1
+    ;;
+    --client-version )
+    client_version="$2"
+    shift 2
+    ;;
+    --help )
+    usage
+    exit 0
+    ;;
+  esac
+done
+
 
 if [ -z "$pmm_server_port" ]
 then
   pmm_server_port=80
 fi
+
 
 node_name=node$((1 + RANDOM % 100))
 json=`curl -d '{"address": "'${pmm_server}'", "custom_labels": {"custom_label": "for_node"}, "node_name": "'$node_name'"}' http://$pmm_server:$pmm_server_port/v1/inventory/Nodes/AddGeneric`
@@ -64,8 +111,11 @@ prop='runs_on_node_id'
 runs_on_node_id=`jsonval`
 echo $runs_on_node_id
 
-if [ $which_db == "mysql" ]
-then
+install() {
+	echo "Installing PMM2-Client..."
+}
+
+configure_mysql(){
 	if [ -z "$db_server_port" ]
 	then
 	      db_server_port='3306'
@@ -85,10 +135,9 @@ then
 
   json=`curl -d '{"custom_labels": {"custom_label6": "for_perfschemaAgent"}, "pmm_agent_id": "'$agent_id'", "service_id": "'$service_id'", "username": "'$db_user'", "password": "'$db_password'"}' \
   http://$pmm_server:$pmm_server_port/v1/inventory/Agents/AddQANMySQLPerfSchemaAgent`
-fi
+}
 
-if [ $which_db == "mongodb" ]
-then
+configure_mongodb(){
 	service_name=mongodb-$((1 + RANDOM % 100))
 	json=`curl -d '{"address": "'${db_server}'", "port": '${db_server_port}', "custom_labels": {"custom_label3": "for_service"}, "node_id": "'$node_id'", "service_name": "'$service_name'"}' \
 	http://$pmm_server:$pmm_server_port/v1/inventory/Services/AddMongoDB`
@@ -101,10 +150,9 @@ then
 	prop='runs_on_node_id'
 	runs_on_node_id=`jsonval`
 	echo $runs_on_node_id
-fi
+}
 
-if [ $which_db == "postgresql" ]
-then
+configure_postgresql(){
 	service_name=postgres-$((1 + RANDOM % 100))
 	json=`curl -d '{"address": "'${db_server}'", "port": '${db_server_port}', "custom_labels": {"custom_label6": "for_postgres_service"}, "node_id": "'$node_id'", "service_name": "'$service_name'"}' \
 	http://$pmm_server:$pmm_server_port/v1/inventory/Services/AddPostgreSQL`
@@ -117,4 +165,20 @@ then
 	prop='runs_on_node_id'
 	runs_on_node_id=`jsonval`
 	echo $runs_on_node_id
+}
+
+if [ ! -z $install_client ]; then
+	install
+fi
+
+if [ "$which_db" == "mysql" ]; then
+	configure_mysql
+fi
+
+if [ "$which_db" == "mongodb" ]; then
+	configure_mongodb
+fi
+
+if [ "$which_db" == "postgresql" ]; then
+	configure_postgresql
 fi

--- a/pmm-tests/pmm2-client-setup.sh
+++ b/pmm-tests/pmm2-client-setup.sh
@@ -113,6 +113,17 @@ echo $runs_on_node_id
 
 install() {
 	echo "Installing PMM2-Client..."
+	if grep -iq "ubuntu"  /etc/os-release ; then
+		wget https://repo.percona.com/apt/percona-release_latest.generic_all.deb
+  	sudo dpkg -i percona-release_latest.generic_all.deb
+  	sudo apt-get -y install pmm2-client
+		sudo apt-get update
+		rm percona-release_latest.generic_all.deb
+	elif grep -iq "centos"  /etc/os-release || grep -iq "rhel"  /etc/os-release  ; then
+		sudo yum -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+		sudo yum clean all
+		sudo yum -y install pmm2-client
+		sudo yum -y update
 }
 
 configure_mysql(){

--- a/pmm-tests/pmm2-client-setup.sh
+++ b/pmm-tests/pmm2-client-setup.sh
@@ -115,8 +115,8 @@ install() {
 	echo "Installing PMM2-Client..."
 	if grep -iq "ubuntu"  /etc/os-release ; then
 		wget https://repo.percona.com/apt/percona-release_latest.generic_all.deb
-  	sudo dpkg -i percona-release_latest.generic_all.deb
-  	sudo apt-get -y install pmm2-client
+		sudo dpkg -i percona-release_latest.generic_all.deb
+		sudo apt-get -y install pmm2-client
 		sudo apt-get update
 		rm percona-release_latest.generic_all.deb
 	elif grep -iq "centos"  /etc/os-release || grep -iq "rhel"  /etc/os-release  ; then
@@ -124,6 +124,7 @@ install() {
 		sudo yum clean all
 		sudo yum -y install pmm2-client
 		sudo yum -y update
+	fi
 }
 
 configure_mysql(){


### PR DESCRIPTION
1. Improve options passing functionality in script using `getopt`
      - command line options no longer hard-coded
2. Refactor `mysql/mongodb/postgresql` configuration into separate functions
3. Added `pmm2-client` installation using `yum/apt`
     - installs latest ` public release` of pmm2-client using `percona-release` repository by default

@puneet0191 