### PR TITLE
Stabilize PMM-T269 QAN and PMM-T1565 nightly dashboard tests

### DIFF
--- a/codeceptjs-e2e/tests/QAN/common_test.js
+++ b/codeceptjs-e2e/tests/QAN/common_test.js
@@ -8,14 +8,14 @@ Before(async ({ I, queryAnalyticsPage }) => {
 });
 
 Scenario('PMM-T269 - Verify QAN UI Elements are displayed @qan', async ({ I, queryAnalyticsPage }) => {
-  queryAnalyticsPage.waitForLoaded();
-  I.waitForVisible(queryAnalyticsPage.buttons.addColumnButton, 30);
+  await queryAnalyticsPage.waitForLoaded();
+  await I.waitForVisible(queryAnalyticsPage.buttons.addColumnButton, 30);
   await queryAnalyticsPage.data.verifyRowCount(26);
   await queryAnalyticsPage.data.verifyPagesAndCount(25);
 
   for await (const filter of queryAnalyticsPage.filters.labels.filterGroups) {
-    I.wait(5);
-    I.waitForElement(queryAnalyticsPage.filters.fields.filterCheckBoxesInGroup(filter), 10);
+    await I.wait(5);
+    await I.waitForElement(queryAnalyticsPage.filters.fields.filterCheckBoxesInGroup(filter), 10);
     const countFilters = await I.grabNumberOfVisibleElements(queryAnalyticsPage.filters.fields.filterCheckBoxesInGroup(filter));
     const randomFilterValue = Math.floor(Math.random() * countFilters) + 1;
 
@@ -24,8 +24,9 @@ Scenario('PMM-T269 - Verify QAN UI Elements are displayed @qan', async ({ I, que
     await queryAnalyticsPage.filters.selectFilterInGroupAtPosition(filter, randomFilterValue);
   }
 
-  queryAnalyticsPage.filters.selectFilter('pmm-server');
-  I.wait(3);
+  await queryAnalyticsPage.waitForLoaded();
+  await queryAnalyticsPage.filters.selectFilter('pmm-server');
+  await I.wait(3);
   const displayedServiceName = await I.grabTextFrom(queryAnalyticsPage.filters.fields.filterCheckBoxesInGroup('Service Name'));
 
   I.assertContain(

--- a/codeceptjs-e2e/tests/QAN/common_test.js
+++ b/codeceptjs-e2e/tests/QAN/common_test.js
@@ -25,6 +25,7 @@ Scenario('PMM-T269 - Verify QAN UI Elements are displayed @qan', async ({ I, que
   }
 
   await queryAnalyticsPage.waitForLoaded();
+  await queryAnalyticsPage.filters.resetAllFilters();
   await queryAnalyticsPage.filters.selectFilter('pmm-server');
   await I.wait(3);
   const displayedServiceName = await I.grabTextFrom(queryAnalyticsPage.filters.fields.filterCheckBoxesInGroup('Service Name'));

--- a/codeceptjs-e2e/tests/pages/components/queryAnalytics/queryAnalyticsFilters.js
+++ b/codeceptjs-e2e/tests/pages/components/queryAnalytics/queryAnalyticsFilters.js
@@ -57,11 +57,14 @@ class QueryAnalyticsFilters {
   selectFilter(filterName, timeout = 30000) {
     I.waitForVisible(this.fields.filterBy, 30);
     I.usePlaywrightTo('Search and select QAN Filter', async ({ page }) => {
+      const filterInput = page.locator(this.fields.filterBy.value);
       const locator = page.locator(this.fields.filterByExactName(filterName).value).first();
 
-      await page.locator(this.fields.filterBy.value).fill(filterName);
-
-      await locator.waitFor({ state: 'attached', timeout });
+      await filterInput.waitFor({ state: 'visible', timeout });
+      await filterInput.fill(filterName);
+      await new Promise((resolve) => { setTimeout(resolve, 300); });
+      await locator.waitFor({ state: 'visible', timeout });
+      await locator.scrollIntoViewIfNeeded();
       await locator.click();
     });
     queryAnalyticsPage.waitForLoaded();
@@ -102,11 +105,13 @@ class QueryAnalyticsFilters {
 
   selectFilterInGroupAtPosition(groupName, position) {
     I.usePlaywrightTo('Select QAN Filter', async ({ page }) => {
-      const locator = await page.locator(this.fields.filterCheckBoxesInGroup(groupName).value);
+      const item = page.locator(this.fields.filterCheckBoxesInGroup(groupName).value).nth(position - 1);
 
-      await locator.nth(position - 1).waitFor({ state: 'attached' });
-      await locator.nth(position - 1).click();
+      await item.waitFor({ state: 'visible' });
+      await item.scrollIntoViewIfNeeded();
+      await item.click();
     });
+    queryAnalyticsPage.waitForLoaded();
   }
 
   selectContainFilter(filterName) {

--- a/codeceptjs-e2e/tests/pages/components/queryAnalytics/queryAnalyticsFilters.js
+++ b/codeceptjs-e2e/tests/pages/components/queryAnalytics/queryAnalyticsFilters.js
@@ -58,12 +58,22 @@ class QueryAnalyticsFilters {
     I.waitForVisible(this.fields.filterBy, 30);
     I.usePlaywrightTo('Search and select QAN Filter', async ({ page }) => {
       const filterInput = page.locator(this.fields.filterBy.value);
-      const locator = page.locator(this.fields.filterByExactName(filterName).value).first();
+      const exactLocator = page.locator(this.fields.filterByExactName(filterName).value).first();
+      const containLocator = page.locator(this.fields.filterByName(filterName).value).first();
 
       await filterInput.waitFor({ state: 'visible', timeout });
       await filterInput.fill(filterName);
       await new Promise((resolve) => { setTimeout(resolve, 300); });
-      await locator.waitFor({ state: 'visible', timeout });
+
+      let locator = exactLocator;
+
+      try {
+        await exactLocator.waitFor({ state: 'visible', timeout: 3000 });
+      } catch (error) {
+        locator = containLocator;
+        await locator.waitFor({ state: 'visible', timeout });
+      }
+
       await locator.scrollIntoViewIfNeeded();
       await locator.click();
     });
@@ -80,6 +90,7 @@ class QueryAnalyticsFilters {
       await locator.waitFor({ state: 'attached' });
       await locator.click();
     });
+    queryAnalyticsPage.waitForLoaded();
   }
 
   selectFilterInGroup(filterName, groupName) {

--- a/codeceptjs-e2e/tests/pages/dashboardPage.js
+++ b/codeceptjs-e2e/tests/pages/dashboardPage.js
@@ -1372,9 +1372,15 @@ module.exports = {
     let maxTries = 20;
 
     while (collapsedRows > 0 && maxTries > 0) {
-      I.pressKey('End');
-      I.click(locate(this.fields.collapsedDashboardRow).first());
-      I.wait(1);
+      await I.pressKey('End');
+      I.usePlaywrightTo('Expand collapsed dashboard row', async ({ page }) => {
+        const locator = page.locator(this.fields.collapsedDashboardRow).first();
+
+        await locator.scrollIntoViewIfNeeded();
+        await locator.waitFor({ state: 'visible', timeout: 10000 });
+        await locator.click({ force: true });
+      });
+      await I.wait(1);
       collapsedRows = await I.grabNumberOfVisibleElements(this.fields.collapsedDashboardRow);
       // eslint-disable-next-line no-plusplus
       maxTries--; // eslint-disable-line no-plusplus

--- a/codeceptjs-e2e/tests/pages/dashboardPage.js
+++ b/codeceptjs-e2e/tests/pages/dashboardPage.js
@@ -1196,19 +1196,19 @@ module.exports = {
     await adminPage.performPageDown(5);
     I.waitForElement(this.graphsLocator(metrics[0]), 60);
     for (const i in metrics) {
-      I.pressKey('PageDown');
+      await I.pressKey('PageDown');
       await this.expandEachDashboardRow();
-      I.waitForElement(this.graphsLocator(metrics[i]), 5);
       I.scrollTo(this.graphsLocator(metrics[i]));
+      I.waitForElement(this.graphsLocator(metrics[i]), 30);
     }
   },
 
   async verifyMetricsExistencePartialMatch(metrics) {
     for (const i in metrics) {
-      I.pressKey('PageDown');
+      await I.pressKey('PageDown');
       await this.expandEachDashboardRow();
-      I.waitForElement(this.graphsLocatorPartialMatch(metrics[i]), 5);
       I.scrollTo(this.graphsLocatorPartialMatch(metrics[i]));
+      I.waitForElement(this.graphsLocatorPartialMatch(metrics[i]), 30);
     }
   },
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stability fixes for flaky CodeceptJS tests PMM-T269 (`@qan`) and PMM-T1565 (`@nightly`), without changing test expectations.

### PMM-T269 root cause (run 29421841331)
The failure was **not** a timing flake. `selectFilter('pmm-server')` waits for exact `filter-checkbox-pmm-server`, but the PMM server postgres service is registered as **`pmm-server-postgresql`**. The assertion already allows this (`assertContain(..., 'pmm-server')`).

**Fix:**
- `selectFilter()` tries exact match first (3s), then falls back to contains match (`filter-checkbox-pmm-server*`)
- Reset all filters before the final `pmm-server` step to clear state from the filter-group loop
- Earlier timing/await hardening retained

### PMM-T1565
- `expandEachDashboardRow()` scrolls into view, waits for visibility, force-clicks inside Grafana iframe
- Verified passing on staging locally (36s)

## Verification
- Staging CodeceptJS: PMM-T1565 Disk Space Total variant **passed**
- Nightly run 29421841331: QAN shard failed only on PMM-T269 (same selector); `@nightly` shard still running at time of fix

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://perconacorp.slack.com/archives/C07RY25R4EA/p1784098407109049?thread_ts=1784098407.109049&cid=C07RY25R4EA)

<div><a href="https://cursor.com/agents/bc-f94708b7-192b-5561-a88c-402c083812ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f94708b7-192b-5561-a88c-402c083812ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

