### PR TITLE
PMM-7: Fix PMM-15054 ClickHouse log table CLI test

### DIFF
--- a/cli/tests/pmm-server-only.spec.ts
+++ b/cli/tests/pmm-server-only.spec.ts
@@ -9,6 +9,28 @@ const DOCKER_IMAGE = process.env.DOCKER_VERSION && process.env.DOCKER_VERSION.le
 const stopList: string[] = [];
 const removeList: string[] = [];
 
+/** Kept after PMM-15054 ClickHouse log optimization (percona/pmm#5423). */
+const CLICKHOUSE_CORE_LOG_TABLES = [
+  'crash_log',
+  'part_log',
+  'query_log',
+  'query_thread_log',
+  'query_views_log',
+];
+
+/** Present on servers built before PMM-15054; dropped once optimization is applied. */
+const CLICKHOUSE_PRE_OPTIMIZATION_EXTRA_LOG_TABLES = ['trace_log'];
+
+const CLICKHOUSE_REMOVED_LOG_TABLES = [
+  'asynchronous_insert_log',
+  'asynchronous_metric_log',
+  'metric_log',
+  'opentelemetry_span_log',
+  'processors_profile_log',
+  'text_log',
+  ...CLICKHOUSE_PRE_OPTIMIZATION_EXTRA_LOG_TABLES,
+];
+
 test.describe(
   'PMM Server CLI tests for Docker Environment Variables',
   { tag: '@server-only' },
@@ -245,13 +267,29 @@ test.describe(
 
       await expect(async () => {
         const output = await cli.exec(
-          `docker exec pmm-server clickhouse client --password=clickhouse -q "SELECT COUNT(*) FROM system.tables WHERE database='system' AND name LIKE '%log%';"`,
+          `docker exec pmm-server clickhouse client --password=clickhouse -q "SELECT name FROM system.tables WHERE database='system' AND name LIKE '%log%' ORDER BY name"`,
         );
         await output.assertSuccess();
+        const tables = output.stdout.trim().split('\n').filter(Boolean);
+        const hasOptimization = !tables.some((table) =>
+          CLICKHOUSE_PRE_OPTIMIZATION_EXTRA_LOG_TABLES.includes(table),
+        );
+        const expected = hasOptimization
+          ? CLICKHOUSE_CORE_LOG_TABLES
+          : [...CLICKHOUSE_CORE_LOG_TABLES, ...CLICKHOUSE_PRE_OPTIMIZATION_EXTRA_LOG_TABLES];
+
         expect(
-          output.stdout.trim(),
-          'Verify ClickHouse "system" database has exactly 5 "*log*" tables',
-        ).toEqual('5');
+          tables,
+          hasOptimization
+            ? 'PMM-15054 ClickHouse log optimization is active'
+            : 'Pre-PMM-15054 server still exposes trace_log',
+        ).toEqual(expected);
+
+        if (hasOptimization) {
+          for (const removed of CLICKHOUSE_REMOVED_LOG_TABLES) {
+            expect(tables, `unexpected system log table ${removed}`).not.toContain(removed);
+          }
+        }
       }).toPass({
         intervals: [2_000, 2_000, 2_000],
         timeout: 30_000,


### PR DESCRIPTION
## Summary

- The \@server-only\ PMM-15054 test hardcoded an exact count of five ClickHouse \system.*log*\ tables, which only holds after percona/pmm#5423 (ClickHouse log optimization).
- FB branches built without that server change (e.g. PMM-14915 / pmm-submodules#4376) still expose \	race_log\, so the suite reports six tables and \CLI tests pmm-server container\ fails.
- Detect optimization by table names: five core tables when \	race_log\ is absent; six (core + \	race_log\) on older server images. Optimized servers also assert removed log tables stay absent.

## Context

- Failing check: \CLI tests pmm-server container\ on https://github.com/Percona-Lab/pmm-submodules/actions/runs/27009345670
- Passing reference: same suite on pmm-submodules#4375 (server includes PMM-15054)