### PR TITLE
PMM-7: Gate encrypted client config setup to PMM client 3.7.0+

### DIFF
--- a/qa-integration/pmm_qa/tasks/install_pmm_client.yml
+++ b/qa-integration/pmm_qa/tasks/install_pmm_client.yml
@@ -189,10 +189,22 @@
   when:
     - client_version | regex_search('^https?://.*\\.tar\\.gz$') is not none
 
+# Config file encryption (--config-file-key-file/password) was added in PMM client 3.7.0 (PMM-14643).
+- name: Determine if encrypted client config is supported for this client version
+  set_fact:
+    use_encrypted_client_config: >-
+      {{
+        (encrypted_client_config | default(false) | bool) and (
+          client_version in ['3-dev-latest', 'pmm3-rc', 'pmm3-latest', 'latest-tarball'] or
+          (client_version is match('^3\\.[0-9]+\\.[0-9]+$') and client_version is version('3.7.0', '>=')) or
+          (client_version | regex_search('^https?://') is not none)
+        )
+      }}
+
 - name: Generate keys for encrypted client config
   shell: |
     docker exec --user root {{ container_name }} openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:4096 -aes256 -pass pass:testpass -out "/usr/local/percona/pmm/config/pmm-key.pem"
-  when: encrypted_client_config | default(false) | bool
+  when: use_encrypted_client_config | default(false) | bool
 
 - name: Connect pmm client to pmm server using metrics mode without encrypted client config
   shell: |
@@ -207,7 +219,7 @@
         {{ container_name }}
   when:
     - metrics_mode | length > 0
-    - not (encrypted_client_config | default(false) | bool)
+    - not (use_encrypted_client_config | default(false) | bool)
 
 - name: Connect pmm client to pmm server using default metrics mode without encrypted client config
   shell: |
@@ -221,7 +233,7 @@
         {{ container_name }}
   when:
     - metrics_mode | length == 0
-    - not (encrypted_client_config | default(false) | bool)
+    - not (use_encrypted_client_config | default(false) | bool)
 
 - name: Connect pmm client to pmm server using default metrics mode with encrypted client config
   shell: |
@@ -238,7 +250,7 @@
         {{ container_name }}
   when:
     - metrics_mode | length == 0
-    - encrypted_client_config | default(false) | bool
+    - use_encrypted_client_config | default(false) | bool
 
 - name: Connect pmm client to pmm server using metrics mode with encrypted client config
   shell: |
@@ -256,7 +268,7 @@
         {{ container_name }}
   when:
     - metrics_mode | length > 0
-    - encrypted_client_config | default(false) | bool
+    - use_encrypted_client_config | default(false) | bool
 
 - name: Wait 5 seconds for connection to complete
   pause:
@@ -266,13 +278,13 @@
   shell: |
     docker exec --user root {{ container_name }} \
       sh -c 'nohup pmm-agent --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml > /var/log/pmm-agent.log 2>&1 &'
-  when: not (encrypted_client_config | default(false) | bool)
+  when: not (use_encrypted_client_config | default(false) | bool)
 
 - name: Start pmm client with encrypted client config
   shell: |
     docker exec --user root {{ container_name }} \
       sh -c 'nohup pmm-agent --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml --config-file-key-file="/usr/local/percona/pmm/config/pmm-key.pem" --config-file-key-password="testpass" > /var/log/pmm-agent.log 2>&1 &'
-  when: encrypted_client_config | default(false) | bool
+  when: use_encrypted_client_config | default(false) | bool
 
 - name: Wait 5 seconds for start to complete
   pause:


### PR DESCRIPTION
## Summary

RC compatibility CLI jobs enable `ENCRYPTED_CLIENT_CONFIG=true` for the Generic test (Percona Server setup), but the `--config-file-key-file` / `--config-file-key-password` flags were only added in PMM client **3.7.0** (PMM-14643). Older GA clients in the matrix (3.4.x–3.6.x) fail `pmm-agent setup` with an unknown-flag error.

This change computes `use_encrypted_client_config` in `install_pmm_client.yml`: encryption runs only when requested **and** the installed client version supports it (semver `>= 3.7.0`, or rolling channels / tarball URLs). Otherwise the playbook uses the standard non-encrypted setup path.

## Context

- Failing path: `generic-tests` → `--database ps,ENCRYPTED_CLIENT_CONFIG=true` with `pmm_client_version` from the GA compatibility matrix.
- A passing job on the same workflow run (e.g. Generic with client 3.6.0) did not hit this path because it only ran `pdpgsql` setup, not PS with encrypted config.