### PR TITLE
PMM-15135: Add pmm-manual-test Cursor skill

### DIFF
--- a/.cursor/skills/pmm-manual-test/SKILL.md
+++ b/.cursor/skills/pmm-manual-test/SKILL.md
@@ -1,0 +1,391 @@
+---
+name: pmm-manual-test
+description: Guides PMM manual testing by reading a Jira ticket, syncing local repos, finding pmm-submodules build artifacts, analyzing flaky FB Tests for test insights, choosing pmm3-aws-staging-start or pmm3-deploy-services, determining all Jenkins parameters, generating a fully pre-filled parambuild URL, screenshotting FB test results with playwright-cli into Jira FB test screenshots field, and writing verified test steps. Use when the user asks for help with manual testing, PMM staging setup, FB test analysis, or wants a Jenkins job link to test a Jira ticket.
+---
+
+# PMM Manual Test
+
+## Trigger
+
+Start when the user asks for help with **manual testing**. **Always ask for the Jira ticket key** (e.g. `PMM-14915`) if not provided.
+
+## Local repo layout
+
+PMM repos are expected as **siblings** under one parent directory (repos root). This skill ships in **pmm-qa**; resolve paths from the pmm-qa clone.
+
+| Repo | Directory (under repos root) | Remote |
+|------|------------------------------|--------|
+| pmm-qa | `pmm-qa` | `percona/pmm-qa` |
+| pmm | `pmm` | `percona/pmm` |
+| grafana | `grafana` | `percona/grafana` |
+| jenkins-pipelines | `jenkins-pipelines` | `Percona-Lab/jenkins-pipelines` |
+
+**pmm-submodules** — read PR comments and checks via `gh` only, never clone.
+
+### Resolve repos root and paths
+
+**Repos root** = parent directory of the `pmm-qa` git root.
+
+```powershell
+$pmmQaRoot = git -C "<path-to-pmm-qa>" rev-parse --show-toplevel
+$ReposRoot = (Get-Item $pmmQaRoot).Parent.FullName
+```
+
+```bash
+PMM_QA_ROOT="$(git -C pmm-qa rev-parse --show-toplevel)"
+REPOS_ROOT="$(dirname "$PMM_QA_ROOT")"
+```
+
+| Variable | Example path |
+|----------|----------------|
+| `$ReposRoot` / `$REPOS_ROOT` | `~/vscodeProjects/PMM` |
+| pmm | `$ReposRoot/pmm` |
+| grafana | `$ReposRoot/grafana` |
+| jenkins-pipelines | `$ReposRoot/jenkins-pipelines` |
+| pmm-qa | `$ReposRoot/pmm-qa` |
+
+### Clone if missing
+
+If a sibling repo directory does not exist, clone it into **repos root**:
+
+```powershell
+$ReposRoot = (Get-Item (git rev-parse --show-toplevel)).Parent.FullName
+$repos = @{
+  pmm = "https://github.com/percona/pmm.git"
+  grafana = "https://github.com/percona/grafana.git"
+  "jenkins-pipelines" = "https://github.com/Percona-Lab/jenkins-pipelines.git"
+}
+foreach ($name in $repos.Keys) {
+  $path = Join-Path $ReposRoot $name
+  if (-not (Test-Path $path)) { git clone $repos[$name] $path }
+}
+```
+
+```bash
+REPOS_ROOT="$(dirname "$(git rev-parse --show-toplevel)")"
+[ -d "$REPOS_ROOT/pmm" ] || git clone https://github.com/percona/pmm.git "$REPOS_ROOT/pmm"
+[ -d "$REPOS_ROOT/grafana" ] || git clone https://github.com/percona/grafana.git "$REPOS_ROOT/grafana"
+[ -d "$REPOS_ROOT/jenkins-pipelines" ] || git clone https://github.com/Percona-Lab/jenkins-pipelines.git "$REPOS_ROOT/jenkins-pipelines"
+```
+
+Then `git fetch` / `git pull --ff-only` in each repo that exists.
+
+## Workflow checklist
+
+```
+- [ ] 1. Get Jira ticket key from user
+- [ ] 2. Read ticket via Atlassian MCP (summary, description, linked PRs, acceptance criteria)
+- [ ] 3. Identify affected repos (pmm, grafana, or both)
+- [ ] 4. Resolve repos root; clone missing siblings; update local repos (git pull)
+- [ ] 5. Find pmm-submodules PR and latest JNKPercona build comment — older comments are not valid
+- [ ] 6. Analyze FB Tests from latest FB build (`gh pr checks` on pmm-submodules PR)
+- [ ] 7. Choose Jenkins job (pmm3-aws-staging-start vs pmm3-deploy-services)
+- [ ] 8. Determine required job parameters to setup instance based on ticket scope and PR diffs
+- [ ] 9. Build complete parambuild URL (all relevant params, not just DOCKER_VERSION + CLIENT_VERSION)
+- [ ] 10. Review PR diffs — do not trust "How to test" blindly
+- [ ] 11. Write test instructions in chat (adapt using FB test failures where relevant)
+- [ ] 12. Screenshot FB Tests Actions run (playwright-cli) and update Jira FB test screenshots field
+- [ ] 13. Open Jenkins parambuild URL in browser
+```
+
+## Step 1: Get Jira ticket key
+
+Ask if missing. Proceed once you have the key (e.g. `PMM-14915`).
+
+## Step 2: Read Jira ticket
+
+Use **Atlassian MCP** (`jira_get_issue`, `jira_get_issue_development_info`):
+
+- Summary, description, QA notes, acceptance criteria
+- Existing **How to test** (`customfield_10083`) and **FB test screenshots** (`customfield_10492`)
+- Development panel: linked GitHub PRs/branches
+- Environment or setup hints
+
+**Setup is ticket-specific.** Pay attention to:
+
+- Which subsystems change (server, UI/grafana, clients, telemetry, advisors, etc.)
+- Whether monitored databases are needed
+- Required **PMM server environment variables** (`DOCKER_ENV_VARIABLE`) — job defaults are often wrong for the test (e.g. default `PMM_ENABLE_TELEMETRY=0`)
+- PMM Settings changes the user must apply after provisioning
+
+## Step 3: Identify affected repos
+
+| Change area | Repo |
+|-------------|------|
+| Backend, API, managed services | `percona/pmm` |
+| Grafana UI, dashboards, frontend | `percona/grafana` |
+| Both | Check both PRs |
+
+Grafana-only tickets still need an FB **server** image from pmm-submodules.
+
+## Step 4: Update local repos
+
+Resolve `$ReposRoot` (see above). Clone any missing sibling, then pull:
+
+```powershell
+git -C "$ReposRoot/pmm" fetch origin
+git -C "$ReposRoot/pmm" pull --ff-only
+```
+
+Repeat for `grafana`, `jenkins-pipelines`, and `pmm-qa` as needed.
+
+## Step 5: Find linked PRs and build artifacts
+
+### Find PRs
+
+```powershell
+gh search prs "PMM-14915" --repo percona/pmm --json number,title,url
+gh search prs "PMM-14915" --repo percona/grafana --json number,title,url
+```
+
+```powershell
+gh pr view <n> --repo percona/pmm --json title,body,url,files
+gh pr diff <n> --repo percona/pmm
+```
+
+### pmm-submodules PR
+
+Read the FB link in the pmm PR body (e.g. `Percona-Lab/pmm-submodules/pull/4376`). **Submodules PR number ≠ pmm PR number.**
+
+### JNKPercona build comment
+
+```powershell
+gh api repos/Percona-Lab/pmm-submodules/issues/<SUBMODULES_PR>/comments `
+  --jq '[.[] | select(.user.login == "JNKPercona" and (.body | contains("Staging instance:"))) | {created_at, body}] | sort_by(.created_at) | .[-1]'
+```
+
+Extract from the **latest** build-summary comment (older FB builds are invalid):
+
+| Field | Param |
+|-------|-------|
+| `Server docker:` | `DOCKER_VERSION` |
+| `Watchtower docker:` | `WATCHTOWER_VERSION` |
+| `Client tarball:` | `CLIENT_VERSION` |
+| `Client docker:` | **ignore** for `CLIENT_VERSION` |
+
+## Step 6: Analyze FB Tests
+
+FB Tests = **GitHub PR checks** on `pmm-submodules` (`gh pr checks`). They are **often flaky** but give useful hints — use failures to **adapt** manual test steps when they overlap the ticket scope.
+
+**Ignore** JNKPercona `API tests have succeded/failed` comments — not relevant for this workflow.
+
+### Collect results
+
+```powershell
+gh pr checks <SUBMODULES_PR> -R Percona-Lab/pmm-submodules
+```
+
+### What to extract
+
+| Source | Data |
+|--------|------|
+| `gh pr checks` | Failed/passed UI (`@* UI tests`) and CLI (`CLI tests *`) matrix |
+| Check links | Actions run URL, Jenkins `pmm3-submodules/PR-XXXX` build |
+
+### How to use failures
+
+1. List failures from the **latest** FB build only
+2. Mark each: **relevant** (overlaps ticket) / **flaky** / **out of scope**
+3. **Relevant** failures → add explicit checks to manual test plan (step 11) and Jenkins params (step 8) if setup-related
+4. **Flaky/out of scope** → note in FB test screenshots field, do not expand manual scope
+
+Full reference: [fb-tests.md](fb-tests.md)
+
+## Step 7: Choose Jenkins job
+
+| Scenario | Job |
+|----------|-----|
+| Server/UI/API; optional **local** clients on same VM via `CLIENTS` | **pmm3-aws-staging-start** |
+| Separate client VMs, multi-node DB topologies, external exporters | **pmm3-deploy-services** |
+
+FB test failures may inform this choice (e.g. CLI integration failure on a DB type → consider `CLIENTS` or `DEPLOY_*_GROUP`).
+
+### staging-start with local clients (`CLIENTS`)
+
+`CLIENTS` feeds `pmm-framework.py` in this repo (`qa-integration/pmm_qa/pmm-framework.py`) on the same EC2 instance.
+
+**Limitations:** single VM only; no multi-VM topologies. Use **deploy-services** for those.
+
+Leave `CLIENTS` empty for server-only tests (UI, API, settings, network-tab checks).
+
+See [jenkins-jobs.md](jenkins-jobs.md) for all parameters. Groovy source: `$ReposRoot/jenkins-pipelines/pmm/v3/`.
+
+## Step 8: Determine required job parameters
+
+Derive **every** param that differs from defaults. The user should not need to edit the Jenkins form.
+
+Include **all** params in the `parambuild` URL for the chosen job — not only `DOCKER_VERSION` + `CLIENT_VERSION`. Walk through the full list below; keep defaults only when they are correct for this ticket.
+
+### Always set from FB build
+
+- `DOCKER_VERSION`, `CLIENT_VERSION`, `WATCHTOWER_VERSION`
+
+### Adapt from ticket + PR diffs + FB test insights
+
+| Concern | Params to review |
+|---------|------------------|
+| PMM server env vars | `DOCKER_ENV_VARIABLE` — read PR diff + `$ReposRoot/pmm/managed/CONTRIBUTING.md` + docker env docs |
+| Monitored databases | `CLIENTS` (staging-start) or `DEPLOY_*_GROUP` flags (deploy-services) |
+| DB versions | `PS_VERSION`, `MS_VERSION`, `PXC_VERSION`, `PGSQL_VERSION`, `PDPGSQL_VERSION`, `PSMDB_VERSION`, `MODB_VERSION` |
+| SSH access | `SSH_KEY` |
+| Client repo channel | `PMM_CLIENT_REPO` (staging-start only) |
+| Provisioner scripts | `PMM_QA_GIT_BRANCH` |
+| Instance lifetime | `DAYS` (staging-start) |
+| Pull mode | `ENABLE_PULL_MODE` |
+| Server install type | `SERVER_TYPE` (deploy-services only) |
+| FB failure pointed at specific suite | Match setup (e.g. PSMDB failure → `--database psmdb` or `DEPLOY_MONGO_GROUP=true`) |
+
+### pmm3-aws-staging-start — review every param
+
+| Param | Default | When to override |
+|-------|---------|------------------|
+| `DOCKER_VERSION` | `perconalab/pmm-server:3-dev-latest` | Always → FB server image |
+| `WATCHTOWER_VERSION` | `perconalab/watchtower:dev-latest` | Always → FB watchtower image |
+| `CLIENT_VERSION` | `3-dev-latest` | Always → FB client **tarball** URL |
+| `SSH_KEY` | *(empty)* | When SSH access to EC2 is needed |
+| `ADMIN_PASSWORD` | `pmm3admin!` | When test docs use a different password |
+| `PMM_CLIENT_REPO` | `experimental` | `testing` / `release` for RC or release client tests |
+| `ENABLE_PULL_MODE` | `no` | `yes` when testing pull-mode clients |
+| `DAYS` | `1` | `0` to disable auto-stop; higher if long test |
+| `DOCKER_ENV_VARIABLE` | `-e PMM_DEBUG=1 -e PMM_ENABLE_TELEMETRY=0` | **Often wrong by default** — set per ticket |
+| `PXC_VERSION` | `8.4` | When `CLIENTS` uses `pxc` |
+| `PS_VERSION` | `8.0` | When `CLIENTS` uses `ps` |
+| `MS_VERSION` | `8.0` | When `CLIENTS` uses `mysql` |
+| `PGSQL_VERSION` | `16` | When `CLIENTS` uses `pgsql` |
+| `PDPGSQL_VERSION` | `16` | When `CLIENTS` uses `pdpgsql` |
+| `PSMDB_VERSION` | `8.0` | When `CLIENTS` uses `psmdb` |
+| `MODB_VERSION` | `8.0` | When `CLIENTS` uses `modb` |
+| `CLIENTS` | `--database ps=5.7,...` | Empty for server-only; set `--database ...` for local clients |
+| `NOTIFY` | `false` | Usually keep `false` |
+| `CLIENT_INSTANCE` | `no` | `yes` only when this VM is a client node for another server |
+| `SERVER_IP` | `0.0.0.0` | Required when `CLIENT_INSTANCE=yes` |
+| `PMM_QA_GIT_BRANCH` | `main` | Branch with provisioner fixes for the test |
+
+### pmm3-deploy-services — review every param
+
+| Param | Default | When to override |
+|-------|---------|------------------|
+| `SERVER_TYPE` | `docker` | `ovf` / `ami` / `helm` / `ha` when ticket tests those install paths |
+| `DOCKER_VERSION` | `perconalab/pmm-server:3-dev-latest` | Always → FB server image (docker/helm/ha) |
+| `OVA_VERSION` | `PMM3-Server-OVF-3.0.0-latest.ova` | When `SERVER_TYPE=ovf` |
+| `AMI_ID` | `ami-0669b163befffb6c3` | When `SERVER_TYPE=ami` |
+| `CLIENT_VERSION` | `3-dev-latest` | Always → FB client **tarball** URL |
+| `ENABLE_PULL_MODE` | `no` | `yes` for pull-mode client tests |
+| `ADMIN_PASSWORD` | `pmm3admin!` | When test requires specific password |
+| `SSH_KEY` | *(empty)* | When SSH access to client/server VMs is needed |
+| `DEPLOY_EXTERNAL` | `false` | `true` for external node + HAProxy tests |
+| `DEPLOY_MYSQL_GROUP` | `false` | `true` for GR, PXC, async repl, standalone MySQL VMs |
+| `DEPLOY_MONGO_GROUP` | `false` | `true` for sharded + PSS Mongo VMs |
+| `DEPLOY_POSTGRES_GROUP` | `false` | `true` for PG, PDPGSQL, Patroni VMs |
+| `DEPLOY_VALKEY` | `false` | `true` for Valkey tests |
+| `GENERATE_DASHBOARD_SCREENSHOTS` | `false` | `true` only when screenshot generation is the goal |
+| `SCREENSHOTS_SLACK_TARGET` | `@catalina.adam` | When screenshots enabled |
+| `PXC_VERSION` | `8.0` | Match DB versions under test |
+| `PS_VERSION` | `8.4` | |
+| `MS_VERSION` | `8.4` | |
+| `PGSQL_VERSION` | `17` | |
+| `PDPGSQL_VERSION` | `17` | |
+| `PSMDB_VERSION` | `8.0` | |
+| `MODB_VERSION` | `8.0` | |
+| `HELM_CHART_BRANCH` | `pmmha-v3` | When `SERVER_TYPE=ha` |
+| `OPENSHIFT_VERSION` | `latest` | When `SERVER_TYPE=helm` |
+| `K8S_VERSION` | `1.34` | When `SERVER_TYPE=ha` |
+| `WATCHTOWER_VERSION` | `perconalab/watchtower:dev-latest` | Always → FB watchtower image |
+| `PMM_QA_GIT_BRANCH` | `main` | Branch with provisioner fixes |
+
+**Note:** `deploy-services` nested `runStagingServer` uses a fixed `DOCKER_ENV_VARIABLE`. For env-var-heavy tickets, prefer **staging-start** unless multi-VM clients are required.
+
+### `DOCKER_ENV_VARIABLE` — common mistake
+
+Job default (staging-start): `-e PMM_DEBUG=1 -e PMM_ENABLE_TELEMETRY=0` — override when the ticket requires different server config.
+
+Full defaults and CLIENTS syntax: [jenkins-jobs.md](jenkins-jobs.md).
+
+## Step 9: Build complete parambuild URL
+
+**Pre-fill all parameters** from step 8 — every param from the chosen job table that applies.
+
+Base URLs:
+
+- staging-start: `https://pmm.cd.percona.com/job/pmm3-aws-staging-start/parambuild/`
+- deploy-services: `https://pmm.cd.percona.com/job/pmm3-deploy-services/parambuild/`
+
+URL-encode `DOCKER_ENV_VARIABLE` and `CLIENTS`. Full reference: [jenkins-jobs.md](jenkins-jobs.md).
+
+## Step 10: Review PR diffs
+
+Do **not** trust PR "How to test" or Jira QA bullets without verifying code.
+
+1. Read diffs in `percona/pmm` and/or `percona/grafana`
+2. Map changes to concrete UI/API/network steps
+3. Cross-check with FB test failures marked **relevant**
+4. Note post-provision steps (PMM Settings toggles, etc.)
+
+## Step 11: Write test instructions
+
+Post in chat **before** Jira update and browser:
+
+1. Job chosen and why
+2. Params set and why
+3. FB test summary (failures relevant to this ticket)
+4. Provision → configure → exercise → expected result
+5. DevTools / logs / PMM Settings checks
+
+## Step 12: Screenshot FB Tests run → Jira
+
+### When to screenshot
+
+**Attach a screenshot to Jira only when all `gh pr checks` are green** (no `fail` lines).
+
+If any check failed: skip screenshot; text-only update to `customfield_10492`.
+
+If **all passed**: screenshot the **FB Tests** Actions run:
+
+```powershell
+$runId = gh pr checks <SUBMODULES_PR> -R Percona-Lab/pmm-submodules 2>&1 |
+  Select-String -Pattern 'actions/runs/(\d+)' |
+  ForEach-Object { $_.Matches[0].Groups[1].Value } |
+  Select-Object -First 1
+
+playwright-cli open "https://github.com/Percona-Lab/pmm-submodules/actions/runs/$runId"
+playwright-cli resize 1920 1080
+playwright-cli screenshot --filename="fb-test-<TICKET>-checks.png"
+playwright-cli close
+```
+
+Jira fields: `customfield_10492` (FB test screenshots), `customfield_10083` (How to test).
+
+**Ask the user before writing to Jira** unless they explicitly requested the update.
+
+Details: [fb-tests.md](fb-tests.md)
+
+## Step 13: Open browser
+
+```powershell
+Start-Process "<full-parambuild-url>"
+```
+
+## gh CLI quick reference
+
+| Task | Command |
+|------|---------|
+| FB Tests (PR checks) | `gh pr checks <n> -R Percona-Lab/pmm-submodules` |
+| View PR | `gh pr view <n> -R owner/repo` |
+| PR diff | `gh pr diff <n> -R owner/repo` |
+| Search by ticket | `gh search prs "PMM-XXXX" --repo percona/pmm` |
+| PR comments | `gh api repos/OWNER/REPO/issues/<n>/comments` |
+
+## Done criteria
+
+1. Jira read; scope understood
+2. Latest JNKPercona build comment used
+3. FB Tests analyzed; relevant failures reflected in manual plan
+4. Correct job + **complete** parambuild URL
+5. Test instructions posted in chat
+6. Jira `FB test screenshots` updated — screenshot only if all checks passed (when user approves)
+7. Browser opened to parambuild URL
+
+## Additional resources
+
+- [jenkins-jobs.md](jenkins-jobs.md) — all Jenkins parameters
+- [fb-tests.md](fb-tests.md) — FB test sources, flaky guidance, screenshot & Jira templates

--- a/.cursor/skills/pmm-manual-test/fb-tests.md
+++ b/.cursor/skills/pmm-manual-test/fb-tests.md
@@ -1,0 +1,170 @@
+# FB Tests — Analysis & Jira Documentation
+
+FB Tests are the **GitHub PR checks** on `pmm-submodules` (`gh pr checks`). They are **often flaky** — treat failures as signals, not automatic blockers. Cross-check failed suites against the ticket scope before adding them to manual test steps.
+
+**Ignore JNKPercona API test comments** (`API tests have succeded/failed`) — not part of this workflow.
+
+## Source: GitHub PR checks (latest FB build only)
+
+```powershell
+gh pr checks <SUBMODULES_PR> -R Percona-Lab/pmm-submodules
+```
+
+Returns matrix jobs from `pmm-qa-fb-checks.yml` and Jenkins:
+
+| Check pattern | Type |
+|---------------|------|
+| `@* UI tests` | Playwright UI suites in pmm-qa |
+| `CLI tests *` | CLI/integration package tests |
+| `continuous-integration/jenkins/pr-head` | `pmm3-submodules` Jenkins build |
+| `actions/workflows/helm-tests` | Helm tests |
+
+All matrix checks share one **FB Tests** workflow run:
+
+```
+https://github.com/Percona-Lab/pmm-submodules/actions/runs/<run_id>
+```
+
+**Do not use** `https://github.com/Percona-Lab/pmm-submodules/pull/<PR>/checks` — that tab is often empty on `pmm-submodules` PRs. Screenshot the **Actions run** page instead (workflow name: `FB Tests`).
+
+### Get the run URL for the latest FB build
+
+```powershell
+# run_id from any check line in gh pr checks
+gh pr checks <SUBMODULES_PR> -R Percona-Lab/pmm-submodules 2>&1 |
+  Select-String -Pattern 'actions/runs/(\d+)' |
+  ForEach-Object { $_.Matches[0].Groups[1].Value } |
+  Select-Object -First 1 -Unique
+```
+
+Then open: `https://github.com/Percona-Lab/pmm-submodules/actions/runs/<run_id>`
+
+Or via API (latest commit on PR):
+
+```powershell
+$sha = gh api repos/Percona-Lab/pmm-submodules/pulls/<SUBMODULES_PR> --jq .head.sha
+gh api "repos/Percona-Lab/pmm-submodules/commits/$sha/check-runs" `
+  --jq '[.check_runs[] | select(.app.slug=="github-actions")] | .[0].details_url' |
+  ForEach-Object { $_ -replace '/job/.*','' }
+```
+
+Jenkins submodules build is separate: `continuous-integration/jenkins/pr-head` → `pmm3-submodules/PR-XXXX` (not the FB Tests screenshot target).
+
+## Analysis workflow
+
+1. Run `gh pr checks` and list **failed** / **passed** suites
+2. For each failure, note suite name (e.g. `@rta UI tests`, `CLI tests pmm-server container`)
+3. **Filter by ticket relevance:**
+   - In scope → add explicit manual verification to How to test
+   - Out of scope / known flaky → mention as FYI, do not expand manual test scope
+4. Open failed job logs on GitHub Actions only when the failure might be ticket-related
+
+### Flaky test guidance
+
+- UI matrix suites (`@fb-*`, `@rbac`, etc.) fail often on infrastructure timing
+- A failure unrelated to the PR diff (e.g. MySQL integration failing on a telemetry-only ticket) → note flakiness, skip from manual plan
+- Multiple failures in one area related to the change → prioritize in manual test steps
+
+## Screenshot with playwright-cli
+
+Prefer **playwright-cli** over Playwright MCP (simpler for one-off screenshots).
+
+### Screenshot only when all checks pass
+
+```powershell
+gh pr checks <SUBMODULES_PR> -R Percona-Lab/pmm-submodules 2>&1 | Select-String '\tfail\t'
+```
+
+| Result | Action |
+|--------|--------|
+| **No fail lines** | Screenshot + attach to Jira `customfield_10492` |
+| **Any fail** | **No screenshot** — update Jira with text only (run URL, failed suites, relevant/flaky notes) |
+
+Failures still matter for manual test planning (step 6/11); they just do not get a green screenshot in Jira.
+
+**Screenshot the FB Tests Actions run page** when all green — shows the full matrix (UI + CLI checks).
+
+```powershell
+# 1. Resolve run_id (example: 27009345670 for PR-4376)
+$runId = gh pr checks 4376 -R Percona-Lab/pmm-submodules 2>&1 |
+  Select-String -Pattern 'actions/runs/(\d+)' |
+  ForEach-Object { $_.Matches[0].Groups[1].Value } |
+  Select-Object -First 1
+
+# 2. Screenshot the workflow run summary
+playwright-cli open "https://github.com/Percona-Lab/pmm-submodules/actions/runs/$runId"
+playwright-cli resize 1920 1080
+playwright-cli screenshot --filename="fb-test-PMM-14915-checks.png"
+playwright-cli close
+```
+
+Requires GitHub login in the browser session if the repo is private — log in first if the page is blank.
+
+Save screenshots to a temp path the user can find (e.g. workspace root or `%TEMP%`).
+
+**Tips:**
+
+- Resize if needed: `playwright-cli resize 1920 1080` before screenshot
+- For long Jenkins pages: screenshot after scrolling to the failure section using `playwright-cli eval "window.scrollTo(0, document.body.scrollHeight)"` then screenshot
+- Close browser when done: `playwright-cli close`
+
+## Update Jira
+
+### Custom fields
+
+| Field | ID | Use |
+|-------|-----|-----|
+| **FB test screenshots** | `customfield_10492` | FB test analysis summary + screenshot reference |
+| **How to test** | `customfield_10083` | Manual test steps (adapt using FB failures + PR diff) |
+
+### Update with Atlassian MCP
+
+**All checks passed** — attach screenshot and update fields in one call:
+
+
+```json
+jira_update_issue(
+  issue_key: "PMM-14915",
+  fields: "{\"customfield_10492\": \"## FB Tests — PR-4376 (all green)\\n\\n**Run:** https://github.com/Percona-Lab/pmm-submodules/actions/runs/27009345670\\n\\n!fb-test-PMM-14915-checks.png|width=900!\"}",
+  attachments: "/path/to/fb-test-PMM-14915-checks.png"
+)
+```
+
+After attachment upload, Jira may render images inline: `!fb-test-PMM-14915-checks.png|width=900!`
+
+**Any check failed** — text only, no attachment:
+
+```json
+jira_update_issue(
+  issue_key: "PMM-14915",
+  fields: "{\"customfield_10492\": \"## FB Tests — PR-4376 (failures — no screenshot)\\n\\n**Run:** https://github.com/Percona-Lab/pmm-submodules/actions/runs/27009345670\\n\\n**Failed:** @rta UI tests, @pmm-ps-integration UI tests, CLI tests pmm-server container\\n\\n**Relevant to ticket:** none (flaky / out of scope)\\n\\n_Screenshot pending — waiting for all-green FB build._\"}"
+)
+```
+
+Update **How to test** separately when manual steps are finalized:
+
+```json
+jira_update_issue(
+  issue_key: "PMM-14915",
+  fields: "{\"customfield_10083\": \"1. Provision FB staging (link in comment)...\\n2. DevTools: no /v1/ui-events/Store calls...\"}"
+)
+```
+
+**Ask the user before writing to Jira** if they did not explicitly request the update in this session.
+
+### FB test screenshots field template
+
+```markdown
+## FB Tests — PR-<submodules_pr>
+
+**FB Tests run:** https://github.com/Percona-Lab/pmm-submodules/actions/runs/<run_id>
+
+### Failures (latest)
+- `@suite` — [relevant|flaky|out of scope]: <one-line reason>
+
+### Passed (ticket-relevant)
+- list suites that cover the change area
+
+### Screenshot
+!fb-test-<TICKET>-checks.png|width=900!
+```

--- a/.cursor/skills/pmm-manual-test/jenkins-jobs.md
+++ b/.cursor/skills/pmm-manual-test/jenkins-jobs.md
@@ -1,0 +1,146 @@
+# PMM Jenkins Jobs — Full Parameter Reference
+
+Source of truth: `$ReposRoot/jenkins-pipelines/pmm/v3/pmm3-aws-staging-start.groovy` and `pmm3-deploy-services.groovy`.
+
+**Goal for manual tests:** build a **complete** `parambuild` URL with every relevant param pre-filled so the user only clicks **Build**. Do not stop at `DOCKER_VERSION` + `CLIENT_VERSION` alone when other params matter for the ticket.
+
+URL format: `https://pmm.cd.percona.com/job/<job-name>/parambuild/?PARAM=value&PARAM2=value2`
+
+- URL-encode values (` ` → `%20`, `:` in env vars → `%3A`, `=` → `%3D`, `&` inside values → `%26`)
+- `text` params (`CLIENTS`, `DOCKER_ENV_VARIABLE`) may need encoding
+- Omit params only when the Jenkins default is correct for the test
+
+---
+
+## pmm3-aws-staging-start
+
+**Purpose:** Single EC2 instance — PMM server docker + optional **local** clients on the same VM via `pmm-framework.py`.
+
+**Activity:** https://pmm.cd.percona.com/blue/organizations/jenkins/pmm3-aws-staging-start/activity
+
+### All parameters
+
+| Param | Type | Default | Notes |
+|-------|------|---------|-------|
+| `DOCKER_VERSION` | string | `perconalab/pmm-server:3-dev-latest` | FB: `perconalab/pmm-server-fb:PR-XXXX-<sha>` |
+| `WATCHTOWER_VERSION` | string | `perconalab/watchtower:dev-latest` | FB: `perconalab/pmm-watchtower-fb:PR-XXXX-<sha>` from JNKPercona comment |
+| `CLIENT_VERSION` | string | `3-dev-latest` | FB: **tarball URL** only — never client docker image |
+| `SSH_KEY` | string | *(empty)* | OpenSSH public key for `ec2-user` SSH access |
+| `ADMIN_PASSWORD` | string | `pmm3admin!` | Grafana/PMM admin password |
+| `PMM_CLIENT_REPO` | choice | `experimental` | `experimental` \| `testing` \| `release` |
+| `ENABLE_PULL_MODE` | choice | `no` | `no` \| `yes` |
+| `DAYS` | choice | `1` | Auto-stop VM after N days; `0` = never |
+| `DOCKER_ENV_VARIABLE` | text | `-e PMM_DEBUG=1 -e PMM_ENABLE_TELEMETRY=0` | Space-separated `-e KEY=VAL` passed to server container |
+| `PXC_VERSION` | choice | `8.4` | `8.4` \| `8.0` \| `5.7` |
+| `PS_VERSION` | choice | `8.0` | `8.0` \| `8.4` \| `5.7` \| `5.7.30` \| `5.6` |
+| `MS_VERSION` | choice | `8.0` | `8.0` \| `8.4` \| `5.7` \| `5.6` |
+| `PGSQL_VERSION` | choice | `16` | `16` \| `17` \| `18` \| `15` \| `14` \| `13` |
+| `PDPGSQL_VERSION` | choice | `16` | `16` \| `17` \| `18` \| `15` \| `14` \| `13` |
+| `PSMDB_VERSION` | choice | `8.0` | `8.0` \| `7.0` \| `6.0` \| `5.0` \| `4.4` |
+| `MODB_VERSION` | choice | `8.0` | `8.0` \| `7.0` \| `6.0` \| `5.0` \| `4.4` |
+| `CLIENTS` | text | `--database ps=5.7,QUERY_SOURCE=perfschema` | Flags for `pmm-framework.py`; empty = server only |
+| `NOTIFY` | choice | `false` | Slack notifications |
+| `CLIENT_INSTANCE` | choice | `no` | `yes` = this VM is client-only (needs `SERVER_IP`) |
+| `SERVER_IP` | string | `0.0.0.0` | PMM server IP when `CLIENT_INSTANCE=yes` |
+| `PMM_QA_GIT_BRANCH` | string | `main` | Branch cloned for `pmm-framework.py` provisioning |
+
+### Local clients via `CLIENTS` / `pmm-framework.py`
+
+Provisioner script in this repo: `qa-integration/pmm_qa/pmm-framework.py`.
+
+When the test needs **one or a few databases on the same VM**, use **staging-start** with `CLIENTS` instead of **deploy-services**.
+
+**Limitations** (prefer **deploy-services** when any apply):
+
+- Single VM — no separate client hosts, no multi-VM topologies
+- Heavy/complex setups unreliable on one `t3.xlarge`
+- `deploy-services` spawns dedicated client VMs via nested `staging-start` with `CLIENT_INSTANCE=yes`
+
+**CLIENTS examples:**
+
+```
+--database ps=5.7,QUERY_SOURCE=perfschema
+--database psmdb,SETUP_TYPE=pss
+--database pgsql=16
+```
+
+Leave `CLIENTS` empty for **server-only** tests (UI, API, settings).
+
+### Common `DOCKER_ENV_VARIABLE` values
+
+Read `$ReposRoot/pmm/managed/CONTRIBUTING.md` and `$ReposRoot/pmm/documentation/docs/install-pmm/install-pmm-server/deployment-options/docker/env_var.md` when PR/ticket touches server config.
+
+| Variable | Typical test use |
+|----------|------------------|
+| `PMM_DEBUG=1` | Verbose logs (default in job) |
+| `PMM_ENABLE_TELEMETRY=0\|1` | Job default is `0`; set `1` when ticket tests server telemetry |
+| `PMM_DEV_TELEMETRY_DISABLE_START_DELAY=1` | Run telemetry immediately |
+| `PMM_DEV_TELEMETRY_DISABLE_SEND=1` | Gather telemetry but don't send to SaaS |
+| `PMM_DEV_TELEMETRY_INTERVAL=30s` | Short interval for telemetry debugging |
+
+**Important:** job default sets `PMM_ENABLE_TELEMETRY=0`. Override when the ticket requires telemetry enabled.
+
+---
+
+## pmm3-deploy-services
+
+**Purpose:** Orchestrator — provisions PMM server + **separate client VMs**.
+
+**Activity:** https://pmm.cd.percona.com/blue/organizations/jenkins/pmm3-deploy-services/activity
+
+### All parameters
+
+| Param | Type | Default | Notes |
+|-------|------|---------|-------|
+| `SERVER_TYPE` | choice | `docker` | `docker` \| `ovf` \| `ami` \| `helm` \| `ha` |
+| `DOCKER_VERSION` | string | `perconalab/pmm-server:3-dev-latest` | Used for docker/helm/ha server types |
+| `OVA_VERSION` | string | `PMM3-Server-OVF-3.0.0-latest.ova` | OVF only |
+| `AMI_ID` | string | `ami-0669b163befffb6c3` | AMI only |
+| `CLIENT_VERSION` | string | `3-dev-latest` | Tarball URL for client VMs |
+| `ENABLE_PULL_MODE` | choice | `no` | `no` \| `yes` |
+| `ADMIN_PASSWORD` | string | `pmm3admin!` | Applied after provisioning |
+| `SSH_KEY` | string | *(empty)* | SSH key for AWS instances |
+| `DEPLOY_EXTERNAL` | boolean | `false` | External node + HAProxy VM |
+| `DEPLOY_MYSQL_GROUP` | boolean | `false` | GR, PXC, async repl, standalone VMs |
+| `DEPLOY_MONGO_GROUP` | boolean | `false` | Sharded + PSS replica set VMs |
+| `DEPLOY_POSTGRES_GROUP` | boolean | `false` | PG, PDPGSQL, Patroni VMs |
+| `DEPLOY_VALKEY` | boolean | `false` | Valkey VM |
+| `GENERATE_DASHBOARD_SCREENSHOTS` | boolean | `false` | Skip 24h hold; run Playwright screenshots |
+| `SCREENSHOTS_SLACK_TARGET` | string | `@catalina.adam` | Slack target for screenshots |
+| `PXC_VERSION` | choice | `8.0` | Passed to nested client jobs |
+| `PS_VERSION` | choice | `8.4` | |
+| `MS_VERSION` | choice | `8.4` | |
+| `PGSQL_VERSION` | choice | `17` | |
+| `PDPGSQL_VERSION` | choice | `17` | |
+| `PSMDB_VERSION` | choice | `8.0` | |
+| `MODB_VERSION` | choice | `8.0` | |
+| `HELM_CHART_BRANCH` | string | `pmmha-v3` | HA only |
+| `OPENSHIFT_VERSION` | choice | `latest` | Helm only |
+| `K8S_VERSION` | choice | `1.34` | HA only |
+| `WATCHTOWER_VERSION` | string | `perconalab/watchtower:dev-latest` | Passed to nested staging-start |
+| `PMM_QA_GIT_BRANCH` | string | `main` | Provisioner scripts branch |
+
+### Client groups when flags are `true`
+
+| Flag | CLIENTS provisioned |
+|------|---------------------|
+| `DEPLOY_EXTERNAL` | `--database external --database haproxy` |
+| `DEPLOY_MYSQL_GROUP` | GR+mysql, repl+pxc, ps-single+psmdb-pss, pxc-extra |
+| `DEPLOY_POSTGRES_GROUP` | pdpgsql, pgsql, patroni |
+| `DEPLOY_MONGO_GROUP` | psmdb sharding, valkey+psmdb inmemory |
+| `DEPLOY_VALKEY` | valkey |
+
+---
+
+## Job selection
+
+| Scenario | Job |
+|----------|-----|
+| Server/UI/API only; optional 1-VM local DB via `CLIENTS` | **pmm3-aws-staging-start** |
+| Multi-VM client topologies, external nodes, full DB matrix | **pmm3-deploy-services** |
+
+---
+
+## JNKPercona build comment
+
+Use the **latest** JNKPercona comment containing `Staging instance:`. `pmm-submodules` PR number often differs from `percona/pmm` PR number.


### PR DESCRIPTION
## Summary

- Add shared Cursor Agent skill at \.cursor/skills/pmm-manual-test/\ for PMM manual QA workflow
- Covers Jira ticket intake, pmm-submodules FB artifacts, FB Tests (\gh pr checks\) analysis, full Jenkins parambuild URLs, and playwright-cli screenshots for Jira
- Uses sibling-repo layout under a common repos root with clone-if-missing for pmm, grafana, and jenkins-pipelines

## Jira

https://perconadev.atlassian.net/browse/PMM-15135