### PR TITLE
PMM-15210: pass installation_type to Launchable test-suite

### DIFF
--- a/.github/workflows/nightly-e2e-tests-matrix.yml
+++ b/.github/workflows/nightly-e2e-tests-matrix.yml
@@ -35,6 +35,11 @@ on:
         required: false
         default: '100%'
         type: string
+      installation_type:
+        description: "PMM Server installation type (docker|ami|helm|ha)"
+        required: false
+        default: 'docker'
+        type: string
 
   workflow_call:
     inputs:
@@ -60,6 +65,10 @@ on:
       launchable_confidence:
         required: false
         default: '100%'
+        type: string
+      installation_type:
+        required: false
+        default: 'docker'
         type: string
     secrets:
       LAUNCHABLE_TOKEN:
@@ -138,3 +147,4 @@ jobs:
       expected_setup_jobs: 14
       workers: 1
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
+      installation_type: ${{ inputs.installation_type || 'docker' }}

--- a/.github/workflows/nightly-e2e-tests-matrix.yml
+++ b/.github/workflows/nightly-e2e-tests-matrix.yml
@@ -35,6 +35,11 @@ on:
         required: false
         default: '100%'
         type: string
+      deployment_type:
+        description: "PMM Server deployment type (docker|ami|helm|ha)"
+        required: false
+        default: 'docker'
+        type: string
 
   workflow_call:
     inputs:
@@ -60,6 +65,10 @@ on:
       launchable_confidence:
         required: false
         default: '100%'
+        type: string
+      deployment_type:
+        required: false
+        default: 'docker'
         type: string
     secrets:
       LAUNCHABLE_TOKEN:
@@ -138,3 +147,4 @@ jobs:
       expected_setup_jobs: 14
       workers: 1
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
+      deployment_type: ${{ inputs.deployment_type || 'docker' }}

--- a/.github/workflows/nightly-e2e-tests-matrix.yml
+++ b/.github/workflows/nightly-e2e-tests-matrix.yml
@@ -35,11 +35,6 @@ on:
         required: false
         default: '100%'
         type: string
-      deployment_type:
-        description: "PMM Server deployment type (docker|ami|helm|ha)"
-        required: false
-        default: 'docker'
-        type: string
 
   workflow_call:
     inputs:
@@ -65,10 +60,6 @@ on:
       launchable_confidence:
         required: false
         default: '100%'
-        type: string
-      deployment_type:
-        required: false
-        default: 'docker'
         type: string
     secrets:
       LAUNCHABLE_TOKEN:
@@ -147,4 +138,3 @@ jobs:
       expected_setup_jobs: 14
       workers: 1
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
-      deployment_type: ${{ inputs.deployment_type || 'docker' }}

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
@@ -37,10 +37,6 @@ on:
         required: false
         default: '100%'
         type: string
-      deployment_type:
-        required: false
-        default: 'docker'
-        type: string
     secrets:
       LAUNCHABLE_TOKEN:
         required: false
@@ -68,7 +64,6 @@ jobs:
       TAGS_FOR_TESTS: ${{ inputs.tags_for_tests }}
       WORKERS: ${{ inputs.workers || 1 }}
       LAUNCHABLE_CONFIDENCE: ${{ inputs.launchable_confidence || '100%' }}
-      DEPLOYMENT_TYPE: ${{ inputs.deployment_type || 'docker' }}
       ZEPHYR_PMM_API_KEY: ${{ secrets.ZEPHYR_PMM_API_KEY }}
       LAUNCHABLE_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN }}
       SUBSET_FILE_NAME: 'launchable-subset.json'
@@ -140,28 +135,28 @@ jobs:
           pip3 install --user --upgrade launchable~=1.0
           launchable verify || true
 
-          DEPLOYMENT_TYPE="${{ env.DEPLOYMENT_TYPE }}"
           SERVER_IMAGE="${{ env.DOCKER_VERSION }}"
           CLIENT_VER="${{ env.CLIENT_VERSION }}"
           TAGS_SUFFIX="${{ steps.tags_processed.outputs.result }}"
 
-          if [[ "${DEPLOYMENT_TYPE}" == "ami" || "${SERVER_IMAGE}" == ami-* ]]; then
+          if [[ "${SERVER_IMAGE}" == ami-* ]]; then
             export LAUNCHABLE_BUILD="${SERVER_IMAGE}"
+            TEST_SUITE="nightly-ui-tests-ami-${TAGS_SUFFIX}"
           else
             docker pull "${SERVER_IMAGE}" || true
             export LAUNCHABLE_BUILD=$(docker inspect -f '{{index .RepoDigests 0}}' "${SERVER_IMAGE}" | cut -d@ -f2) || true
+            TEST_SUITE="nightly-ui-tests-${TAGS_SUFFIX}"
           fi
 
           echo "Launchable build: ${LAUNCHABLE_BUILD}"
-          echo "Launchable deployment type: ${DEPLOYMENT_TYPE}"
+          echo "Launchable test suite: ${TEST_SUITE}"
           echo "Launchable confidence: ${{ env.LAUNCHABLE_CONFIDENCE }}"
 
           launchable record session \
             --build "${LAUNCHABLE_BUILD}" \
-            --test-suite "nightly-ui-tests-${DEPLOYMENT_TYPE}-${TAGS_SUFFIX}" \
+            --test-suite "${TEST_SUITE}" \
             --flavor "pmm-server-tag=${SERVER_IMAGE}" \
             --flavor "pmm-client-version=${CLIENT_VER}" \
-            --flavor "deployment-type=${DEPLOYMENT_TYPE}" \
             > launchable-session.txt || true
           node launchable-prepare.js "${{ env.TAGS_FOR_TESTS }}"
           cat test_list.txt | launchable subset --session "$(cat launchable-session.txt)" --confidence ${{ env.LAUNCHABLE_CONFIDENCE }} --use-case feature-branch codeceptjs > launchable-subset.json || true

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
@@ -129,8 +129,15 @@ jobs:
           result-encoding: string
 
       - name: Prepare launchable
+        id: prepare_launchable
         working-directory: pmm-qa/codeceptjs-e2e
         run: |
+          if [[ "${{ env.DOCKER_VERSION }}" == ami-* ]]; then
+            echo "skip_launchable=true" >> "$GITHUB_OUTPUT"
+            echo "AMI server image (${{ env.DOCKER_VERSION }}): skipping Launchable subset."
+            exit 0
+          fi
+
           pip3 install --user --upgrade launchable~=1.0
           launchable verify || true
 
@@ -148,11 +155,17 @@ jobs:
         id: check_launchable_subset
         working-directory: pmm-qa/codeceptjs-e2e
         run: |
-          if [ -s "${{ env.SUBSET_FILE_NAME }}" ]; then
+          if [ "${{ steps.prepare_launchable.outputs.skip_launchable }}" = "true" ]; then
             echo "has_subset=true" >> "$GITHUB_OUTPUT"
+            echo "run_all_tests=true" >> "$GITHUB_OUTPUT"
+            echo "AMI deployment: running all tests matching grep (Launchable skipped)."
+          elif [ -s "${{ env.SUBSET_FILE_NAME }}" ]; then
+            echo "has_subset=true" >> "$GITHUB_OUTPUT"
+            echo "run_all_tests=false" >> "$GITHUB_OUTPUT"
             echo "Launchable subset is not empty. Continue with tests."
           else
             echo "has_subset=false" >> "$GITHUB_OUTPUT"
+            echo "run_all_tests=false" >> "$GITHUB_OUTPUT"
             echo "Launchable subset is empty. Test execution will be skipped."
           fi
 
@@ -259,11 +272,18 @@ jobs:
           sed -i "s+http://localhost/+${PMM_UI_URL}+g" pr.codecept.js
           sed -i "s+https://localhost/+${PMM_UI_URL}+g" pr.codecept.js
 
-          npx codeceptjs run-workers ${{ env.WORKERS }} \
-            -c pr.codecept.js \
-            --grep "${{ env.TAGS_FOR_TESTS }}" \
-            --reporter mocha-multi \
-            -o "$(cat "${{ env.SUBSET_FILE_NAME }}")"
+          if [ "${{ steps.check_launchable_subset.outputs.run_all_tests }}" = "true" ]; then
+            npx codeceptjs run-workers ${{ env.WORKERS }} \
+              -c pr.codecept.js \
+              --grep "${{ env.TAGS_FOR_TESTS }}" \
+              --reporter mocha-multi
+          else
+            npx codeceptjs run-workers ${{ env.WORKERS }} \
+              -c pr.codecept.js \
+              --grep "${{ env.TAGS_FOR_TESTS }}" \
+              --reporter mocha-multi \
+              -o "$(cat "${{ env.SUBSET_FILE_NAME }}")"
+          fi
 
       - name: Download PMM Server logs
         if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' && always() }}
@@ -274,7 +294,7 @@ jobs:
           unzip logs.zip -d logs || true
 
       - name: Record launchable test results
-        if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' && always() }}
+        if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' && steps.check_launchable_subset.outputs.run_all_tests != 'true' && always() }}
         working-directory: pmm-qa/codeceptjs-e2e
         run: |
          sed -i "s|$(pwd)/||g" tests/output/result.xml || true
@@ -282,7 +302,7 @@ jobs:
          launchable gate --session "$(cat launchable-session.txt)"
 
       - name: Record launchable logs on failure
-        if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' && failure() }}
+        if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' && steps.check_launchable_subset.outputs.run_all_tests != 'true' && failure() }}
         working-directory: pmm-qa/codeceptjs-e2e
         continue-on-error: true
         run: |

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
@@ -37,6 +37,10 @@ on:
         required: false
         default: '100%'
         type: string
+      deployment_type:
+        required: false
+        default: 'docker'
+        type: string
     secrets:
       LAUNCHABLE_TOKEN:
         required: false
@@ -64,6 +68,7 @@ jobs:
       TAGS_FOR_TESTS: ${{ inputs.tags_for_tests }}
       WORKERS: ${{ inputs.workers || 1 }}
       LAUNCHABLE_CONFIDENCE: ${{ inputs.launchable_confidence || '100%' }}
+      DEPLOYMENT_TYPE: ${{ inputs.deployment_type || 'docker' }}
       ZEPHYR_PMM_API_KEY: ${{ secrets.ZEPHYR_PMM_API_KEY }}
       LAUNCHABLE_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN }}
       SUBSET_FILE_NAME: 'launchable-subset.json'
@@ -132,41 +137,52 @@ jobs:
         id: prepare_launchable
         working-directory: pmm-qa/codeceptjs-e2e
         run: |
-          if [[ "${{ env.DOCKER_VERSION }}" == ami-* ]]; then
-            echo "skip_launchable=true" >> "$GITHUB_OUTPUT"
-            echo "AMI server image (${{ env.DOCKER_VERSION }}): skipping Launchable subset."
-            exit 0
-          fi
-
           pip3 install --user --upgrade launchable~=1.0
           launchable verify || true
 
-          docker pull ${{ env.DOCKER_VERSION }} || true
-          export DOCKER_IMAGE_ID=$(docker inspect -f '{{index .RepoDigests 0}}' ${{ env.DOCKER_VERSION }} | cut -d@ -f2) || true
-          echo "Launchable build: ${DOCKER_IMAGE_ID}"
+          DEPLOYMENT_TYPE="${{ env.DEPLOYMENT_TYPE }}"
+          SERVER_IMAGE="${{ env.DOCKER_VERSION }}"
+          CLIENT_VER="${{ env.CLIENT_VERSION }}"
+          TAGS_SUFFIX="${{ steps.tags_processed.outputs.result }}"
+
+          if [[ "${DEPLOYMENT_TYPE}" == "ami" || "${SERVER_IMAGE}" == ami-* ]]; then
+            export LAUNCHABLE_BUILD="${SERVER_IMAGE}"
+          else
+            docker pull "${SERVER_IMAGE}" || true
+            export LAUNCHABLE_BUILD=$(docker inspect -f '{{index .RepoDigests 0}}' "${SERVER_IMAGE}" | cut -d@ -f2) || true
+          fi
+
+          echo "Launchable build: ${LAUNCHABLE_BUILD}"
+          echo "Launchable deployment type: ${DEPLOYMENT_TYPE}"
           echo "Launchable confidence: ${{ env.LAUNCHABLE_CONFIDENCE }}"
 
-          launchable record session --build ${DOCKER_IMAGE_ID} --test-suite "nightly-ui-tests-${{ steps.tags_processed.outputs.result }}" > launchable-session.txt || true
+          launchable record session \
+            --build "${LAUNCHABLE_BUILD}" \
+            --test-suite "nightly-ui-tests-${DEPLOYMENT_TYPE}-${TAGS_SUFFIX}" \
+            --flavor "pmm-server-tag=${SERVER_IMAGE}" \
+            --flavor "pmm-client-version=${CLIENT_VER}" \
+            --flavor "deployment-type=${DEPLOYMENT_TYPE}" \
+            > launchable-session.txt || true
           node launchable-prepare.js "${{ env.TAGS_FOR_TESTS }}"
-          cat test_list.txt | launchable subset --session $(cat launchable-session.txt) --confidence ${{ env.LAUNCHABLE_CONFIDENCE }} --use-case feature-branch codeceptjs > launchable-subset.json || true
+          cat test_list.txt | launchable subset --session "$(cat launchable-session.txt)" --confidence ${{ env.LAUNCHABLE_CONFIDENCE }} --use-case feature-branch codeceptjs > launchable-subset.json || true
           echo "$(cat launchable-subset.json)" || true
 
       - name: Check if launchable subset is empty
         id: check_launchable_subset
         working-directory: pmm-qa/codeceptjs-e2e
         run: |
-          if [ "${{ steps.prepare_launchable.outputs.skip_launchable }}" = "true" ]; then
-            echo "has_subset=true" >> "$GITHUB_OUTPUT"
-            echo "run_all_tests=true" >> "$GITHUB_OUTPUT"
-            echo "AMI deployment: running all tests matching grep (Launchable skipped)."
-          elif [ -s "${{ env.SUBSET_FILE_NAME }}" ]; then
+          if [ -s "${{ env.SUBSET_FILE_NAME }}" ]; then
             echo "has_subset=true" >> "$GITHUB_OUTPUT"
             echo "run_all_tests=false" >> "$GITHUB_OUTPUT"
             echo "Launchable subset is not empty. Continue with tests."
+          elif [ -s launchable-session.txt ]; then
+            echo "has_subset=true" >> "$GITHUB_OUTPUT"
+            echo "run_all_tests=true" >> "$GITHUB_OUTPUT"
+            echo "Launchable subset empty (session recorded). Running all tests matching grep."
           else
             echo "has_subset=false" >> "$GITHUB_OUTPUT"
             echo "run_all_tests=false" >> "$GITHUB_OUTPUT"
-            echo "Launchable subset is empty. Test execution will be skipped."
+            echo "Launchable session missing. Test execution will be skipped."
           fi
 
       - name: Skip notice
@@ -294,15 +310,17 @@ jobs:
           unzip logs.zip -d logs || true
 
       - name: Record launchable test results
-        if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' && steps.check_launchable_subset.outputs.run_all_tests != 'true' && always() }}
+        if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' && always() }}
         working-directory: pmm-qa/codeceptjs-e2e
         run: |
          sed -i "s|$(pwd)/||g" tests/output/result.xml || true
          launchable record tests --session "$(cat launchable-session.txt)" codeceptjs tests/output/result.xml || true
-         launchable gate --session "$(cat launchable-session.txt)"
+         if [ "${{ steps.check_launchable_subset.outputs.run_all_tests }}" != "true" ]; then
+           launchable gate --session "$(cat launchable-session.txt)"
+         fi
 
       - name: Record launchable logs on failure
-        if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' && steps.check_launchable_subset.outputs.run_all_tests != 'true' && failure() }}
+        if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' && failure() }}
         working-directory: pmm-qa/codeceptjs-e2e
         continue-on-error: true
         run: |

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
@@ -129,37 +129,23 @@ jobs:
           result-encoding: string
 
       - name: Prepare launchable
-        id: prepare_launchable
         working-directory: pmm-qa/codeceptjs-e2e
         run: |
           pip3 install --user --upgrade launchable~=1.0
           launchable verify || true
 
-          SERVER_IMAGE="${{ env.DOCKER_VERSION }}"
-          CLIENT_VER="${{ env.CLIENT_VERSION }}"
-          TAGS_SUFFIX="${{ steps.tags_processed.outputs.result }}"
-
-          if [[ "${SERVER_IMAGE}" == ami-* ]]; then
-            export LAUNCHABLE_BUILD="${SERVER_IMAGE}"
-            TEST_SUITE="nightly-ui-tests-ami-${TAGS_SUFFIX}"
+          if [[ "${{ env.DOCKER_VERSION }}" == ami-* ]]; then
+            export DOCKER_IMAGE_ID="${{ env.DOCKER_VERSION }}"
           else
-            docker pull "${SERVER_IMAGE}" || true
-            export LAUNCHABLE_BUILD=$(docker inspect -f '{{index .RepoDigests 0}}' "${SERVER_IMAGE}" | cut -d@ -f2) || true
-            TEST_SUITE="nightly-ui-tests-${TAGS_SUFFIX}"
+            docker pull ${{ env.DOCKER_VERSION }} || true
+            export DOCKER_IMAGE_ID=$(docker inspect -f '{{index .RepoDigests 0}}' ${{ env.DOCKER_VERSION }} | cut -d@ -f2) || true
           fi
-
-          echo "Launchable build: ${LAUNCHABLE_BUILD}"
-          echo "Launchable test suite: ${TEST_SUITE}"
+          echo "Launchable build: ${DOCKER_IMAGE_ID}"
           echo "Launchable confidence: ${{ env.LAUNCHABLE_CONFIDENCE }}"
 
-          launchable record session \
-            --build "${LAUNCHABLE_BUILD}" \
-            --test-suite "${TEST_SUITE}" \
-            --flavor "pmm-server-tag=${SERVER_IMAGE}" \
-            --flavor "pmm-client-version=${CLIENT_VER}" \
-            > launchable-session.txt || true
+          launchable record session --build ${DOCKER_IMAGE_ID} --test-suite "nightly-ui-tests-${{ steps.tags_processed.outputs.result }}" > launchable-session.txt || true
           node launchable-prepare.js "${{ env.TAGS_FOR_TESTS }}"
-          cat test_list.txt | launchable subset --session "$(cat launchable-session.txt)" --confidence ${{ env.LAUNCHABLE_CONFIDENCE }} --use-case feature-branch codeceptjs > launchable-subset.json || true
+          cat test_list.txt | launchable subset --session $(cat launchable-session.txt) --confidence ${{ env.LAUNCHABLE_CONFIDENCE }} --use-case feature-branch codeceptjs > launchable-subset.json || true
           echo "$(cat launchable-subset.json)" || true
 
       - name: Check if launchable subset is empty
@@ -168,16 +154,10 @@ jobs:
         run: |
           if [ -s "${{ env.SUBSET_FILE_NAME }}" ]; then
             echo "has_subset=true" >> "$GITHUB_OUTPUT"
-            echo "run_all_tests=false" >> "$GITHUB_OUTPUT"
             echo "Launchable subset is not empty. Continue with tests."
-          elif [ -s launchable-session.txt ]; then
-            echo "has_subset=true" >> "$GITHUB_OUTPUT"
-            echo "run_all_tests=true" >> "$GITHUB_OUTPUT"
-            echo "Launchable subset empty (session recorded). Running all tests matching grep."
           else
             echo "has_subset=false" >> "$GITHUB_OUTPUT"
-            echo "run_all_tests=false" >> "$GITHUB_OUTPUT"
-            echo "Launchable session missing. Test execution will be skipped."
+            echo "Launchable subset is empty. Test execution will be skipped."
           fi
 
       - name: Skip notice
@@ -283,18 +263,11 @@ jobs:
           sed -i "s+http://localhost/+${PMM_UI_URL}+g" pr.codecept.js
           sed -i "s+https://localhost/+${PMM_UI_URL}+g" pr.codecept.js
 
-          if [ "${{ steps.check_launchable_subset.outputs.run_all_tests }}" = "true" ]; then
-            npx codeceptjs run-workers ${{ env.WORKERS }} \
-              -c pr.codecept.js \
-              --grep "${{ env.TAGS_FOR_TESTS }}" \
-              --reporter mocha-multi
-          else
-            npx codeceptjs run-workers ${{ env.WORKERS }} \
-              -c pr.codecept.js \
-              --grep "${{ env.TAGS_FOR_TESTS }}" \
-              --reporter mocha-multi \
-              -o "$(cat "${{ env.SUBSET_FILE_NAME }}")"
-          fi
+          npx codeceptjs run-workers ${{ env.WORKERS }} \
+            -c pr.codecept.js \
+            --grep "${{ env.TAGS_FOR_TESTS }}" \
+            --reporter mocha-multi \
+            -o "$(cat "${{ env.SUBSET_FILE_NAME }}")"
 
       - name: Download PMM Server logs
         if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' && always() }}
@@ -310,9 +283,7 @@ jobs:
         run: |
          sed -i "s|$(pwd)/||g" tests/output/result.xml || true
          launchable record tests --session "$(cat launchable-session.txt)" codeceptjs tests/output/result.xml || true
-         if [ "${{ steps.check_launchable_subset.outputs.run_all_tests }}" != "true" ]; then
-           launchable gate --session "$(cat launchable-session.txt)"
-         fi
+         launchable gate --session "$(cat launchable-session.txt)"
 
       - name: Record launchable logs on failure
         if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' && failure() }}

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
@@ -144,7 +144,7 @@ jobs:
           echo "Launchable build: ${DOCKER_IMAGE_ID}"
           echo "Launchable confidence: ${{ env.LAUNCHABLE_CONFIDENCE }}"
 
-          launchable record session --build ${DOCKER_IMAGE_ID} --test-suite "${{ env.INSTALLATION_TYPE }}-ui-nightly" > launchable-session.txt || true
+          launchable record session --build ${DOCKER_IMAGE_ID} --test-suite "${{ env.INSTALLATION_TYPE }}-nightly-ui-tests-${{ steps.tags_processed.outputs.result }}" > launchable-session.txt || true
           node launchable-prepare.js "${{ env.TAGS_FOR_TESTS }}"
           cat test_list.txt | launchable subset --session $(cat launchable-session.txt) --confidence ${{ env.LAUNCHABLE_CONFIDENCE }} --use-case feature-branch codeceptjs > launchable-subset.json || true
           echo "$(cat launchable-subset.json)" || true

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
@@ -37,6 +37,10 @@ on:
         required: false
         default: '100%'
         type: string
+      installation_type:
+        required: false
+        default: 'docker'
+        type: string
     secrets:
       LAUNCHABLE_TOKEN:
         required: false
@@ -64,6 +68,7 @@ jobs:
       TAGS_FOR_TESTS: ${{ inputs.tags_for_tests }}
       WORKERS: ${{ inputs.workers || 1 }}
       LAUNCHABLE_CONFIDENCE: ${{ inputs.launchable_confidence || '100%' }}
+      INSTALLATION_TYPE: ${{ inputs.installation_type || 'docker' }}
       ZEPHYR_PMM_API_KEY: ${{ secrets.ZEPHYR_PMM_API_KEY }}
       LAUNCHABLE_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN }}
       SUBSET_FILE_NAME: 'launchable-subset.json'
@@ -134,16 +139,12 @@ jobs:
           pip3 install --user --upgrade launchable~=1.0
           launchable verify || true
 
-          if [[ "${{ env.DOCKER_VERSION }}" == ami-* ]]; then
-            export DOCKER_IMAGE_ID="${{ env.DOCKER_VERSION }}"
-          else
-            docker pull ${{ env.DOCKER_VERSION }} || true
-            export DOCKER_IMAGE_ID=$(docker inspect -f '{{index .RepoDigests 0}}' ${{ env.DOCKER_VERSION }} | cut -d@ -f2) || true
-          fi
+          docker pull ${{ env.DOCKER_VERSION }} || true
+          export DOCKER_IMAGE_ID=$(docker inspect -f '{{index .RepoDigests 0}}' ${{ env.DOCKER_VERSION }} | cut -d@ -f2) || true
           echo "Launchable build: ${DOCKER_IMAGE_ID}"
           echo "Launchable confidence: ${{ env.LAUNCHABLE_CONFIDENCE }}"
 
-          launchable record session --build ${DOCKER_IMAGE_ID} --test-suite "nightly-ui-tests-${{ steps.tags_processed.outputs.result }}" > launchable-session.txt || true
+          launchable record session --build ${DOCKER_IMAGE_ID} --test-suite "${{ env.INSTALLATION_TYPE }}-ui-nightly" > launchable-session.txt || true
           node launchable-prepare.js "${{ env.TAGS_FOR_TESTS }}"
           cat test_list.txt | launchable subset --session $(cat launchable-session.txt) --confidence ${{ env.LAUNCHABLE_CONFIDENCE }} --use-case feature-branch codeceptjs > launchable-subset.json || true
           echo "$(cat launchable-subset.json)" || true


### PR DESCRIPTION
## Problem

AMI nightly GHA runs share the same Launchable test-suite as Docker runs. Launchable cannot distinguish installation types, so subset selection fails for AMI.

## Fix

- Jenkins passes `SERVER_TYPE` as `installation_type` (default `docker`)
- GHA records Launchable sessions as `{installation_type}-ui-nightly` (e.g. `docker-ui-nightly`, `ami-ui-nightly`)
- `pmm_server_image` stays the docker image; build resolution via `docker inspect` is unchanged

## Related

- PMM-15210
- jenkins-pipelines: `PMM-15210-ami-nightly-gha`
