### PR TITLE
PMM-5405 Empty --filename in summary command.

### DIFF
--- a/pmm-tests/pmm-2-0-bats-tests/generic-tests.bats
+++ b/pmm-tests/pmm-2-0-bats-tests/generic-tests.bats
@@ -172,10 +172,9 @@ echo "$output"
 }
 
 @test "run pmm-admin summary --filename empty" {
-skip "now it returns no such file error, but it should generate .zip file with generated filename"
 run pmm-admin summary --filename=""
 echo "$output"
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 0 ]
     echo "${lines[-1]}" | grep ".zip created."
 }
 


### PR DESCRIPTION
Activated test for empty filename in summary command.

https://jira.percona.com/browse/PMM-5405
Percona-Lab/pmm-submodules#2236