### PR TITLE
PMM-7: Use /v1/server/readyz instead of /ping for PMM waits

### DIFF
--- a/.github/workflows/runner-e2e-tests-codeceptjs.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs.yml
@@ -202,7 +202,7 @@ jobs:
         run: |
           docker network create pmm-qa || true
           PWD=$(pwd) PMM_SERVER_IMAGE=${{ env.DOCKER_VERSION }} docker compose -f ${{ env.DOCKER_COMPOSE_FILE }} up -d
-          timeout 120 bash -c 'until [ "$(curl -s -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD}" http://127.0.0.1/ping)" = "200" ]; do sleep 5; done'
+          timeout 120 bash -c 'until [ "$(curl -s -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD}" http://127.0.0.1/v1/server/readyz)" = "200" ]; do sleep 5; done'
           bash -x testdata/db_setup.sh
           docker network connect pmm-qa pmm-server || true
 

--- a/.github/workflows/runner-e2e-tests-playwright.yml
+++ b/.github/workflows/runner-e2e-tests-playwright.yml
@@ -182,7 +182,7 @@ jobs:
           docker volume create pmm-volume
 
           PWD=$(pwd) docker compose -f docker-compose.yml up -d
-          timeout 120 bash -c 'until [ "$(curl -s -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD}" http://127.0.0.1/ping)" = "200" ]; do sleep 5; done'
+          timeout 120 bash -c 'until [ "$(curl -s -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD}" http://127.0.0.1/v1/server/readyz)" = "200" ]; do sleep 5; done'
 
       - name: Setup PMM-Client
         if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' }}

--- a/.github/workflows/runner-e2e-tests-podman.yml
+++ b/.github/workflows/runner-e2e-tests-podman.yml
@@ -194,7 +194,7 @@ jobs:
             fi
             sleep 10
           done;
-          timeout 100 bash -c 'while [[ "$(curl -s -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD}" http://127.0.0.1/ping)" != "200" ]]; do sleep 5; done'
+          timeout 100 bash -c 'while [[ "$(curl -s -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD}" http://127.0.0.1/v1/server/readyz)" != "200" ]]; do sleep 5; done'
           # bash -x testdata/db_setup.sh
 
       - name: Print Podman logs on failure

--- a/.github/workflows/runner-easy-install.yml
+++ b/.github/workflows/runner-easy-install.yml
@@ -101,7 +101,7 @@ jobs:
 
               cd /pmm/easy-install/
               curl -fsSL https://raw.githubusercontent.com/percona/pmm/refs/heads/${{ env.EASY_INSTALL_BRANCH }}/get-pmm.sh | /bin/bash
-              timeout 100 bash -c 'while [[ ! "$(curl -i -s --insecure -w "%{http_code}" https://127.0.0.1/ping)" =~ "200" ]]; do sleep 5; echo "$(curl -i -s --insecure -w "%{http_code}" https://127.0.0.1/ping)"; done' || false
+              timeout 100 bash -c 'while [[ ! "$(curl -i -s --insecure -w "%{http_code}" https://127.0.0.1/v1/server/readyz)" =~ "200" ]]; do sleep 5; echo "$(curl -i -s --insecure -w "%{http_code}" https://127.0.0.1/v1/server/readyz)"; done' || false
               echo "Echo containers:"
               docker ps -a
               echo "Echo pmm server status: "

--- a/qa-integration/pmm_psmdb-pbm_setup/start-rs.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/start-rs.sh
@@ -21,7 +21,7 @@ docker compose -f docker-compose-rs.yaml -f docker-compose-pmm.yaml build
 docker compose -f docker-compose-pmm.yaml -f docker-compose-rs.yaml up -d
 echo
 echo "waiting for pmm-server to start"
-timeout 120 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" --user "admin:'"$pmm_server_admin_pass"'" https://127.0.0.1/ping)" = "200" ]; do sleep 5; done'
+timeout 120 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" --user "admin:'"$pmm_server_admin_pass"'" https://127.0.0.1/v1/server/readyz)" = "200" ]; do sleep 5; done'
 if [ $mongo_setup_type == "pss" ]; then
   bash -e ./configure-replset.sh
 else

--- a/qa-integration/pmm_psmdb-pbm_setup/start-sharded.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/start-sharded.sh
@@ -10,7 +10,7 @@ docker compose -f docker-compose-sharded.yaml build
 docker compose -f docker-compose-sharded.yaml up -d
 
 echo "waiting for pmm-server to start"
-timeout 120 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD:-password}" https://127.0.0.1/ping)" = "200" ]; do sleep 5; done'
+timeout 120 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD:-password}" https://127.0.0.1/v1/server/readyz)" = "200" ]; do sleep 5; done'
 
 echo "waiting 30 seconds for mongodb to start"
 sleep 30

--- a/qa-integration/pmm_psmdb_diffauth_setup/docker-compose-pmm-psmdb.yml
+++ b/qa-integration/pmm_psmdb_diffauth_setup/docker-compose-pmm-psmdb.yml
@@ -72,7 +72,7 @@ services:
     hostname: pmm-server
     image: ${PMM_SERVER_IMAGE:-${PMM_IMAGE:-perconalab/pmm-server:3-dev-latest}}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://127.0.0.1:8080/ping" ]
+      test: [ "CMD", "curl", "-f", "http://127.0.0.1:8080/v1/server/readyz" ]
       interval: 3s
       timeout: 2s
       retries: 20

--- a/qa-integration/pmm_qa/pmm-framework.py
+++ b/qa-integration/pmm_qa/pmm-framework.py
@@ -487,7 +487,7 @@ def mongo_sharding_setup(script_filename, args):
                             f'{shell_file_path}'])
             if args.pmm_server_ip:
                 subprocess.run(
-                    ['sed', '-i', f's|https://127.0.0.1/ping|https://{args.pmm_server_ip}/ping|g',
+                    ['sed', '-i', f's|https://127.0.0.1/v1/server/readyz|https://{args.pmm_server_ip}/v1/server/readyz|g',
                      f'{shell_file_path}'])
     except subprocess.CalledProcessError as e:
         print(f"Error occurred: {e}")


### PR DESCRIPTION
## Summary

Replace PMM Server health waits from ping\to /v1/server/readyz (Grafana, VictoriaMetrics, VMAlert, QAN must be ready).

Linked to https://github.com/Percona-Lab/jenkins-pipelines/pull/4135
