### PR TITLE
Fix RBAC test dashboard graph verification

### DIFF
--- a/codeceptjs-e2e/tests/configuration/verifyRoleBasedAccessControl_test.js
+++ b/codeceptjs-e2e/tests/configuration/verifyRoleBasedAccessControl_test.js
@@ -70,7 +70,7 @@ Scenario(
     dashboardPage.waitForDashboardOpened();
     await dashboardPage.expandEachDashboardRow();
     dashboardPage.waitForDashboardOpened();
-    await dashboardPage.verifyThereAreNoGraphsWithoutData(4);
+    await dashboardPage.waitForGraphsToHaveData(5);
 
     I.amOnPage(I.buildUrlWithParams(dashboardPage.postgresqlInstanceSummaryDashboard.url, dashboardTimeRange));
     dashboardPage.waitForDashboardOpened();
@@ -92,7 +92,7 @@ Scenario(
     dashboardPage.waitForDashboardOpened();
     await dashboardPage.expandEachDashboardRow();
     dashboardPage.waitForDashboardOpened();
-    await dashboardPage.verifyThereAreNoGraphsWithoutData(2);
+    await dashboardPage.waitForGraphsToHaveData(3);
 
     await I.unAuthorize();
 


### PR DESCRIPTION
Replace verifyThereAreNoGraphsWithoutData with waitForGraphsToHaveData method and adjust expected graph counts. The new method provides better reliability for waiting on graph data to populate, addressing flakiness in the role-based access control test scenario.