### PR TITLE
PMM-7: Use client package release 1 for PMM 3.8.1+

### DIFF
--- a/qa-integration/pmm_psmdb-pbm_setup/Dockerfile
+++ b/qa-integration/pmm_psmdb-pbm_setup/Dockerfile
@@ -75,8 +75,8 @@ RUN if [[ "$PMM_CLIENT_VERSION" == http* ]]; then \
             BUILD_NUMBER=7; \
             MINOR_VERSION=${PMM_CLIENT_VERSION#3.}; \
             MINOR_VERSION=${MINOR_VERSION%%.*}; \
-            if [[ "$PMM_CLIENT_VERSION" == "3.7.1" || "$PMM_CLIENT_VERSION" == "3.8.0" ]]; then BUILD_NUMBER=8; \
-            elif [[ "$PMM_CLIENT_VERSION" == "3.8.1" || "$MINOR_VERSION" -gt 8 ]]; then BUILD_NUMBER=1; fi; \
+            if [ "$PMM_CLIENT_VERSION" = "3.7.1" ] || [ "$PMM_CLIENT_VERSION" = "3.8.0" ]; then BUILD_NUMBER=8; \
+            elif [ "$PMM_CLIENT_VERSION" = "3.8.1" ] || [ "$MINOR_VERSION" -gt 8 ]; then BUILD_NUMBER=1; fi; \
             dnf -y install pmm-client-${PMM_CLIENT_VERSION}-${BUILD_NUMBER}.el${OL_VERSION} ; \
         else \
             dnf -y install pmm-client-${PMM_CLIENT_VERSION}-6.el${OL_VERSION} ; \

--- a/qa-integration/pmm_psmdb-pbm_setup/Dockerfile
+++ b/qa-integration/pmm_psmdb-pbm_setup/Dockerfile
@@ -73,9 +73,11 @@ RUN if [[ "$PMM_CLIENT_VERSION" == http* ]]; then \
         percona-release enable pmm3-client release && \
         if [[ "$PMM_CLIENT_VERSION" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then \
             BUILD_NUMBER=7; \
-            MINOR=${PMM_CLIENT_VERSION#3.}; MINOR=${MINOR%%.*}; PATCH=${PMM_CLIENT_VERSION##*.}; \
+            MINOR_VERSION=${PMM_CLIENT_VERSION#3.}; \
+            MINOR_VERSION=${MINOR_VERSION%%.*}; \
+            PATCH_VERSION=${PMM_CLIENT_VERSION##*.}; \
             if [[ "$PMM_CLIENT_VERSION" == "3.7.1" || "$PMM_CLIENT_VERSION" == "3.8.0" ]]; then BUILD_NUMBER=8; \
-            elif [[ "$MINOR" -gt 8 || ( "$MINOR" -eq 8 && "$PATCH" -gt 0 ) ]]; then BUILD_NUMBER=1; fi; \
+            elif [[ "$MINOR_VERSION" -gt 8 || ( "$MINOR_VERSION" -eq 8 && "$PATCH_VERSION" -gt 0 ) ]]; then BUILD_NUMBER=1; fi; \
             dnf -y install pmm-client-${PMM_CLIENT_VERSION}-${BUILD_NUMBER}.el${OL_VERSION} ; \
         else \
             dnf -y install pmm-client-${PMM_CLIENT_VERSION}-6.el${OL_VERSION} ; \

--- a/qa-integration/pmm_psmdb-pbm_setup/Dockerfile
+++ b/qa-integration/pmm_psmdb-pbm_setup/Dockerfile
@@ -75,9 +75,8 @@ RUN if [[ "$PMM_CLIENT_VERSION" == http* ]]; then \
             BUILD_NUMBER=7; \
             MINOR_VERSION=${PMM_CLIENT_VERSION#3.}; \
             MINOR_VERSION=${MINOR_VERSION%%.*}; \
-            PATCH_VERSION=${PMM_CLIENT_VERSION##*.}; \
             if [[ "$PMM_CLIENT_VERSION" == "3.7.1" || "$PMM_CLIENT_VERSION" == "3.8.0" ]]; then BUILD_NUMBER=8; \
-            elif [[ "$MINOR_VERSION" -gt 8 || ( "$MINOR_VERSION" -eq 8 && "$PATCH_VERSION" -gt 0 ) ]]; then BUILD_NUMBER=1; fi; \
+            elif [[ "$PMM_CLIENT_VERSION" == "3.8.1" || "$MINOR_VERSION" -gt 8 ]]; then BUILD_NUMBER=1; fi; \
             dnf -y install pmm-client-${PMM_CLIENT_VERSION}-${BUILD_NUMBER}.el${OL_VERSION} ; \
         else \
             dnf -y install pmm-client-${PMM_CLIENT_VERSION}-6.el${OL_VERSION} ; \

--- a/qa-integration/pmm_psmdb-pbm_setup/Dockerfile
+++ b/qa-integration/pmm_psmdb-pbm_setup/Dockerfile
@@ -73,9 +73,8 @@ RUN if [[ "$PMM_CLIENT_VERSION" == http* ]]; then \
         percona-release enable pmm3-client release && \
         if [[ "$PMM_CLIENT_VERSION" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then \
             BUILD_NUMBER=7; \
-            MINOR_VERSION=${PMM_CLIENT_VERSION#3.}; \
-            MINOR_VERSION=${MINOR_VERSION%%.*}; \
-            if [[ "$PMM_CLIENT_VERSION" == "3.7.1" || "$MINOR_VERSION" -gt 7 ]]; then BUILD_NUMBER=8; fi; \
+            if [[ "$PMM_CLIENT_VERSION" == "3.7.1" || "$PMM_CLIENT_VERSION" == "3.8.0" ]]; then BUILD_NUMBER=8; \
+            elif [[ "$(printf '%s\n' '3.8.0' "$PMM_CLIENT_VERSION" | sort -V | tail -n1)" == "$PMM_CLIENT_VERSION" && "$PMM_CLIENT_VERSION" != "3.8.0" ]]; then BUILD_NUMBER=1; fi; \
             dnf -y install pmm-client-${PMM_CLIENT_VERSION}-${BUILD_NUMBER}.el${OL_VERSION} ; \
         else \
             dnf -y install pmm-client-${PMM_CLIENT_VERSION}-6.el${OL_VERSION} ; \

--- a/qa-integration/pmm_psmdb-pbm_setup/Dockerfile
+++ b/qa-integration/pmm_psmdb-pbm_setup/Dockerfile
@@ -73,8 +73,9 @@ RUN if [[ "$PMM_CLIENT_VERSION" == http* ]]; then \
         percona-release enable pmm3-client release && \
         if [[ "$PMM_CLIENT_VERSION" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then \
             BUILD_NUMBER=7; \
+            MINOR=${PMM_CLIENT_VERSION#3.}; MINOR=${MINOR%%.*}; PATCH=${PMM_CLIENT_VERSION##*.}; \
             if [[ "$PMM_CLIENT_VERSION" == "3.7.1" || "$PMM_CLIENT_VERSION" == "3.8.0" ]]; then BUILD_NUMBER=8; \
-            elif [[ "$(printf '%s\n' '3.8.0' "$PMM_CLIENT_VERSION" | sort -V | tail -n1)" == "$PMM_CLIENT_VERSION" && "$PMM_CLIENT_VERSION" != "3.8.0" ]]; then BUILD_NUMBER=1; fi; \
+            elif [[ "$MINOR" -gt 8 || ( "$MINOR" -eq 8 && "$PATCH" -gt 0 ) ]]; then BUILD_NUMBER=1; fi; \
             dnf -y install pmm-client-${PMM_CLIENT_VERSION}-${BUILD_NUMBER}.el${OL_VERSION} ; \
         else \
             dnf -y install pmm-client-${PMM_CLIENT_VERSION}-6.el${OL_VERSION} ; \

--- a/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
@@ -83,12 +83,12 @@ fi
 
 if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
   build_number=7
-  minor=${client_version#3.}
-  minor=${minor%%.*}
-  patch=${client_version##*.}
+  minor_version=${client_version#3.}
+  minor_version=${minor_version%%.*}
+  patch_version=${client_version##*.}
   if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
     build_number=8
-  elif [[ "$minor" -gt 8 || ( "$minor" -eq 8 && "$patch" -gt 0 ) ]]; then
+  elif [[ "$minor_version" -gt 8 || ( "$minor_version" -eq 8 && "$patch_version" -gt 0 ) ]]; then
     build_number=1
   fi
   wget -O pmm-client.rpm https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-${build_number}.el9.x86_64.rpm

--- a/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
@@ -85,10 +85,9 @@ if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
   build_number=7
   minor_version=${client_version#3.}
   minor_version=${minor_version%%.*}
-  patch_version=${client_version##*.}
   if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
     build_number=8
-  elif [[ "$minor_version" -gt 8 || ( "$minor_version" -eq 8 && "$patch_version" -gt 0 ) ]]; then
+  elif [[ "$client_version" == "3.8.1" || "$minor_version" -gt 8 ]]; then
     build_number=1
   fi
   wget -O pmm-client.rpm https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-${build_number}.el9.x86_64.rpm

--- a/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
@@ -85,9 +85,9 @@ if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
   build_number=7
   minor_version=${client_version#3.}
   minor_version=${minor_version%%.*}
-  if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
+  if [ "$client_version" = "3.7.1" ] || [ "$client_version" = "3.8.0" ]; then
     build_number=8
-  elif [[ "$client_version" == "3.8.1" || "$minor_version" -gt 8 ]]; then
+  elif [ "$client_version" = "3.8.1" ] || [ "$minor_version" -gt 8 ]; then
     build_number=1
   fi
   wget -O pmm-client.rpm https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-${build_number}.el9.x86_64.rpm

--- a/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
@@ -83,10 +83,10 @@ fi
 
 if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
   build_number=7
-  minor_version=${client_version#3.}
-  minor_version=${minor_version%%.*}
-  if [[ "$client_version" == "3.7.1" || "$minor_version" -gt 7 ]]; then
+  if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
     build_number=8
+  elif [[ "$(printf '%s\n' '3.8.0' "$client_version" | sort -V | tail -n1)" == "$client_version" && "$client_version" != "3.8.0" ]]; then
+    build_number=1
   fi
   wget -O pmm-client.rpm https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-${build_number}.el9.x86_64.rpm
   rpm -i pmm-client.rpm

--- a/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
@@ -83,9 +83,12 @@ fi
 
 if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
   build_number=7
+  minor=${client_version#3.}
+  minor=${minor%%.*}
+  patch=${client_version##*.}
   if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
     build_number=8
-  elif [[ "$(printf '%s\n' '3.8.0' "$client_version" | sort -V | tail -n1)" == "$client_version" && "$client_version" != "3.8.0" ]]; then
+  elif [[ "$minor" -gt 8 || ( "$minor" -eq 8 && "$patch" -gt 0 ) ]]; then
     build_number=1
   fi
   wget -O pmm-client.rpm https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-${build_number}.el9.x86_64.rpm

--- a/qa-integration/pmm_qa/pmm3-client-setup.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup.sh
@@ -100,9 +100,9 @@ if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
   build_number=7
   minor_version=${client_version#3.}
   minor_version=${minor_version%%.*}
-  if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
+  if [ "$client_version" = "3.7.1" ] || [ "$client_version" = "3.8.0" ]; then
     build_number=8
-  elif [[ "$client_version" == "3.8.1" || "$minor_version" -gt 8 ]]; then
+  elif [ "$client_version" = "3.8.1" ] || [ "$minor_version" -gt 8 ]; then
     build_number=1
   fi
   wget -O pmm-client.deb https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb

--- a/qa-integration/pmm_qa/pmm3-client-setup.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup.sh
@@ -98,10 +98,10 @@ fi
 ## Only supported for debian based systems for now
 if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
   build_number=7
-  minor_version=${client_version#3.}
-  minor_version=${minor_version%%.*}
-  if [[ "$client_version" == "3.7.1" || "$minor_version" -gt 7 ]]; then
+  if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
     build_number=8
+  elif [[ "$(printf '%s\n' '3.8.0' "$client_version" | sort -V | tail -n1)" == "$client_version" && "$client_version" != "3.8.0" ]]; then
+    build_number=1
   fi
   wget -O pmm-client.deb https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb
   dpkg -i pmm-client.deb

--- a/qa-integration/pmm_qa/pmm3-client-setup.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup.sh
@@ -100,10 +100,9 @@ if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
   build_number=7
   minor_version=${client_version#3.}
   minor_version=${minor_version%%.*}
-  patch_version=${client_version##*.}
   if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
     build_number=8
-  elif [[ "$minor_version" -gt 8 || ( "$minor_version" -eq 8 && "$patch_version" -gt 0 ) ]]; then
+  elif [[ "$client_version" == "3.8.1" || "$minor_version" -gt 8 ]]; then
     build_number=1
   fi
   wget -O pmm-client.deb https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb

--- a/qa-integration/pmm_qa/pmm3-client-setup.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup.sh
@@ -98,9 +98,12 @@ fi
 ## Only supported for debian based systems for now
 if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
   build_number=7
+  minor=${client_version#3.}
+  minor=${minor%%.*}
+  patch=${client_version##*.}
   if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
     build_number=8
-  elif [[ "$(printf '%s\n' '3.8.0' "$client_version" | sort -V | tail -n1)" == "$client_version" && "$client_version" != "3.8.0" ]]; then
+  elif [[ "$minor" -gt 8 || ( "$minor" -eq 8 && "$patch" -gt 0 ) ]]; then
     build_number=1
   fi
   wget -O pmm-client.deb https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb

--- a/qa-integration/pmm_qa/pmm3-client-setup.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup.sh
@@ -98,12 +98,12 @@ fi
 ## Only supported for debian based systems for now
 if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
   build_number=7
-  minor=${client_version#3.}
-  minor=${minor%%.*}
-  patch=${client_version##*.}
+  minor_version=${client_version#3.}
+  minor_version=${minor_version%%.*}
+  patch_version=${client_version##*.}
   if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
     build_number=8
-  elif [[ "$minor" -gt 8 || ( "$minor" -eq 8 && "$patch" -gt 0 ) ]]; then
+  elif [[ "$minor_version" -gt 8 || ( "$minor_version" -eq 8 && "$patch_version" -gt 0 ) ]]; then
     build_number=1
   fi
   wget -O pmm-client.deb https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb

--- a/qa-integration/pmm_qa/tasks/install_pmm_client.yml
+++ b/qa-integration/pmm_qa/tasks/install_pmm_client.yml
@@ -141,10 +141,10 @@
     docker exec --user root {{ container_name }} bash -c '
       build_number=7
       client_version="{{ client_version }}"
-      minor_version=${client_version#3.}
-      minor_version=${minor_version%%.*}
-      if [[ "$client_version" == "3.7.1" || "$minor_version" -gt 7 ]]; then
+      if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
         build_number=8
+      elif [[ "$(printf '%s\n' '3.8.0' "$client_version" | sort -V | tail -n1)" == "$client_version" && "$client_version" != "3.8.0" ]]; then
+        build_number=1
       fi
       wget -O /pmm-client.deb "https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb"
     '
@@ -158,10 +158,10 @@
     docker exec --user root {{ container_name }} bash -c '
       build_number=7
       client_version="{{ client_version }}"
-      minor_version=${client_version#3.}
-      minor_version=${minor_version%%.*}
-      if [[ "$client_version" == "3.7.1" || "$minor_version" -gt 7 ]]; then
+      if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
         build_number=8
+      elif [[ "$(printf '%s\n' '3.8.0' "$client_version" | sort -V | tail -n1)" == "$client_version" && "$client_version" != "3.8.0" ]]; then
+        build_number=1
       fi
       wget -O /pmm-client.rpm "https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-${build_number}.el9.x86_64.rpm"
     '

--- a/qa-integration/pmm_qa/tasks/install_pmm_client.yml
+++ b/qa-integration/pmm_qa/tasks/install_pmm_client.yml
@@ -143,10 +143,9 @@
       client_version="{{ client_version }}"
       minor_version=${client_version#3.}
       minor_version=${minor_version%%.*}
-      patch_version=${client_version##*.}
       if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
         build_number=8
-      elif [[ "$minor_version" -gt 8 || ( "$minor_version" -eq 8 && "$patch_version" -gt 0 ) ]]; then
+      elif [[ "$client_version" == "3.8.1" || "$minor_version" -gt 8 ]]; then
         build_number=1
       fi
       wget -O /pmm-client.deb "https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb"
@@ -163,10 +162,9 @@
       client_version="{{ client_version }}"
       minor_version=${client_version#3.}
       minor_version=${minor_version%%.*}
-      patch_version=${client_version##*.}
       if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
         build_number=8
-      elif [[ "$minor_version" -gt 8 || ( "$minor_version" -eq 8 && "$patch_version" -gt 0 ) ]]; then
+      elif [[ "$client_version" == "3.8.1" || "$minor_version" -gt 8 ]]; then
         build_number=1
       fi
       wget -O /pmm-client.rpm "https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-${build_number}.el9.x86_64.rpm"

--- a/qa-integration/pmm_qa/tasks/install_pmm_client.yml
+++ b/qa-integration/pmm_qa/tasks/install_pmm_client.yml
@@ -141,9 +141,12 @@
     docker exec --user root {{ container_name }} bash -c '
       build_number=7
       client_version="{{ client_version }}"
+      minor=${client_version#3.}
+      minor=${minor%%.*}
+      patch=${client_version##*.}
       if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
         build_number=8
-      elif [[ "$(printf '%s\n' '3.8.0' "$client_version" | sort -V | tail -n1)" == "$client_version" && "$client_version" != "3.8.0" ]]; then
+      elif [[ "$minor" -gt 8 || ( "$minor" -eq 8 && "$patch" -gt 0 ) ]]; then
         build_number=1
       fi
       wget -O /pmm-client.deb "https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb"
@@ -158,9 +161,12 @@
     docker exec --user root {{ container_name }} bash -c '
       build_number=7
       client_version="{{ client_version }}"
+      minor=${client_version#3.}
+      minor=${minor%%.*}
+      patch=${client_version##*.}
       if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
         build_number=8
-      elif [[ "$(printf '%s\n' '3.8.0' "$client_version" | sort -V | tail -n1)" == "$client_version" && "$client_version" != "3.8.0" ]]; then
+      elif [[ "$minor" -gt 8 || ( "$minor" -eq 8 && "$patch" -gt 0 ) ]]; then
         build_number=1
       fi
       wget -O /pmm-client.rpm "https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-${build_number}.el9.x86_64.rpm"

--- a/qa-integration/pmm_qa/tasks/install_pmm_client.yml
+++ b/qa-integration/pmm_qa/tasks/install_pmm_client.yml
@@ -141,12 +141,12 @@
     docker exec --user root {{ container_name }} bash -c '
       build_number=7
       client_version="{{ client_version }}"
-      minor=${client_version#3.}
-      minor=${minor%%.*}
-      patch=${client_version##*.}
+      minor_version=${client_version#3.}
+      minor_version=${minor_version%%.*}
+      patch_version=${client_version##*.}
       if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
         build_number=8
-      elif [[ "$minor" -gt 8 || ( "$minor" -eq 8 && "$patch" -gt 0 ) ]]; then
+      elif [[ "$minor_version" -gt 8 || ( "$minor_version" -eq 8 && "$patch_version" -gt 0 ) ]]; then
         build_number=1
       fi
       wget -O /pmm-client.deb "https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb"
@@ -161,12 +161,12 @@
     docker exec --user root {{ container_name }} bash -c '
       build_number=7
       client_version="{{ client_version }}"
-      minor=${client_version#3.}
-      minor=${minor%%.*}
-      patch=${client_version##*.}
+      minor_version=${client_version#3.}
+      minor_version=${minor_version%%.*}
+      patch_version=${client_version##*.}
       if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
         build_number=8
-      elif [[ "$minor" -gt 8 || ( "$minor" -eq 8 && "$patch" -gt 0 ) ]]; then
+      elif [[ "$minor_version" -gt 8 || ( "$minor_version" -eq 8 && "$patch_version" -gt 0 ) ]]; then
         build_number=1
       fi
       wget -O /pmm-client.rpm "https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-${build_number}.el9.x86_64.rpm"

--- a/qa-integration/pmm_qa/tasks/install_pmm_client.yml
+++ b/qa-integration/pmm_qa/tasks/install_pmm_client.yml
@@ -143,9 +143,9 @@
       client_version="{{ client_version }}"
       minor_version=${client_version#3.}
       minor_version=${minor_version%%.*}
-      if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
+      if [ "$client_version" = "3.7.1" ] || [ "$client_version" = "3.8.0" ]; then
         build_number=8
-      elif [[ "$client_version" == "3.8.1" || "$minor_version" -gt 8 ]]; then
+      elif [ "$client_version" = "3.8.1" ] || [ "$minor_version" -gt 8 ]; then
         build_number=1
       fi
       wget -O /pmm-client.deb "https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb"
@@ -162,9 +162,9 @@
       client_version="{{ client_version }}"
       minor_version=${client_version#3.}
       minor_version=${minor_version%%.*}
-      if [[ "$client_version" == "3.7.1" || "$client_version" == "3.8.0" ]]; then
+      if [ "$client_version" = "3.7.1" ] || [ "$client_version" = "3.8.0" ]; then
         build_number=8
-      elif [[ "$client_version" == "3.8.1" || "$minor_version" -gt 8 ]]; then
+      elif [ "$client_version" = "3.8.1" ] || [ "$minor_version" -gt 8 ]; then
         build_number=1
       fi
       wget -O /pmm-client.rpm "https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-${build_number}.el9.x86_64.rpm"


### PR DESCRIPTION
## Summary
- Update pinned pmm-client package URLs for the RPM/DEB release reset in percona/pmm#5433.
- Release suffix: \7\ for versions before 3.8.0, \8\ for 3.8.0 (and 3.7.1), \1\ for 3.8.1 and newer.

## Related
- Depends on percona/pmm#5433