### PR TITLE
Set Playwright E2E workers default to 1 in CI

### DIFF
--- a/.github/workflows/runner-e2e-tests-playwright.yml
+++ b/.github/workflows/runner-e2e-tests-playwright.yml
@@ -32,7 +32,7 @@ on:
       workers:
         description: 'Number of workers for Playwright tests'
         type: number
-        default: 4
+        default: 1
         required: false
       launchable_confidence:
         description: 'Launchable subset confidence percentage'
@@ -90,7 +90,7 @@ jobs:
       ZEPHYR_PMM_API_KEY: ${{ secrets.ZEPHYR_PMM_API_KEY }}
       LAUNCHABLE_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN }}
       ADMIN_PASSWORD: 'admin-password'
-      WORKERS: ${{ inputs.workers || 4 }}
+      WORKERS: ${{ inputs.workers || 1 }}
       LAUNCHABLE_CONFIDENCE: ${{ inputs.launchable_confidence || github.event.inputs.launchable_confidence || '100%' }}
       SUBSET_FILE_NAME: 'launchable-subset.txt'
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the Playwright E2E worker default with the existing `e2e_tests/playwright.config.ts` setting.

- `e2e_tests/playwright.config.ts` already uses `workers: Number(process.env.WORKERS) || 1`
- `cli/playwright.config.ts` already sets `workers: 1`
- `runner-e2e-tests-playwright.yml` was still defaulting to **4** workers via `WORKERS: ${{ inputs.workers || 4 }}` and a `workflow_dispatch` input default of `4`

## Changes

- Set `workflow_dispatch` `workers` input default from `4` to `1`
- Set CI env fallback from `inputs.workers || 4` to `inputs.workers || 1`

Jobs that explicitly pass `workers: 1` (e.g. FB suite, nightly matrix) are unchanged. Callers can still override workers when needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://perconacorp.slack.com/archives/D0BB61LPPPX/p1784725091650579?thread_ts=1784725091.650579&cid=D0BB61LPPPX)

<div><a href="https://cursor.com/agents/bc-a71e0237-db02-5655-80f1-4128c841cbd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a71e0237-db02-5655-80f1-4128c841cbd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

