### PR TITLE
add wait flag to remove infra influence from the test

### DIFF
--- a/pmm-tests/pmm-2-0-bats-tests/helm-test.bats
+++ b/pmm-tests/pmm-2-0-bats-tests/helm-test.bats
@@ -44,6 +44,7 @@ teardown() {
     helm install pmm \
         --set image.repository=$IMAGE_REPO \
         --set image.tag=$IMAGE_TAG \
+        --wait \
         percona/pmm
     wait_for_pmm
 
@@ -76,6 +77,7 @@ teardown() {
         --set image.tag=$IMAGE_TAG \
         --set-string pmmEnv.ENABLE_DBAAS="1" \
         --set service.type="NodePort" \
+        --wait \
         percona/pmm
     wait_for_pmm
     run bash -c "kubectl get sa pmm-service-account -o json | jq  '.secrets[]|length'"
@@ -90,7 +92,7 @@ teardown() {
     sed -i "s|tag: .*|tag: \"$IMAGE_TAG\"|g" values.yaml
     sed -i "s|repository:.*|repository: $IMAGE_REPO|g" values.yaml
 
-    helm install pmm -f values.yaml percona/pmm
+    helm install pmm -f values.yaml --wait percona/pmm
     wait_for_pmm
 
     helm uninstall --wait --timeout 60s pmm
@@ -103,7 +105,7 @@ teardown() {
     sed -i "s|tag: .*|tag: \"$IMAGE_TAG\"|g" values.yaml
     sed -i "s|repository:.*|repository: $IMAGE_REPO|g" values.yaml
 
-    helm install pmm3 -f values.yaml percona/pmm
+    helm install pmm3 -f values.yaml --wait percona/pmm
     wait_for_pmm
 
     sed -i "s|tag: .*|tag: \"dev-latest\"|g" values.yaml


### PR DESCRIPTION
time to time tests fails as `sleep 5` is not enough, so minikube is not fast enough to apply resources. Use helm `--wait` so helm will wait until resources it applies will be created.

https://github.com/Percona-Lab/pmm-submodules/actions/runs/4074974547/jobs/7020771522