### PR TITLE
docs: add Cursor Cloud test-tooling setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,15 @@ Full Release-Candidate testing is **not** driven from this repo. The orchestrato
 - **Lane 3**: `pmm3-migration-tests`, `pmm3-ui-tests-matrix`, `pmm3-upgrade-ami-test`, `pmm3-package-testing-matrix` (amd64 + arm64), `pmm3-upgrade-tests-matrix`, and a GitHub-API dispatch of [`rc-testing-suite.yml`](.github/workflows/rc-testing-suite.yml).
 
 **Patch RCs** (`x.y.z` where only `z` changes vs the latest GA): Lane 1 compat nightly stages and the `compatibility_integration_tests` job in `rc-testing-suite.yml` are skipped (`skip_compatibility=true`). Minor/major RCs keep full compatibility coverage.
+
+## Cursor Cloud specific instructions
+
+The VM snapshot has the per-suite test tooling preinstalled and the startup update script keeps it fresh: `npm ci` for `e2e_tests`, `cli`, and `codeceptjs-e2e`; Playwright Chromium for the two UI suites (`e2e_tests` uses PW ~1.56, `codeceptjs-e2e` pins PW 1.45 — each ships its own Chromium build under `~/.cache/ms-playwright`); and a Python venv at `qa-integration/pmm_qa/virtenv` with `requirements.txt`. Node 22 and `gh` are on the host. System notes: `python3-venv` and the Playwright OS libraries (`npx playwright install-deps`) are baked into the snapshot; `@playwright/cli` was not needed for any suite here (the suites use each dir's local `playwright`/`@playwright/test`).
+
+All suites run against a **live PMM Server** (see percona/pmm — bring it up with `make env-up`, reachable at `https://localhost`). Non-obvious caveats:
+
+- **`e2e_tests` (active Playwright UI):** no `.env` ships. Set `PMM_UI_URL=https://localhost/` (config's `ignoreHTTPSErrors` handles the self-signed cert; default login `admin`/`admin`, override via `ADMIN_PASSWORD`). Run with `npx playwright test` (optionally `--grep "@tag"`). Verified working: `PMM_UI_URL=https://localhost/ npx playwright test changeTheme.test.ts` (server-only, no DB provisioning). `postRelease.test.ts` reads `PMM_SERVER_LATEST` at import time, so `--list`/runs abort unless that var is set — set it (e.g. the server version) or `--grep` around it.
+- **`cli` (pmm-admin, no browser):** `npx playwright test` / `npm run cli:<tag>`. No browser install needed.
+- **Most tagged UI/CLI tests need provisioned PMM Client + DB containers** on the `pmm-qa` Docker network via `qa-integration/pmm_qa/pmm-framework.py` (activate the venv: `. virtenv/bin/activate`). That provisioning also requires a host PMM Client and Ansible (`ansible-runner` is in the venv, but `pmm-framework.py`'s Ansible playbooks additionally expect the `ansible` binary and a PMM Client install) — install those on demand for full integration runs; the plain `--help` works out of the box.
+- **Env config vs deps:** the update script only installs dependencies; per-run values like `PMM_UI_URL`, `ADMIN_PASSWORD`, `WORKERS`, `HEADLESS`, `PMM_SERVER_LATEST` are runtime env vars, not part of setup.
+- A committed `.cursor/environment.json` (see open PR that adds one) would become the repo's environment source of truth and take precedence over the snapshot update script; keep the two in sync if that PR merges.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the Cursor Cloud environment setup for running the pmm-qa test suites, and records the non-obvious run caveats discovered while installing/verifying the tooling.

The VM snapshot now has the per-suite tooling preinstalled and the startup update script keeps it fresh:
- `npm ci` for `e2e_tests`, `cli`, and `codeceptjs-e2e`
- Playwright Chromium for both UI suites (`e2e_tests` ~PW 1.56, `codeceptjs-e2e` PW 1.45 — each ships its own browser build)
- Python venv at `qa-integration/pmm_qa/virtenv` with `requirements.txt`
- `python3-venv` and Playwright OS libraries baked into the snapshot; `gh` and Node 22 on the host

The new `## Cursor Cloud specific instructions` section in `AGENTS.md` covers: running each suite against a live PMM Server (`https://localhost`), the `e2e_tests` env vars (`PMM_UI_URL`, `ADMIN_PASSWORD`, and the `PMM_SERVER_LATEST` import-time gotcha in `postRelease.test.ts`), the `pmm-framework.py` provisioning prerequisite for tagged integration tests, and a note that a committed `.cursor/environment.json` (open PR) would take precedence over the snapshot update script.

No test code was modified.

## Verification

Installed and verified in the cloud VM (against a running PMM Server v3.8.0 from percona/pmm `make env-up`):
- `e2e_tests`: `npm ci` + `npx playwright install chromium`; `PMM_UI_URL=https://localhost/ npx playwright test changeTheme.test.ts` → 2 passed.
- `cli`: `npm ci`; `npx playwright test --list` → 213 tests.
- `codeceptjs-e2e`: `npm ci` + Chromium; `npx codeceptjs --version` → 3.7.9.
- `qa-integration/pmm_qa`: venv + `pip install -r requirements.txt`; `python pmm-framework.py --help` works.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee65de6d-dfb3-41fc-b5e0-8a7bcf85b7b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee65de6d-dfb3-41fc-b5e0-8a7bcf85b7b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

