### PR TITLE
Fix podman e2e workflow apt setup on Ubuntu jammy

### DIFF
--- a/.github/workflows/runner-e2e-tests-podman.yml
+++ b/.github/workflows/runner-e2e-tests-podman.yml
@@ -108,7 +108,8 @@ jobs:
 
       - name: Setup tools
         run: |
-          sudo apt-get install -y apt-transport-https ca-certificates dirmngr ansible libaio1 libaio-dev libnuma-dev libncurses5 socat sysbench
+          sudo apt-get update
+          sudo apt-get install -y apt-transport-https ca-certificates dirmngr ansible libaio1 libaio-dev libnuma-dev libncurses6 socat sysbench
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 8919F6BD2B48D754
           echo "deb https://packages.clickhouse.com/deb stable main" | sudo tee \
               /etc/apt/sources.list.d/clickhouse.list
@@ -118,7 +119,6 @@ jobs:
           curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
           sudo apt-get update
           sudo apt-get -y upgrade
-          sudo apt-get install -y 
           sudo apt-get install -y clickhouse-client podman
           sudo curl -s https://raw.githubusercontent.com/datacharmer/dbdeployer/master/scripts/dbdeployer-install.sh | bash
           ls -la


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

FB run [28705517533](https://github.com/Percona-Lab/pmm-submodules/actions/runs/28705517533) on PR-4456 failed the **@user-password (podman)** lane because the workflow installed `libncurses5` before `apt-get update`, hitting a 404 on jammy mirrors. The workflow also had a broken empty `apt-get install` line.

## How

- Run `apt-get update` before the first package install in `runner-e2e-tests-podman.yml`
- Replace unavailable `libncurses5` with `libncurses6`
- Remove the broken empty `apt-get install` step

## Related

- Split from #1046 per review feedback — encryption v2 rotation test updates remain in draft PR #1046
- CLI remove error message fix was already merged separately in #1045
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f58bcf78-0fd0-4b3b-8249-deb261c14051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f58bcf78-0fd0-4b3b-8249-deb261c14051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

