### PR TITLE
PMM-15041: Add MongoDB in-memory engine option to PSMDB QA setup

### DIFF
--- a/qa-integration/pmm_psmdb-pbm_setup/conf/mongod-rs-inmemory/mongod.conf
+++ b/qa-integration/pmm_psmdb-pbm_setup/conf/mongod-rs-inmemory/mongod.conf
@@ -1,0 +1,27 @@
+storage:
+  dbPath: /var/lib/mongo
+  engine: inMemory
+  inMemory:
+    engineConfig:
+      inMemorySizeGB: 1
+      statisticsLogDelaySecs: 0
+
+systemLog:
+  destination: syslog
+
+net:
+  port: 27017
+  bindIp: 0.0.0.0
+
+replication:
+  replSetName: "rs"
+
+operationProfiling:
+  mode: all
+  slowOpThresholdMs: 1
+
+security:
+  keyFile: /etc/keyfile
+  authorization: enabled
+setParameter:
+  authenticationMechanisms: SCRAM-SHA-1,GSSAPI

--- a/qa-integration/pmm_psmdb-pbm_setup/docker-compose-rs.yaml
+++ b/qa-integration/pmm_psmdb-pbm_setup/docker-compose-rs.yaml
@@ -33,7 +33,7 @@ services:
       - pmm-ui-tests2
     volumes:
       - ./conf/pbm:/etc/pbm
-      - ./conf/mongod-rs:/etc/mongod
+      - ${MONGOD_RS_CONFIG_DIR:-./conf/mongod-rs}:/etc/mongod
       - ./conf/datagen:/etc/datagen:ro
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - /tmp/backup_data:/tmp/backup_data:rw
@@ -66,7 +66,7 @@ services:
       - pmm-ui-tests3
     volumes:
       - ./conf/pbm:/etc/pbm
-      - ./conf/mongod-rs:/etc/mongod
+      - ${MONGOD_RS_CONFIG_DIR:-./conf/mongod-rs}:/etc/mongod
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - /tmp/backup_data:/tmp/backup_data:rw
       - keytabs:/keytabs
@@ -98,7 +98,7 @@ services:
       - pmm-ui-tests3
     volumes:
       - ./conf/pbm:/etc/pbm
-      - ./conf/mongod-rs:/etc/mongod
+      - ${MONGOD_RS_CONFIG_DIR:-./conf/mongod-rs}:/etc/mongod
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - /tmp/backup_data:/tmp/backup_data:rw
       - keytabs:/keytabs
@@ -132,7 +132,7 @@ services:
       - pmm-ui-tests2
     volumes:
       - ./conf/pbm:/etc/pbm
-      - ./conf/mongod-rs:/etc/mongod
+      - ${MONGOD_RS_CONFIG_DIR:-./conf/mongod-rs}:/etc/mongod
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - /tmp/backup_data:/tmp/backup_data:rw
       - keytabs:/keytabs
@@ -164,7 +164,7 @@ services:
       - pmm-ui-tests3
     volumes:
       - ./conf/pbm:/etc/pbm
-      - ./conf/mongod-rs:/etc/mongod
+      - ${MONGOD_RS_CONFIG_DIR:-./conf/mongod-rs}:/etc/mongod
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - /tmp/backup_data:/tmp/backup_data:rw
       - keytabs:/keytabs
@@ -196,7 +196,7 @@ services:
       - pmm-ui-tests3
     volumes:
       - ./conf/pbm:/etc/pbm
-      - ./conf/mongod-rs:/etc/mongod
+      - ${MONGOD_RS_CONFIG_DIR:-./conf/mongod-rs}:/etc/mongod
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - /tmp/backup_data:/tmp/backup_data:rw
       - keytabs:/keytabs

--- a/qa-integration/pmm_psmdb-pbm_setup/start-rs-only.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/start-rs-only.sh
@@ -3,17 +3,38 @@ set -e
 
 profile=${COMPOSE_PROFILES:-classic}
 mongo_setup_type=${MONGO_SETUP_TYPE:-pss}
+mongo_setup_type=${mongo_setup_type,,}
+mongo_storage_engine=${MONGO_STORAGE_ENGINE:-wiredTiger}
+mongo_storage_engine=${mongo_storage_engine,,}
 ol_version=${OL_VERSION:-9}
+
+
+export COMPOSE_PROFILES=${profile}
+export MONGO_SETUP_TYPE=${mongo_setup_type}
+export OL_VERSION=${ol_version}
+
+case "$mongo_storage_engine" in
+  wiredtiger)
+    ;;
+  inmemory)
+
+    generated_config_dir="/tmp/pmm-qa-mongod-rs-inmemory"
+    rm -rf "$generated_config_dir"
+    mkdir -p "$generated_config_dir"
+    cp ./conf/mongod-rs-inmemory/mongod.conf "$generated_config_dir/mongod.conf"
+    export MONGOD_RS_CONFIG_DIR="$generated_config_dir"
+    ;;
+  *)
+    echo "Unsupported MongoDB storage engine: $mongo_storage_engine"
+    exit 1
+    ;;
+esac
 
 docker network create qa-integration || true
 docker network create pmm-qa || true
 docker network create pmm-ui-tests_pmm-network || true
 docker network create pmm2-upgrade-tests_pmm-network || true
 docker network create pmm2-ui-tests_pmm-network || true
-
-export COMPOSE_PROFILES=${profile}
-export MONGO_SETUP_TYPE=${mongo_setup_type}
-export OL_VERSION=${ol_version}
 
 docker compose -f docker-compose-rs.yaml down -v --remove-orphans
 docker compose -f docker-compose-rs.yaml build --no-cache

--- a/qa-integration/pmm_psmdb-pbm_setup/start-rs-only.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/start-rs-only.sh
@@ -13,22 +13,16 @@ export COMPOSE_PROFILES=${profile}
 export MONGO_SETUP_TYPE=${mongo_setup_type}
 export OL_VERSION=${ol_version}
 
-case "$mongo_storage_engine" in
-  wiredtiger)
-    ;;
-  inmemory)
+if [ "$mongo_storage_engine" = "inmemory" ]; then
 
     generated_config_dir="/tmp/pmm-qa-mongod-rs-inmemory"
     rm -rf "$generated_config_dir"
     mkdir -p "$generated_config_dir"
     cp ./conf/mongod-rs-inmemory/mongod.conf "$generated_config_dir/mongod.conf"
     export MONGOD_RS_CONFIG_DIR="$generated_config_dir"
-    ;;
-  *)
-    echo "Unsupported MongoDB storage engine: $mongo_storage_engine"
-    exit 1
-    ;;
-esac
+else
+    mongo_storage_engine="wiredTiger"
+fi
 
 docker network create qa-integration || true
 docker network create pmm-qa || true

--- a/qa-integration/pmm_qa/pmm-framework.py
+++ b/qa-integration/pmm_qa/pmm-framework.py
@@ -541,6 +541,7 @@ def setup_psmdb(db_type, db_version=None, db_config=None, args=None):
         'PMM_CLIENT_VERSION': client_version,
         'COMPOSE_PROFILES': get_value('COMPOSE_PROFILES', db_type, args, db_config),
         'MONGO_SETUP_TYPE': get_value('SETUP_TYPE', db_type, args, db_config),
+        'MONGO_STORAGE_ENGINE': get_value('STORAGE_ENGINE', db_type, args, db_config),
         'OL_VERSION': get_value('OL_VERSION', db_type, args, db_config),
         'GSSAPI': get_value('GSSAPI', db_type, args, db_config),
         'TESTS': 'no',

--- a/qa-integration/pmm_qa/scripts/database_options.py
+++ b/qa-integration/pmm_qa/scripts/database_options.py
@@ -2,7 +2,7 @@ database_options = {
     "PSMDB": {
         "versions": ["4.4", "5.0", "6.0", "7.0", "8.0", "latest"],
         "configurations": {"CLIENT_VERSION": "3-dev-latest", "SETUP_TYPE": "pss", "COMPOSE_PROFILES": "classic",
-                           "TARBALL": "", "OL_VERSION": "9", "GSSAPI": "false"}
+                           "TARBALL": "", "OL_VERSION": "9", "GSSAPI": "false", "STORAGE_ENGINE": "wiredTiger"}
     },
     "MLAUNCH_PSMDB": {
         "versions": ["4.4", "5.0", "6.0", "7.0", "8.0"],


### PR DESCRIPTION
## Summary

Adds optional MongoDB storage engine selection for the existing PSMDB QA flow so QA environments can run Percona Server for MongoDB with the in-memory storage engine and expose related PMM metrics.

## Changes

- Add `STORAGE_ENGINE` default (`wiredTiger`) to `PSMDB` framework options.
- Pass `MONGO_STORAGE_ENGINE` from `pmm-framework.py` into the `pmm_psmdb-pbm_setup` scripts.
- Parameterize `docker-compose-rs.yaml` mongod config bind mount via `MONGOD_RS_CONFIG_DIR` (defaults keep current WiredTiger config).
- Extend `start-rs-only.sh` to select WiredTiger vs inMemory and mount an in-memory `mongod.conf`.
- Add `conf/mongod-rs-inmemory/mongod.conf` with fixed `inMemorySizeGB` (not parameterized).

## Usage

```
python pmm-framework.py --database PSMDB=8.0,SETUP_TYPE=pss,STORAGE_ENGINE=inMemory
```

## Testing

- `python -m py_compile` on modified Python files
- `bash -n` on `start-rs-only.sh`
- `docker compose ... config` validation for `docker-compose-rs.yaml`
