### PR TITLE
Fix PMM-T1678 SSL external PostgreSQL monitoring flake

### DIFF
--- a/codeceptjs-e2e/docker-compose-clickhouse.yml
+++ b/codeceptjs-e2e/docker-compose-clickhouse.yml
@@ -63,8 +63,8 @@ services:
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
       - CLICKHOUSE_PASSWORD=pmm_password
     healthcheck:
-      test: ['CMD', 'clickhouse-client', '--query', 'SELECT 1']
+      test: ['CMD-SHELL', 'wget -qO /dev/null http://127.0.0.1:8123/ping || exit 1']
       interval: 5s
-      timeout: 5s
-      retries: 24
+      timeout: 3s
+      retries: 10
       start_period: 10s

--- a/codeceptjs-e2e/docker-compose-clickhouse.yml
+++ b/codeceptjs-e2e/docker-compose-clickhouse.yml
@@ -63,4 +63,8 @@ services:
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
       - CLICKHOUSE_PASSWORD=pmm_password
     healthcheck:
-      test: ['CMD', 'wget', '--spider', '-q', 'localhost:8123/ping']
+      test: ['CMD', 'clickhouse-client', '--query', 'SELECT 1']
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 10s

--- a/codeceptjs-e2e/testdata/external-services/external-pgsql-ssl.yml
+++ b/codeceptjs-e2e/testdata/external-services/external-pgsql-ssl.yml
@@ -96,13 +96,13 @@
         path: "{{ item.path }}"
         owner: "{{ item.owner }}"
         group: "{{ item.owner }}"
-        mode: '0600'
+        mode: "{{ item.mode }}"
       loop:
-        - { path: "{{ ssl_dir }}/ca.crt", owner: "26" }
-        - { path: "{{ ssl_dir }}/server.crt", owner: "26" }
-        - { path: "{{ ssl_dir }}/server.key", owner: "26" }
-        - { path: "{{ ssl_dir }}/client.key", owner: "1000" }
-        - { path: "{{ ssl_dir }}/client.crt", owner: "1000" }
+        - { path: "{{ ssl_dir }}/ca.crt", owner: "26", mode: "0644" }
+        - { path: "{{ ssl_dir }}/server.crt", owner: "26", mode: "0600" }
+        - { path: "{{ ssl_dir }}/server.key", owner: "26", mode: "0600" }
+        - { path: "{{ ssl_dir }}/client.key", owner: "1000", mode: "0600" }
+        - { path: "{{ ssl_dir }}/client.crt", owner: "1000", mode: "0600" }
       become: yes
 
     - name: Start external-postgres-ssl container
@@ -116,6 +116,7 @@
         -v {{ ssl_dir }}:/var/lib/postgresql/ssl
         {{ postgres_image }}
         postgres -c ssl=on
+        -c ssl_ca_file=/var/lib/postgresql/ssl/ca.crt
         -c ssl_cert_file=/var/lib/postgresql/ssl/server.crt
         -c ssl_key_file=/var/lib/postgresql/ssl/server.key
         -c shared_preload_libraries=pg_stat_statements

--- a/codeceptjs-e2e/testdata/external-services/external-pgsql-ssl.yml
+++ b/codeceptjs-e2e/testdata/external-services/external-pgsql-ssl.yml
@@ -32,8 +32,11 @@
         - "{{ data_dir }}"
     - name: Stop containers if already running
       shell: |
-        docker rm -f external-postgres-ssl 
+        docker rm -f external-postgres
+        docker rm -f pmm-server-external-postgres
+        docker rm -f external-postgres-ssl
         docker rm -f pmm-server-external-postgres-ssl
+        docker volume rm pmm-server-external-pg
         docker volume rm pmm-server-external-pg-ssl
       ignore_errors: true
 
@@ -93,13 +96,13 @@
         path: "{{ item.path }}"
         owner: "{{ item.owner }}"
         group: "{{ item.owner }}"
-        mode: '0600'
+        mode: "{{ item.mode }}"
       loop:
-        - { path: "{{ ssl_dir }}/ca.crt", owner: "1000" }
-        - { path: "{{ ssl_dir }}/server.crt", owner: "26" }
-        - { path: "{{ ssl_dir }}/server.key", owner: "26" }
-        - { path: "{{ ssl_dir }}/client.key", owner: "1000" }
-        - { path: "{{ ssl_dir }}/client.crt", owner: "1000" }
+        - { path: "{{ ssl_dir }}/ca.crt", owner: "26", mode: "0644" }
+        - { path: "{{ ssl_dir }}/server.crt", owner: "26", mode: "0600" }
+        - { path: "{{ ssl_dir }}/server.key", owner: "26", mode: "0600" }
+        - { path: "{{ ssl_dir }}/client.key", owner: "1000", mode: "0600" }
+        - { path: "{{ ssl_dir }}/client.crt", owner: "1000", mode: "0600" }
       become: yes
 
     - name: Start external-postgres-ssl container
@@ -175,5 +178,5 @@
       shell: docker inspect --format='{{ "{{.State.Health.Status}}" }}' pmm-server-external-postgres-ssl
       register: pmm_server_health
       until: "'healthy' in pmm_server_health.stdout"
-      retries: 5
+      retries: 24
       delay: 5

--- a/codeceptjs-e2e/testdata/external-services/external-pgsql-ssl.yml
+++ b/codeceptjs-e2e/testdata/external-services/external-pgsql-ssl.yml
@@ -113,6 +113,7 @@
         -v {{ ssl_dir }}:/var/lib/postgresql/ssl
         {{ postgres_image }}
         postgres -c ssl=on
+        -c ssl_ca_file=/var/lib/postgresql/ssl/ca.crt
         -c ssl_cert_file=/var/lib/postgresql/ssl/server.crt
         -c ssl_key_file=/var/lib/postgresql/ssl/server.key
         -c shared_preload_libraries=pg_stat_statements

--- a/codeceptjs-e2e/testdata/external-services/external-pgsql-ssl.yml
+++ b/codeceptjs-e2e/testdata/external-services/external-pgsql-ssl.yml
@@ -96,13 +96,13 @@
         path: "{{ item.path }}"
         owner: "{{ item.owner }}"
         group: "{{ item.owner }}"
-        mode: "{{ item.mode }}"
+        mode: '0600'
       loop:
-        - { path: "{{ ssl_dir }}/ca.crt", owner: "26", mode: "0644" }
-        - { path: "{{ ssl_dir }}/server.crt", owner: "26", mode: "0600" }
-        - { path: "{{ ssl_dir }}/server.key", owner: "26", mode: "0600" }
-        - { path: "{{ ssl_dir }}/client.key", owner: "1000", mode: "0600" }
-        - { path: "{{ ssl_dir }}/client.crt", owner: "1000", mode: "0600" }
+        - { path: "{{ ssl_dir }}/ca.crt", owner: "26" }
+        - { path: "{{ ssl_dir }}/server.crt", owner: "26" }
+        - { path: "{{ ssl_dir }}/server.key", owner: "26" }
+        - { path: "{{ ssl_dir }}/client.key", owner: "1000" }
+        - { path: "{{ ssl_dir }}/client.crt", owner: "1000" }
       become: yes
 
     - name: Start external-postgres-ssl container
@@ -116,7 +116,6 @@
         -v {{ ssl_dir }}:/var/lib/postgresql/ssl
         {{ postgres_image }}
         postgres -c ssl=on
-        -c ssl_ca_file=/var/lib/postgresql/ssl/ca.crt
         -c ssl_cert_file=/var/lib/postgresql/ssl/server.crt
         -c ssl_key_file=/var/lib/postgresql/ssl/server.key
         -c shared_preload_libraries=pg_stat_statements
@@ -178,5 +177,5 @@
       shell: docker inspect --format='{{ "{{.State.Health.Status}}" }}' pmm-server-external-postgres-ssl
       register: pmm_server_health
       until: "'healthy' in pmm_server_health.stdout"
-      retries: 24
+      retries: 5
       delay: 5

--- a/codeceptjs-e2e/testdata/external-services/external-pgsql.yml
+++ b/codeceptjs-e2e/testdata/external-services/external-pgsql.yml
@@ -30,10 +30,7 @@
       shell: |
         docker rm -f external-postgres
         docker rm -f pmm-server-external-postgres
-        docker rm -f external-postgres-ssl
-        docker rm -f pmm-server-external-postgres-ssl
         docker volume rm pmm-server-external-pg
-        docker volume rm pmm-server-external-pg-ssl
       ignore_errors: true
 
     - name: Start external-postgres container

--- a/codeceptjs-e2e/testdata/external-services/external-pgsql.yml
+++ b/codeceptjs-e2e/testdata/external-services/external-pgsql.yml
@@ -30,7 +30,10 @@
       shell: |
         docker rm -f external-postgres
         docker rm -f pmm-server-external-postgres
+        docker rm -f external-postgres-ssl
+        docker rm -f pmm-server-external-postgres-ssl
         docker volume rm pmm-server-external-pg
+        docker volume rm pmm-server-external-pg-ssl
       ignore_errors: true
 
     - name: Start external-postgres container
@@ -92,5 +95,5 @@
       shell: docker inspect --format='{{ "{{.State.Health.Status}}" }}' pmm-server-external-postgres
       register: pmm_server_health
       until: "'healthy' in pmm_server_health.stdout"
-      retries: 5
+      retries: 24
       delay: 5

--- a/codeceptjs-e2e/testdata/external-services/external-pgsql.yml
+++ b/codeceptjs-e2e/testdata/external-services/external-pgsql.yml
@@ -30,7 +30,10 @@
       shell: |
         docker rm -f external-postgres
         docker rm -f pmm-server-external-postgres
+        docker rm -f external-postgres-ssl
+        docker rm -f pmm-server-external-postgres-ssl
         docker volume rm pmm-server-external-pg
+        docker volume rm pmm-server-external-pg-ssl
       ignore_errors: true
 
     - name: Start external-postgres container

--- a/codeceptjs-e2e/testdata/external-services/external-pgsql.yml
+++ b/codeceptjs-e2e/testdata/external-services/external-pgsql.yml
@@ -92,5 +92,5 @@
       shell: docker inspect --format='{{ "{{.State.Health.Status}}" }}' pmm-server-external-postgres
       register: pmm_server_health
       until: "'healthy' in pmm_server_health.stdout"
-      retries: 24
+      retries: 5
       delay: 5

--- a/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
+++ b/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
@@ -8,6 +8,7 @@ const basePmmUrl = `http://127.0.0.1:${pmmServerPort}/`;
 const dockerVersion = process.env.DOCKER_VERSION || 'perconalab/pmm-server:3-dev-latest';
 
 BeforeSuite(async ({ I }) => {
+  await I.verifyCommand('docker compose -f docker-compose-clickhouse.yml down -v || true');
   await I.verifyCommand(`PMM_SERVER_IMAGE=${dockerVersion} docker compose -f docker-compose-clickhouse.yml up -d`);
   await I.wait(30);
   await I.verifyCommand('docker exec pmm-client-clickhouse pmm-admin add mysql --username=root --password=7B*53@lCdflR --query-source=perfschema ps8 ps8:3306');
@@ -22,9 +23,8 @@ AfterSuite(async ({ I }) => {
   await I.verifyCommand('docker compose -f docker-compose-clickhouse.yml down -v');
 });
 
-// Tag only for adding into matrix job, to be fixed later.
 Scenario(
-  'PMM-T1218 Verify PMM with external Clickhouse @docker-configuration @cli',
+  'PMM-T1218 Verify PMM with external Clickhouse @docker-configuration',
   async ({ I, dataSourcePage, queryAnalyticsPage }) => {
     I.amOnPage(basePmmUrl + dataSourcePage.url);
     I.waitForVisible(dataSourcePage.elements.clickHouseDatasource, 5);

--- a/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
+++ b/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
@@ -8,7 +8,6 @@ const basePmmUrl = `http://127.0.0.1:${pmmServerPort}/`;
 const dockerVersion = process.env.DOCKER_VERSION || 'perconalab/pmm-server:3-dev-latest';
 
 BeforeSuite(async ({ I }) => {
-  await I.verifyCommand('docker compose -f docker-compose-clickhouse.yml down -v || true');
   await I.verifyCommand(`PMM_SERVER_IMAGE=${dockerVersion} docker compose -f docker-compose-clickhouse.yml up -d`);
   await I.wait(30);
   await I.verifyCommand('docker exec pmm-client-clickhouse pmm-admin add mysql --username=root --password=7B*53@lCdflR --query-source=perfschema ps8 ps8:3306');
@@ -23,8 +22,9 @@ AfterSuite(async ({ I }) => {
   await I.verifyCommand('docker compose -f docker-compose-clickhouse.yml down -v');
 });
 
+// Tag only for adding into matrix job, to be fixed later.
 Scenario(
-  'PMM-T1218 Verify PMM with external Clickhouse @docker-configuration',
+  'PMM-T1218 Verify PMM with external Clickhouse @docker-configuration @cli',
   async ({ I, dataSourcePage, queryAnalyticsPage }) => {
     I.amOnPage(basePmmUrl + dataSourcePage.url);
     I.waitForVisible(dataSourcePage.elements.clickHouseDatasource, 5);

--- a/codeceptjs-e2e/tests/configuration/pages/servicesTab.js
+++ b/codeceptjs-e2e/tests/configuration/pages/servicesTab.js
@@ -30,24 +30,6 @@ module.exports = {
     return (await I.grabTextFrom(this.fields.serviceCellMonitoring(serviceName))).trim();
   },
 
-  async waitForServiceMonitoringStatus(serviceName, expectedStatus = 'OK', timeoutSec = 120) {
-    I.waitForVisible(this.fields.serviceRow(serviceName), 60);
-
-    for (let elapsed = 0; elapsed < timeoutSec; elapsed += 5) {
-      const status = (await I.grabTextFrom(this.fields.serviceCellMonitoring(serviceName))).trim();
-
-      if (status === expectedStatus) {
-        return status;
-      }
-
-      I.wait(5);
-      I.refreshPage();
-      I.waitForVisible(this.fields.serviceRow(serviceName), 30);
-    }
-
-    return (await I.grabTextFrom(this.fields.serviceCellMonitoring(serviceName))).trim();
-  },
-
   async getServiceMonitoringAddress(serviceName) {
     I.waitForVisible(this.fields.serviceRow(serviceName), 60);
 

--- a/codeceptjs-e2e/tests/configuration/pages/servicesTab.js
+++ b/codeceptjs-e2e/tests/configuration/pages/servicesTab.js
@@ -30,6 +30,24 @@ module.exports = {
     return (await I.grabTextFrom(this.fields.serviceCellMonitoring(serviceName))).trim();
   },
 
+  async waitForServiceMonitoringStatus(serviceName, expectedStatus = 'OK', timeoutSec = 120) {
+    I.waitForVisible(this.fields.serviceRow(serviceName), 60);
+
+    for (let elapsed = 0; elapsed < timeoutSec; elapsed += 5) {
+      const status = (await I.grabTextFrom(this.fields.serviceCellMonitoring(serviceName))).trim();
+
+      if (status === expectedStatus) {
+        return status;
+      }
+
+      I.wait(5);
+      I.refreshPage();
+      I.waitForVisible(this.fields.serviceRow(serviceName), 30);
+    }
+
+    return (await I.grabTextFrom(this.fields.serviceCellMonitoring(serviceName))).trim();
+  },
+
   async getServiceMonitoringAddress(serviceName) {
     I.waitForVisible(this.fields.serviceRow(serviceName), 60);
 

--- a/codeceptjs-e2e/tests/dockerConfiguration/externalPostgres_test.js
+++ b/codeceptjs-e2e/tests/dockerConfiguration/externalPostgres_test.js
@@ -8,17 +8,9 @@ const data = new DataTable(['ansibleName', 'postgresqlAddress', 'pdpgsqlContaine
 data.add(['external-pgsql', 'external-postgres:5432', 'external-postgres']);
 data.add(['external-pgsql-ssl', 'external-postgres-ssl:5432', 'external-postgres-ssl']);
 
-async function cleanupExternalPostgresContainers(I) {
+After(async ({ I }) => {
   await I.verifyCommand('docker rm -f external-postgres pmm-server-external-postgres external-postgres-ssl pmm-server-external-postgres-ssl || true');
   await I.verifyCommand('docker volume rm pmm-server-external-pg pmm-server-external-pg-ssl || true');
-}
-
-Before(async ({ I }) => {
-  await cleanupExternalPostgresContainers(I);
-});
-
-After(async ({ I }) => {
-  await cleanupExternalPostgresContainers(I);
 });
 
 Data(data).Scenario(

--- a/codeceptjs-e2e/tests/dockerConfiguration/externalPostgres_test.js
+++ b/codeceptjs-e2e/tests/dockerConfiguration/externalPostgres_test.js
@@ -9,12 +9,8 @@ data.add(['external-pgsql', 'external-postgres:5432', 'external-postgres']);
 data.add(['external-pgsql-ssl', 'external-postgres-ssl:5432', 'external-postgres-ssl']);
 
 After(async ({ I }) => {
-  await I.verifyCommand('docker stop external-postgres || true');
-  await I.verifyCommand('docker stop pmm-server-external-postgres || true');
-  await I.verifyCommand('docker volume rm pmm-server-external-pg || true');
-  await I.verifyCommand('docker stop external-postgres-ssl || true');
-  await I.verifyCommand('docker stop pmm-server-external-postgres-ssl || true');
-  await I.verifyCommand('docker volume rm pmm-server-external-pg-ssl || true');
+  await I.verifyCommand('docker rm -f external-postgres pmm-server-external-postgres external-postgres-ssl pmm-server-external-postgres-ssl || true');
+  await I.verifyCommand('docker volume rm pmm-server-external-pg pmm-server-external-pg-ssl || true');
 });
 
 Data(data).Scenario(
@@ -41,7 +37,7 @@ Data(data).Scenario(
     );
 
     I.assertEqual(
-      await pmmInventoryPage.servicesTab.getServiceMonitoringStatus(serviceName),
+      await pmmInventoryPage.servicesTab.waitForServiceMonitoringStatus(serviceName, 'OK', 120),
       'OK',
       `'${serviceName}' is expected to have 'OK' monitoring status`,
     );

--- a/codeceptjs-e2e/tests/dockerConfiguration/externalPostgres_test.js
+++ b/codeceptjs-e2e/tests/dockerConfiguration/externalPostgres_test.js
@@ -8,9 +8,17 @@ const data = new DataTable(['ansibleName', 'postgresqlAddress', 'pdpgsqlContaine
 data.add(['external-pgsql', 'external-postgres:5432', 'external-postgres']);
 data.add(['external-pgsql-ssl', 'external-postgres-ssl:5432', 'external-postgres-ssl']);
 
-After(async ({ I }) => {
+async function cleanupExternalPostgresContainers(I) {
   await I.verifyCommand('docker rm -f external-postgres pmm-server-external-postgres external-postgres-ssl pmm-server-external-postgres-ssl || true');
   await I.verifyCommand('docker volume rm pmm-server-external-pg pmm-server-external-pg-ssl || true');
+}
+
+Before(async ({ I }) => {
+  await cleanupExternalPostgresContainers(I);
+});
+
+After(async ({ I }) => {
+  await cleanupExternalPostgresContainers(I);
 });
 
 Data(data).Scenario(

--- a/codeceptjs-e2e/tests/dockerConfiguration/externalPostgres_test.js
+++ b/codeceptjs-e2e/tests/dockerConfiguration/externalPostgres_test.js
@@ -9,8 +9,12 @@ data.add(['external-pgsql', 'external-postgres:5432', 'external-postgres']);
 data.add(['external-pgsql-ssl', 'external-postgres-ssl:5432', 'external-postgres-ssl']);
 
 After(async ({ I }) => {
-  await I.verifyCommand('docker rm -f external-postgres pmm-server-external-postgres external-postgres-ssl pmm-server-external-postgres-ssl || true');
-  await I.verifyCommand('docker volume rm pmm-server-external-pg pmm-server-external-pg-ssl || true');
+  await I.verifyCommand('docker stop external-postgres || true');
+  await I.verifyCommand('docker stop pmm-server-external-postgres || true');
+  await I.verifyCommand('docker volume rm pmm-server-external-pg || true');
+  await I.verifyCommand('docker stop external-postgres-ssl || true');
+  await I.verifyCommand('docker stop pmm-server-external-postgres-ssl || true');
+  await I.verifyCommand('docker volume rm pmm-server-external-pg-ssl || true');
 });
 
 Data(data).Scenario(
@@ -37,7 +41,7 @@ Data(data).Scenario(
     );
 
     I.assertEqual(
-      await pmmInventoryPage.servicesTab.waitForServiceMonitoringStatus(serviceName, 'OK', 120),
+      await pmmInventoryPage.servicesTab.getServiceMonitoringStatus(serviceName),
       'OK',
       `'${serviceName}' is expected to have 'OK' monitoring status`,
     );


### PR DESCRIPTION
## Summary

Follow-up fix for PMM-T1678 after #1044 merged.

## Root cause (SSL variant)

CI run [29046972353](https://github.com/percona/pmm-qa/actions/runs/29046972353) showed:
- `external-pgsql` (non-SSL): **passed**
- `external-pgsql-ssl`: **failed** with monitoring status `Failed` (expected `OK`)

Artifact logs and local reproduction show postgres_exporter exposes three VictoriaMetrics scrape pools (hr/lr/mr). After SSL PMM Server becomes healthy, these targets need ~30s before all report `up`. The test asserted monitoring status immediately (~8s after ansible in CI), so the inventory UI still showed `Failed`.

## Changes

- Add `waitForServiceMonitoringStatus()` in `servicesTab.js` — polls inventory with page refresh for up to 120s
- Use the waiter in `externalPostgres_test.js` instead of an immediate status assertion
- Harden teardown with `docker rm -f` + volume cleanup between data-driven scenarios
- Add `ssl_ca_file` to the SSL PostgreSQL container per PMM external PostgreSQL documentation

## Testing

- Investigated CI artifacts from run 29046972353
- Reproduced SSL scrape target warm-up timing locally with `external-pgsql-ssl.yml`