### PR TITLE
PMM-7 fix haproxy.cfg

### DIFF
--- a/pmm-tests/haproxy.cfg
+++ b/pmm-tests/haproxy.cfg
@@ -73,7 +73,6 @@ frontend main
     default_backend             app
     mode http
     timeout client 1m
-    option http-use-htx
     http-request use-service prometheus-exporter if { path /metrics }
     stats enable
     stats uri /stats


### PR DESCRIPTION
HAProxy service could not be started:
```
[ec2-user@ip-10-178-2-146 ~]$ systemctl status haproxy.service
● haproxy.service - HAProxy Load Balancer
   Loaded: loaded (/usr/lib/systemd/system/haproxy.service; disabled; vendor preset: disabled)
   Active: failed (Result: exit-code) since Čt 2022-09-15 09:22:48 UTC; 2min 47s ago
  Process: 28243 ExecStartPre=/usr/sbin/haproxy -f $CONFIG -c -q (code=exited, status=1/FAILURE)

zář 15 09:22:48 ip-10-178-2-146.us-east-2.compute.internal systemd[1]: Starting HAProxy Load Balancer...
zář 15 09:22:48 ip-10-178-2-146.us-east-2.compute.internal systemd[1]: haproxy.service: control process exited, code=exited status=1
zář 15 09:22:48 ip-10-178-2-146.us-east-2.compute.internal systemd[1]: Failed to start HAProxy Load Balancer.
zář 15 09:22:48 ip-10-178-2-146.us-east-2.compute.internal systemd[1]: Unit haproxy.service entered failed state.
zář 15 09:22:48 ip-10-178-2-146.us-east-2.compute.internal systemd[1]: haproxy.service failed.
```

Caused by: parsing [/etc/haproxy/haproxy.cfg:76] : unknown option 'http-use-htx';

After removing this line:
```
[ec2-user@ip-10-178-2-146 haproxy]$ systemctl status haproxy.service
● haproxy.service - HAProxy Load Balancer
   Loaded: loaded (/usr/lib/systemd/system/haproxy.service; disabled; vendor preset: disabled)
   Active: active (running) since Čt 2022-09-15 09:40:43 UTC; 8min ago
  Process: 8211 ExecStartPre=/usr/sbin/haproxy -f $CONFIG -c -q (code=exited, status=0/SUCCESS)
 Main PID: 8231 (haproxy)
    Tasks: 3
   Memory: 9.7M
   CGroup: /system.slice/haproxy.service
           ├─8231 /usr/sbin/haproxy -Ws -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
           └─8237 /usr/sbin/haproxy -Ws -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
```