### PR TITLE
PMM-7: Fix PMM client package build numbers

### DIFF
--- a/qa-integration/pmm_psmdb-pbm_setup/Dockerfile
+++ b/qa-integration/pmm_psmdb-pbm_setup/Dockerfile
@@ -71,8 +71,12 @@ RUN if [[ "$PMM_CLIENT_VERSION" == http* ]]; then \
         dnf -y install pmm-client ; \
     else \
         percona-release enable pmm3-client release && \
-        if [[ "$PMM_CLIENT_VERSION" =~ ^([3-9])\.([1-9][0-9]*)\.([0-9]+)$ ]]; then \
-            dnf -y install pmm-client-${PMM_CLIENT_VERSION}-7.el${OL_VERSION} ; \
+        if [[ "$PMM_CLIENT_VERSION" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then \
+            BUILD_NUMBER=7; \
+            MINOR_VERSION=${PMM_CLIENT_VERSION#3.}; \
+            MINOR_VERSION=${MINOR_VERSION%%.*}; \
+            if [[ "$PMM_CLIENT_VERSION" == "3.7.1" || "$MINOR_VERSION" -gt 7 ]]; then BUILD_NUMBER=8; fi; \
+            dnf -y install pmm-client-${PMM_CLIENT_VERSION}-${BUILD_NUMBER}.el${OL_VERSION} ; \
         else \
             dnf -y install pmm-client-${PMM_CLIENT_VERSION}-6.el${OL_VERSION} ; \
         fi \

--- a/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
@@ -82,8 +82,14 @@ if [[ "$client_version" == "pmm3-latest" ]]; then
 fi
 
 if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
-  wget -O pmm-client.deb https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-7.el9.x86_64.rpm
-  rpm -i pmm-client.deb
+  build_number=7
+  minor_version=${client_version#3.}
+  minor_version=${minor_version%%.*}
+  if [[ "$client_version" == "3.7.1" || "$minor_version" -gt 7 ]]; then
+    build_number=8
+  fi
+  wget -O pmm-client.rpm https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-${build_number}.el9.x86_64.rpm
+  rpm -i pmm-client.rpm
 fi
 
 ## Default Binary path

--- a/qa-integration/pmm_qa/pmm3-client-setup.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup.sh
@@ -92,7 +92,13 @@ fi
 
 ## Only supported for debian based systems for now
 if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
-  wget -O pmm-client.deb https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-7.$(lsb_release -sc)_amd64.deb
+  build_number=7
+  minor_version=${client_version#3.}
+  minor_version=${minor_version%%.*}
+  if [[ "$client_version" == "3.7.1" || "$minor_version" -gt 7 ]]; then
+    build_number=8
+  fi
+  wget -O pmm-client.deb https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb
   dpkg -i pmm-client.deb
 fi
 

--- a/qa-integration/pmm_qa/tasks/install_pmm_client.yml
+++ b/qa-integration/pmm_qa/tasks/install_pmm_client.yml
@@ -138,7 +138,16 @@
 
 - name: Install specific PMM client version on Debian-family containers
   shell: |
-    docker exec --user root {{ container_name }} bash -c 'wget -O /pmm-client.deb "https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_{{ client_version }}-7.$(lsb_release -sc)_amd64.deb"'
+    docker exec --user root {{ container_name }} bash -c '
+      build_number=7
+      client_version="{{ client_version }}"
+      minor_version=${client_version#3.}
+      minor_version=${minor_version%%.*}
+      if [[ "$client_version" == "3.7.1" || "$minor_version" -gt 7 ]]; then
+        build_number=8
+      fi
+      wget -O /pmm-client.deb "https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb"
+    '
     docker exec --user root {{ container_name }} dpkg -i /pmm-client.deb
   when:
     - distro_family == 'debian'
@@ -146,7 +155,16 @@
 
 - name: Install specific PMM client version on RHEL-family containers
   shell: |
-    docker exec --user root {{ container_name }} wget -O /pmm-client.rpm https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-{{ client_version }}-7.el9.x86_64.rpm
+    docker exec --user root {{ container_name }} bash -c '
+      build_number=7
+      client_version="{{ client_version }}"
+      minor_version=${client_version#3.}
+      minor_version=${minor_version%%.*}
+      if [[ "$client_version" == "3.7.1" || "$minor_version" -gt 7 ]]; then
+        build_number=8
+      fi
+      wget -O /pmm-client.rpm "https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-${build_number}.el9.x86_64.rpm"
+    '
     docker exec --user root {{ container_name }} rpm -i /pmm-client.rpm
   when:
     - distro_family == 'rhel'


### PR DESCRIPTION
## Summary
- Selects the PMM client package build suffix for released 3.x versions so 3.7.1 uses the available -8 packages.
- Applies the same package naming in direct setup scripts, Ansible container setup, and PSMDB/PBM image setup.

## Validation
- Ran bash -n for the PMM3 setup scripts.
- Ran git diff --check.
