### PR TITLE
Use version-aligned pmm-qa branch for RC compatibility CLI tests

### DIFF
--- a/.github/workflows/rc-testing-suite.yml
+++ b/.github/workflows/rc-testing-suite.yml
@@ -68,7 +68,7 @@ jobs:
             echo '::error::pmm-version-getter returned no GA tags for compatibility (check Docker Hub).'
             exit 1
           fi
-          compat_matrix_json="$(echo "$VERSIONS_JSON" | jq 'map({version: ., image: ("percona/pmm-client:" + .)})')"
+          compat_matrix_json="$(echo "$VERSIONS_JSON" | jq 'map({version: ., image: ("percona/pmm-client:" + .), pmm_qa_branch: ("pmm-" + .)})')"
           {
             echo "compat_matrix<<__COMPAT_MATRIX_EOF__"
             echo "$compat_matrix_json"
@@ -99,7 +99,7 @@ jobs:
     secrets:
       LAUNCHABLE_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN }}
     with:
-      pmm_qa_branch: ${{ inputs.pmm_qa_branch }}
+      pmm_qa_branch: ${{ matrix.pmm_qa_branch }}
       pmm_server_image: 'perconalab/pmm-server:${{ inputs.rc_version }}-rc'
       pmm_client_image: ${{ matrix.image }}
       pmm_client_version: ${{ matrix.version }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In `rc-testing-suite.yml`, backward-compatibility CLI jobs were always using the workflow-level `pmm_qa_branch` input (default `main`), even though each matrix entry exercises a different GA `percona/pmm-client` version.

This change maps each compatibility matrix entry to the matching `pmm-<version>` branch in `percona/pmm-qa` (for example, client `3.6.0` → branch `pmm-3.6.0`).

## Changes

- Extend the compatibility matrix built in the `plan` job with `pmm_qa_branch: "pmm-<version>"`.
- Pass `matrix.pmm_qa_branch` to `integration-cli-tests.yml` from `compatibility_integration_tests`.

Other RC jobs (current RC CLI, E2E, Helm, GSSAPI, qa-integration) continue to use `inputs.pmm_qa_branch` unchanged.

## Why

CLI compatibility coverage is version-specific. Running older client tags against `main` can pull test/setup changes that did not exist for that release, causing false failures or masking real regressions.

## Test plan

- [ ] Dispatch `RC Testing Suite` with `skip_compatibility=false` and confirm each `Compatibility CLI (<version>)` job checks out `pmm-<version>`.
- [ ] Verify non-compatibility jobs still honor the `pmm_qa_branch` workflow input.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a544572d-639a-4858-873f-732e04e31a1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a544572d-639a-4858-873f-732e04e31a1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

