### PR TITLE
Update timeouts for k8s helm tests

### DIFF
--- a/pmm-tests/pmm-2-0-bats-tests/k8s_helper.sh
+++ b/pmm-tests/pmm-2-0-bats-tests/k8s_helper.sh
@@ -1,13 +1,13 @@
 wait_for_pmm()
 {
     sleep 5
-    kubectl wait --for=condition=Ready --selector=app.kubernetes.io/name=pmm pod --timeout=90s
+    kubectl wait --for=condition=Ready --selector=app.kubernetes.io/name=pmm pod --timeout=5m
 }
 
 delete_pvc()
 {
     kubectl delete pvc --selector=app.kubernetes.io/name=pmm
-    kubectl wait --for=delete --selector=app.kubernetes.io/name=pmm pvc --timeout=90s
+    kubectl wait --for=delete --selector=app.kubernetes.io/name=pmm pvc --timeout=5m
 }
 
 get_pmm_pswd()


### PR DESCRIPTION
update timeout as containers are quite big and sometimes infra is too slow:
https://github.com/Percona-Lab/pmm-submodules/actions/runs/3574634293/jobs/6011858931