### PR TITLE
PMM-15127: Post-release Playwright tests

### DIFF
--- a/e2e_tests/fixtures/pmmTest.ts
+++ b/e2e_tests/fixtures/pmmTest.ts
@@ -20,6 +20,8 @@ import MongoDBHelper from '@helpers/mongodb.helper';
 import VacuumDashboard from '@pages/dashboards/postgresql/vacuumDashboard';
 import apiEndpoints from '@helpers/apiEndpoints';
 import SettingsPage from '@pages/ha/settings.page';
+import UpdatesPage from '@pages/updates.page';
+import DownloadsPage from '@pages/downloads.page';
 
 const pmmTest = base.extend<{
   settingsPage: SettingsPage;
@@ -42,6 +44,8 @@ const pmmTest = base.extend<{
   nodesPage: NodesPage;
   realTimeAnalyticsPage: RealTimeAnalyticsPage;
   vacuumDashboardPage: VacuumDashboard;
+  updatesPage: UpdatesPage;
+  downloadsPage: DownloadsPage;
 }>({
   agentsPage: async ({ page }, use) => await use(new AgentsPage(page)),
   api: async ({ page, request }, use) => {
@@ -91,6 +95,7 @@ const pmmTest = base.extend<{
 
     await use(dashboardPage);
   },
+  downloadsPage: async ({ page }, use) => await use(new DownloadsPage(page)),
   grafanaHelper: async ({ page }, use) => {
     const grafanaHelper = new GrafanaHelper(page);
 
@@ -141,6 +146,7 @@ const pmmTest = base.extend<{
 
     await use(tour);
   },
+  updatesPage: async ({ page }, use) => await use(new UpdatesPage(page)),
   urlHelper: async ({}, use) => {
     const urlHelper = new UrlHelper();
 

--- a/e2e_tests/pages/downloads.page.ts
+++ b/e2e_tests/pages/downloads.page.ts
@@ -1,0 +1,52 @@
+import { Locator } from '@playwright/test';
+import BasePage from '@pages/base.page';
+import pmmTest from '@fixtures/pmmTest';
+import { Timeouts } from '@helpers/timeouts';
+
+/**
+ * Page object for the public Percona downloads website.
+ * Selectors are intentionally text/role based since this is an external site
+ * whose markup is not controlled by the PMM team and may change over time.
+ */
+export default class DownloadsPage extends BasePage {
+  url = 'https://www.percona.com/downloads';
+  builders = {};
+  buttons = {
+    pmmProduct: this.page.getByRole('link', { name: 'Percona Monitoring and Management' }),
+  };
+  elements = {
+    osPackages: this.page.locator('a[href$=".rpm"], a[href$=".deb"], a[href$=".tar.gz"]'),
+    versionSelect: this.page.locator('select').first(),
+  };
+  inputs = {};
+  messages = {};
+
+  getAvailablePackages = async (): Promise<string[]> =>
+    await pmmTest.step('Read available OS packages', async () => {
+      const hrefs = await this.elements.osPackages.evaluateAll((nodes) =>
+        nodes.map((node) => (node as HTMLAnchorElement).href),
+      );
+
+      return hrefs.filter(Boolean);
+    });
+
+  getAvailableVersions = async (): Promise<string[]> =>
+    await pmmTest.step('Read available versions', async () => {
+      const options = this.elements.versionSelect.locator('option');
+
+      return (await options.allInnerTexts()).map((text) => text.trim()).filter(Boolean);
+    });
+
+  open = async (): Promise<void> =>
+    await pmmTest.step('Open Percona downloads page', async () => {
+      await this.page.goto(this.url);
+    });
+
+  selectPmmProduct = async (): Promise<void> =>
+    await pmmTest.step('Select PMM product', async () => {
+      await this.buttons.pmmProduct.first().click({ timeout: Timeouts.THIRTY_SECONDS });
+      await this.page.waitForLoadState();
+    });
+
+  versionLocator = (version: string): Locator => this.page.getByText(version, { exact: false }).first();
+}

--- a/e2e_tests/pages/updates.page.ts
+++ b/e2e_tests/pages/updates.page.ts
@@ -1,0 +1,47 @@
+import { Page, Locator } from '@playwright/test';
+import BasePage from '@pages/base.page';
+import pmmTest from '@fixtures/pmmTest';
+import GrafanaHelper from '@helpers/grafana.helper';
+
+export interface UpdateInfo {
+  installed?: { full_version?: string; version?: string };
+  latest?: { release_notes_text?: string; release_notes_url?: string; tag?: string; version?: string };
+  latest_news_url?: string;
+  update_available: boolean;
+}
+
+export default class UpdatesPage extends BasePage {
+  url = '/pmm-ui/updates';
+  builders = {};
+  buttons = {
+    whatsNew: this.page.getByTestId('update-news-link'),
+  };
+  elements = {
+    availableSection: this.page.getByTestId('update-latest-section'),
+    availableVersion: this.page.getByTestId('update-latest-version'),
+  };
+  inputs = {};
+  messages = {};
+
+  clickWhatsNew = async (button: Locator): Promise<{ href: string | null; newTab: Page }> =>
+    await pmmTest.step("Click What's new link", async () => {
+      const href = await button.getAttribute('href');
+      const [newTab] = await Promise.all([this.page.waitForEvent('popup'), button.click()]);
+
+      return { href, newTab };
+    });
+
+  getUpdateInfo = async (): Promise<UpdateInfo> =>
+    await pmmTest.step('Fetch update info from version service', async () => {
+      const response = await this.page.request.get('v1/server/updates?force=true', {
+        headers: GrafanaHelper.getAuthHeader(),
+      });
+
+      return (await response.json()) as UpdateInfo;
+    });
+
+  open = async (): Promise<void> =>
+    await pmmTest.step('Open Updates page', async () => {
+      await this.page.goto(this.url);
+    });
+}

--- a/e2e_tests/tests/postRelease.test.ts
+++ b/e2e_tests/tests/postRelease.test.ts
@@ -1,0 +1,70 @@
+import pmmTest from '@fixtures/pmmTest';
+import { expect } from '@playwright/test';
+import { Timeouts } from '@helpers/timeouts';
+
+const expectedVersion = process.env.PMM_SERVER_LATEST?.trim() as string;
+
+pmmTest(
+  'PMM-T2200 - Verify new release is available for upgrade @post-release',
+  async ({ grafanaHelper, updatesPage }) => {
+    await grafanaHelper.authorize();
+
+    const updateInfo = await pmmTest.step('Check version service reports an update', async () => {
+      const info = await updatesPage.getUpdateInfo();
+
+      expect(info.update_available, 'A new release should be available for upgrade').toBe(true);
+
+      return info;
+    });
+
+    expect(updateInfo.latest?.version, 'Available version should match the released version').toContain(
+      expectedVersion,
+    );
+
+    await pmmTest.step('Verify available version is displayed on the Updates page', async () => {
+      await updatesPage.open();
+      await expect(updatesPage.elements.availableSection).toBeVisible({ timeout: Timeouts.THIRTY_SECONDS });
+      await expect(updatesPage.elements.availableVersion).toContainText(expectedVersion);
+    });
+  },
+);
+
+pmmTest(
+  "PMM-T2201 - Verify What's new link and release notes @post-release",
+  async ({ grafanaHelper, updatesPage }) => {
+    await grafanaHelper.authorize();
+    await updatesPage.open();
+
+    await pmmTest.step("Verify What's new link is displayed", async () => {
+      await expect(updatesPage.buttons.whatsNew).toBeVisible({ timeout: Timeouts.THIRTY_SECONDS });
+    });
+
+    await pmmTest.step('Open release notes and verify the released version', async () => {
+      const { href, newTab } = await updatesPage.clickWhatsNew(updatesPage.buttons.whatsNew);
+
+      expect(href, "What's new link should have an href").toBeTruthy();
+      await newTab.waitForLoadState();
+      expect(newTab.url(), 'Release notes should open an external page').toMatch(/per\.co\.na|percona\.com/);
+    });
+  },
+);
+
+pmmTest(
+  'PMM-T2202 - Verify PMM new version on percona.com/downloads @post-release @downloads',
+  async ({ downloadsPage }) => {
+    await downloadsPage.open();
+    await downloadsPage.selectPmmProduct();
+
+    await pmmTest.step('Verify the new version is displayed', async () => {
+      await expect(downloadsPage.versionLocator(expectedVersion)).toBeVisible({
+        timeout: Timeouts.THIRTY_SECONDS,
+      });
+    });
+
+    await pmmTest.step('Verify the list of available OSes with packages is not empty', async () => {
+      const packages = await downloadsPage.getAvailablePackages();
+
+      expect(packages.length, 'There should be downloadable OS packages for PMM').toBeGreaterThan(0);
+    });
+  },
+);


### PR DESCRIPTION
## Summary
- Add \@post-release\ Playwright suite for PMM-15127.
- Verifies update availability and What's new release notes on the old server.
- Verifies the new GA version and OS packages on percona.com/downloads.
- \PMM_SERVER_LATEST\ is set by the Jenkins pipeline from auto-detected versions.