### PR TITLE
PMM-7: Fix psmdb-sharded setup for remote PMM Server

### DIFF
--- a/qa-integration/pmm_psmdb-pbm_setup/start-sharded.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/start-sharded.sh
@@ -16,8 +16,11 @@ docker compose -f docker-compose-sharded.yaml down -v --remove-orphans
 docker compose -f docker-compose-sharded.yaml build
 docker compose -f docker-compose-sharded.yaml up -d
 
-echo "waiting for pmm-server to start"
-timeout 120 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" --user "admin:${ADMIN_PASSWORD:-password}" https://127.0.0.1/v1/server/readyz)" = "200" ]; do sleep 5; done'
+pmm_server_host=${PMM_SERVER_CONTAINER_ADDRESS:-127.0.0.1:443}
+pmm_server_admin_pass=${ADMIN_PASSWORD:-password}
+
+echo "waiting for pmm-server to start at ${pmm_server_host}"
+timeout 120 bash -c 'until [ "$(curl -ks -o /dev/null -w "%{http_code}" --user "admin:'"$pmm_server_admin_pass"'" https://'"${pmm_server_host}"'/v1/server/readyz)" = "200" ]; do sleep 5; done'
 
 echo
 echo "waiting 60 seconds for replica set members to start"


### PR DESCRIPTION
## Summary
- Use `PMM_SERVER_CONTAINER_ADDRESS` in `start-sharded.sh` readyz polling instead of hardcoded `127.0.0.1`.
- Fixes nightly GHA `setup / psmdb-sharded` jobs that already receive the remote PMM URL from Jenkins but timed out waiting for a local server.
