### PR TITLE
Fix arm64 tarball URL in pmm3_client_install_tarball.sh

### DIFF
--- a/package_tests/scripts/pmm3_client_install_tarball.sh
+++ b/package_tests/scripts/pmm3_client_install_tarball.sh
@@ -90,7 +90,9 @@ elif [[ "$architecture" == "x86_64" ]]; then
 fi
 
 if [[ "$architecture" == "arm64" ]]; then
-    tarball_url=https://downloads.percona.com/downloads/TESTING/pmm-arm/${client_tar}
+    # TESTING/pmm-arm was never populated by any pipeline; released arm64 client
+    # tarballs live on the downloads site with an -aarch64 suffix.
+    tarball_url=https://downloads.percona.com/downloads/pmm3/${version}/binary/tarball/pmm-client-${version}-aarch64.tar.gz
 elif [[ "$architecture" == "amd64" ]]; then
     tarball_url=https://downloads.percona.com/downloads/TESTING/pmm/${client_tar}
 fi


### PR DESCRIPTION
The arm64 branch of the script downloads the previous client version from downloads.percona.com/downloads/TESTING/pmm-arm/, but nothing has ever uploaded tarballs there, so every package upgrade test on aarch64 dies with a 404 before it gets to do anything.

Released arm64 client tarballs do exist on the downloads site with an -aarch64 suffix (checked 3.7.1, 3.8.0 and 3.8.1), so the script uses those now. The amd64 path is untouched.

Found while running the pmm3 package upgrade tests against an arm64 staging server.

Side note for whoever owns the repo-push job: both arch tarballs land in TESTING/pmm/ under the same file name (pmm-client-VER.tar.gz), so amd64 and arm64 overwrite each other there on every RC. Worth fixing separately.