### PR TITLE
Consolidate Dependabot updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+
+multi-ecosystem-groups:
+  all-dependencies:
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+
+updates:
+  - package-ecosystem: npm
+    directories:
+      - /cli
+      - /codeceptjs-e2e
+      - /e2e_tests
+    patterns:
+      - "*"
+    multi-ecosystem-group: all-dependencies
+
+  - package-ecosystem: pip
+    directory: /qa-integration/pmm_qa
+    patterns:
+      - "*"
+    multi-ecosystem-group: all-dependencies


### PR DESCRIPTION
## Summary

- Close the backlog of 23 individual Dependabot PRs and delete their branches.
- Add `.github/dependabot.yml` with a multi-ecosystem group so npm (`/cli`, `/codeceptjs-e2e`, `/e2e_tests`) and pip (`/qa-integration/pmm_qa`) updates land in one weekly PR.

## Test plan

- [ ] Merge this PR.
- [ ] Confirm Dependabot shows the `all-dependencies` group under Insights → Dependency graph → Dependabot.
- [ ] Wait for the next scheduled run (or trigger manually) and verify a single consolidated PR is opened.
