### PR TITLE
Skip compatibility CLI matrix for patch release candidates

### DIFF
--- a/.github/workflows/rc-testing-suite.yml
+++ b/.github/workflows/rc-testing-suite.yml
@@ -35,6 +35,11 @@ on:
         required: false
         default: '17'
         type: string
+      skip_compatibility:
+        description: 'Skip backward-compatibility CLI matrix (patch RCs)'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   get_compat_versions:
@@ -83,6 +88,7 @@ jobs:
       pmm_client_version: pmm3-rc
 
   compatibility_integration_tests:
+    if: ${{ !inputs.skip_compatibility }}
     name: Compatibility CLI (${{ matrix.version }})
     needs: plan
     strategy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ To find the entry workflow for a suite, search `runner-<suite>*.yml` in [.github
 
 Full Release-Candidate testing is **not** driven from this repo. The orchestrator is the Jenkins pipeline [`Percona-Lab/jenkins-pipelines` › `pmm/v3/pmm3-rc-testing.groovy`](https://github.com/Percona-Lab/jenkins-pipelines/blob/master/pmm/v3/pmm3-rc-testing.groovy). For a given `RC_VERSION` it runs three parallel lanes:
 
-- **Lane 1**: `pmm3-ui-tests-nightly` against the AMI plus the last 5 GA `percona/pmm-client` tags (backward-compatibility).
-- **Lane 2**: `pmm3-ui-tests-nightly` for OVF / Docker / Helm / HA, `pmm3-ui-tests-nightly-gssapi`, `openshift-helm-tests`.
+- **Lane 1**: `pmm3-ui-tests-nightly-gha` against the AMI plus the last 5 GA `percona/pmm-client` tags (backward-compatibility; compat lanes skipped on patch RCs).
+- **Lane 2**: `pmm3-ui-tests-nightly-gha` for OVF / Docker / Helm / HA, `pmm3-ui-tests-nightly-gssapi`, `openshift-helm-tests`.
 - **Lane 3**: `pmm3-migration-tests`, `pmm3-ui-tests-matrix`, `pmm3-upgrade-ami-test`, `pmm3-package-testing-matrix` (amd64 + arm64), `pmm3-upgrade-tests-matrix`, and a GitHub-API dispatch of [`rc-testing-suite.yml`](.github/workflows/rc-testing-suite.yml).
+
+**Patch RCs** (`x.y.z` where only `z` changes vs the latest GA): Lane 1 compat nightly stages and the `compatibility_integration_tests` job in `rc-testing-suite.yml` are skipped (`skip_compatibility=true`). Minor/major RCs keep full compatibility coverage.


### PR DESCRIPTION
This pull request updates the release candidate (RC) testing workflow to allow skipping backward-compatibility tests for patch RCs, and documents this behavior. The main goal is to optimize CI resources by not running compatibility tests when only patch versions are released, while still ensuring full coverage for minor and major releases.

Key changes:

**Workflow configuration:**

* Added a new boolean input `skip_compatibility` to the `.github/workflows/rc-testing-suite.yml` workflow, allowing callers to control whether backward-compatibility CLI tests are run.
* Updated the `compatibility_integration_tests` job in the same workflow to only run if `skip_compatibility` is false, effectively skipping these tests when requested.

**Documentation updates:**

* Updated `AGENTS.md` to clarify that for patch RCs, backward-compatibility tests (both in Jenkins Lane 1 and the GitHub Actions workflow) are skipped by setting `skip_compatibility=true`, while minor and major RCs retain full compatibility coverage. Also updated the job names to reflect the use of GitHub Actions.