### PR TITLE
PMM-15005 Remove a bundled certificate

### DIFF
--- a/cli/tests/pmm-server-only.spec.ts
+++ b/cli/tests/pmm-server-only.spec.ts
@@ -221,5 +221,23 @@ test.describe(
           'was collected before with the same name and label values',
         );
     });
+
+    test('PMM-T2082 Verify there are no certificate issues reported in ClickHouse logs', async () => {
+      const chLogs = await cli.exec(
+        'docker exec pmm-server cat /srv/logs/clickhouse-server.log | grep -i "CertificateReloader:"',
+      );
+      expect
+        .soft(
+          chLogs.stdout,
+          'Verify the ClickHouse client is not trying to connect via TLS and reporting certificate reloader errors',
+        )
+        .not.toContain('CertificateReloader: One of paths is empty');
+      expect
+        .soft(
+          chLogs.stdout,
+          'Verify ClickHouse server is not trying to load TLS certificates and reporting modification time errors',
+        )
+        .not.toContain('CertificateReloader: Cannot obtain modification time');
+    });
   },
 );


### PR DESCRIPTION
PMM-15005

FB: https://github.com/Percona-Lab/pmm-submodules/pull/4327
Ref: https://github.com/percona/pmm/pull/5297

New test coverage:

* Added a test (`PMM-T2082`) to verify that there are no certificate-related errors reported in the ClickHouse server logs, specifically checking for missing paths and modification time errors.
