### PR TITLE
PMM-15127: Fix post-release What's new test for home page link

### DIFF
--- a/e2e_tests/pages/updates.page.ts
+++ b/e2e_tests/pages/updates.page.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from '@playwright/test';
+import { expect, Locator, Page } from '@playwright/test';
 import BasePage from '@pages/base.page';
 import pmmTest from '@fixtures/pmmTest';
 import GrafanaHelper from '@helpers/grafana.helper';
@@ -16,15 +16,13 @@ export default class UpdatesPage extends BasePage {
   homeUrl = '/pmm-ui/graph/';
   builders = {};
   buttons = {
-    goToUpdates: this.page.getByTestId('update-modal-go-to-updates-button'),
-    releaseNotes: this.page.getByTestId('update-modal-release-notes-link'),
     updateNow: this.page.getByRole('button', { name: 'Update now' }),
+    whatsNew: this.grafanaIframe().getByRole('link', { name: "What's new" }),
   };
   elements = {
     availableSection: this.page.getByRole('heading', { name: /New update available/i }),
     newVersionLine: this.page.locator('p').filter({ hasText: 'New version:' }),
     pageTitle: this.page.getByRole('heading', { exact: true, name: 'Updates' }),
-    updateModalTitle: this.page.getByTestId('modal-title'),
   };
   inputs = {};
   messages = {};
@@ -52,9 +50,9 @@ export default class UpdatesPage extends BasePage {
       await this.elements.pageTitle.waitFor({ state: 'visible' });
     });
 
-  openHomeForUpdateModal = async (): Promise<void> =>
-    await pmmTest.step('Open home page to show update modal', async () => {
+  openHomeForWhatsNew = async (): Promise<void> =>
+    await pmmTest.step('Open home page', async () => {
       await this.page.goto(this.homeUrl);
-      await this.buttons.releaseNotes.waitFor({ state: 'visible', timeout: Timeouts.THIRTY_SECONDS });
+      await expect(this.buttons.whatsNew).toBeVisible({ timeout: Timeouts.THIRTY_SECONDS });
     });
 }

--- a/e2e_tests/tests/postRelease.test.ts
+++ b/e2e_tests/tests/postRelease.test.ts
@@ -3,7 +3,11 @@ import { expect } from '@playwright/test';
 import apiEndpoints from '@helpers/apiEndpoints';
 import { Timeouts } from '@helpers/timeouts';
 
-const expectedVersion = process.env.PMM_SERVER_LATEST?.trim() as string;
+if (!process.env.PMM_SERVER_LATEST?.trim()) {
+  throw new Error('PMM_SERVER_LATEST env var is required for @post-release tests');
+}
+
+const expectedVersion = process.env.PMM_SERVER_LATEST.trim();
 
 pmmTest.beforeEach(async ({ context, page }) => {
   await page.unroute(apiEndpoints.server.updates);
@@ -42,29 +46,21 @@ pmmTest(
   "PMM-T2201 - Verify What's new link and release notes @post-release",
   async ({ grafanaHelper, updatesPage }) => {
     await grafanaHelper.authorize();
-    await updatesPage.openHomeForUpdateModal();
+    await updatesPage.openHomeForWhatsNew();
 
-    await pmmTest.step('Verify Release Notes link is displayed in the update modal', async () => {
-      await expect(updatesPage.elements.updateModalTitle).toContainText(expectedVersion);
-      await expect(updatesPage.buttons.releaseNotes).toBeVisible({ timeout: Timeouts.THIRTY_SECONDS });
-      await expect(updatesPage.buttons.releaseNotes).toHaveAttribute(
+    await pmmTest.step("Verify What's new link on home page", async () => {
+      await expect(updatesPage.buttons.whatsNew).toBeVisible({ timeout: Timeouts.THIRTY_SECONDS });
+      await expect(updatesPage.buttons.whatsNew).toHaveAttribute(
         'href',
         new RegExp(`per\\.co\\.na/pmm/${expectedVersion.replaceAll('.', '\\.')}`),
       );
     });
 
     await pmmTest.step('Open release notes and verify the released version', async () => {
-      const { href, newTab } = await updatesPage.clickReleaseNotes(updatesPage.buttons.releaseNotes);
+      const { newTab } = await updatesPage.clickReleaseNotes(updatesPage.buttons.whatsNew);
 
-      expect(href, 'Release Notes link should point to the GA release notes URL').toMatch(
-        new RegExp(`per\\.co\\.na/pmm/${expectedVersion.replaceAll('.', '\\.')}`),
-      );
-      await newTab.waitForLoadState();
-      expect(newTab.url(), 'Release notes should open Percona documentation').toMatch(
-        /per\.co\.na|percona\.com|docs\.percona\.com/,
-      );
-      expect(newTab.url(), 'Release notes page should reference the released version').toContain(
-        expectedVersion,
+      await expect(newTab).toHaveURL(
+        `https://docs.percona.com/percona-monitoring-and-management/3/release-notes/${expectedVersion}.html`,
       );
     });
   },


### PR DESCRIPTION
## Summary
- T2201 uses the home page ''What's new'' link inside the Grafana iframe instead of the update modal.
- Asserts the per.co.na href and the docs.percona.com release notes URL for PMM_SERVER_LATEST.
- Fail fast when PMM_SERVER_LATEST is not set (avoids replaceAll on undefined).

## Test plan
- [ ] Run post-release tests with PMM_SERVER_LATEST set against a PMM server with an available update
