### PR TITLE
PMM-7: Restore sharding Mongo wait and fix external Redis registration

### DIFF
--- a/qa-integration/pmm_psmdb-pbm_setup/start-sharded.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/start-sharded.sh
@@ -12,6 +12,9 @@ docker compose -f docker-compose-sharded.yaml up -d
 echo "waiting for pmm-server to start"
 timeout 120 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD:-password}" https://127.0.0.1/ping)" = "200" ]; do sleep 5; done'
 
+echo "waiting 30 seconds for mongodb to start"
+sleep 30
+
 nodes="rs101 rs201"
 for node in $nodes
 do

--- a/qa-integration/pmm_qa/external_setup.yml
+++ b/qa-integration/pmm_qa/external_setup.yml
@@ -72,6 +72,11 @@
     with_items:
       - docker exec {{ external_container }} nohup bash -c './redis_exporter/redis_exporter -redis.password=oFukiBRg7GujAJXq3tmd -redis.addr=redis_container:6379 -web.listen-address=:42200 > redis.log 2>&1 &'
 
+  - name: Wait for redis exporter metrics endpoint
+    shell: >
+      docker exec {{ external_container }} bash -c
+      'timeout 60 bash -c "until curl -sf http://127.0.0.1:42200/metrics >/dev/null 2>&1; do sleep 2; done"'
+
   - name: Execute Setup script inside the External container for Process Exporter
     shell: "{{ item }}"
     with_items:


### PR DESCRIPTION
## Summary
- Restores the 30-second pause after the PMM ping check in `start-sharded.sh` so MongoDB is ready before `rs.initiate`.
- Waits for the Redis exporter `/metrics` endpoint on port 42200 before `pmm-admin add external`, avoiding connection refused races.

## Why
PSMDB sharding with an external PMM server passed the ping wait but hit `ECONNREFUSED` on `127.0.0.1:27017` because containers were not given time to start. The external setup playbook started the Redis exporter in the background and immediately registered it with PMM, which failed when nothing was listening on `127.0.0.1:42200` yet.