### PR TITLE
ci: cancel in-progress E2E matrix runs on the same PR branch

### DIFF
--- a/.github/workflows/e2e-tests-matrix.yml
+++ b/.github/workflows/e2e-tests-matrix.yml
@@ -1,5 +1,9 @@
 name: "E2E tests Matrix"
 
+concurrency:
+  group: e2e-tests-${{ github.event_name == 'pull_request' && github.head_ref || (github.event.inputs.pmm_qa_branch || github.ref_name) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
## Why

Every push to a PR branch triggers the full 30-job E2E tests matrix (~30 min). Rapid iteration (e.g. dependency fix attempts) spawns parallel matrix runs with no cancellation, wasting CI minutes.

## How

Add a `concurrency` group to `e2e-tests-matrix.yml` keyed by the target branch name. `cancel-in-progress` is enabled only for `pull_request` events, so:

- **PR branches**: new push cancels the in-progress matrix run
- **main** (schedule / manual dispatch): runs are not cancelled — RC testing and nightly jobs can overlap as before
- **Different branches**: run in parallel (separate concurrency groups)