### PR TITLE
Increase job timeout for RC testing queue wait

### DIFF
--- a/.github/workflows/PMM_PDPGSQL.yaml
+++ b/.github/workflows/PMM_PDPGSQL.yaml
@@ -42,7 +42,7 @@ on:
 jobs:
   PMM_PDPGSQL_TEST:
     runs-on: ubuntu-22.04
-    timeout-minutes: 40
+    timeout-minutes: ${{ contains(inputs.pmm_server_image, '-rc') && 120 || 40 }}
     env:
       ADMIN_PASSWORD: 'admin'
       PDPGSQL_VERSION: ${{ inputs.pdpgsql_version || '17' }}

--- a/.github/workflows/PMM_PDPGSQL.yaml
+++ b/.github/workflows/PMM_PDPGSQL.yaml
@@ -42,7 +42,7 @@ on:
 jobs:
   PMM_PDPGSQL_TEST:
     runs-on: ubuntu-22.04
-    timeout-minutes: ${{ contains(inputs.pmm_server_image, '-rc') && 120 || 40 }}
+    timeout-minutes: 40
     env:
       ADMIN_PASSWORD: 'admin'
       PDPGSQL_VERSION: ${{ inputs.pdpgsql_version || '17' }}

--- a/.github/workflows/PMM_PDPGSQL.yaml
+++ b/.github/workflows/PMM_PDPGSQL.yaml
@@ -38,11 +38,14 @@ on:
       pmm_client_version:
         required: false
         type: string
+      job_timeout_minutes:
+        required: false
+        type: number
 
 jobs:
   PMM_PDPGSQL_TEST:
     runs-on: ubuntu-22.04
-    timeout-minutes: 40
+    timeout-minutes: ${{ inputs.job_timeout_minutes || 40 }}
     env:
       ADMIN_PASSWORD: 'admin'
       PDPGSQL_VERSION: ${{ inputs.pdpgsql_version || '17' }}

--- a/.github/workflows/PMM_PROXYSQL.yaml
+++ b/.github/workflows/PMM_PROXYSQL.yaml
@@ -46,11 +46,14 @@ on:
       pmm_client_version:
         required: false
         type: string
+      job_timeout_minutes:
+        required: false
+        type: number
 
 jobs:
   PMM_PXC_TEST:
     runs-on: ubuntu-22.04
-    timeout-minutes: 40
+    timeout-minutes: ${{ inputs.job_timeout_minutes || 40 }}
     env:
       ADMIN_PASSWORD: 'admin'
       PXC_VERSION: ${{ inputs.pxc_version || '8.0' }}

--- a/.github/workflows/PMM_PROXYSQL.yaml
+++ b/.github/workflows/PMM_PROXYSQL.yaml
@@ -50,7 +50,7 @@ on:
 jobs:
   PMM_PXC_TEST:
     runs-on: ubuntu-22.04
-    timeout-minutes: ${{ contains(inputs.pmm_server_image, '-rc') && 120 || 40 }}
+    timeout-minutes: 40
     env:
       ADMIN_PASSWORD: 'admin'
       PXC_VERSION: ${{ inputs.pxc_version || '8.0' }}

--- a/.github/workflows/PMM_PROXYSQL.yaml
+++ b/.github/workflows/PMM_PROXYSQL.yaml
@@ -50,7 +50,7 @@ on:
 jobs:
   PMM_PXC_TEST:
     runs-on: ubuntu-22.04
-    timeout-minutes: 40
+    timeout-minutes: ${{ contains(inputs.pmm_server_image, '-rc') && 120 || 40 }}
     env:
       ADMIN_PASSWORD: 'admin'
       PXC_VERSION: ${{ inputs.pxc_version || '8.0' }}

--- a/.github/workflows/PMM_PSMDB_PBM_FULL.yml
+++ b/.github/workflows/PMM_PSMDB_PBM_FULL.yml
@@ -30,11 +30,14 @@ on:
       pmm_server_image:
         required: false
         type: string
+      job_timeout_minutes:
+        required: false
+        type: number
 
 jobs:
   test_replica_set:
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.job_timeout_minutes || 20 }}
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +56,7 @@ jobs:
 
   test_sharded_cluster:
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.job_timeout_minutes || 20 }}
     strategy:
       fail-fast: false
       matrix:
@@ -72,7 +75,7 @@ jobs:
 
   test_diff_auth:
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.job_timeout_minutes || 20 }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/PMM_PSMDB_PBM_FULL.yml
+++ b/.github/workflows/PMM_PSMDB_PBM_FULL.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   test_replica_set:
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: ${{ contains(inputs.pmm_server_image, '-rc') && 120 || 20 }}
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +53,7 @@ jobs:
 
   test_sharded_cluster:
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: ${{ contains(inputs.pmm_server_image, '-rc') && 120 || 20 }}
     strategy:
       fail-fast: false
       matrix:
@@ -72,7 +72,7 @@ jobs:
 
   test_diff_auth:
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: ${{ contains(inputs.pmm_server_image, '-rc') && 120 || 20 }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/PMM_PSMDB_PBM_FULL.yml
+++ b/.github/workflows/PMM_PSMDB_PBM_FULL.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   test_replica_set:
     runs-on: ubuntu-22.04
-    timeout-minutes: ${{ contains(inputs.pmm_server_image, '-rc') && 120 || 20 }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +53,7 @@ jobs:
 
   test_sharded_cluster:
     runs-on: ubuntu-22.04
-    timeout-minutes: ${{ contains(inputs.pmm_server_image, '-rc') && 120 || 20 }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -72,7 +72,7 @@ jobs:
 
   test_diff_auth:
     runs-on: ubuntu-22.04
-    timeout-minutes: ${{ contains(inputs.pmm_server_image, '-rc') && 120 || 20 }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-tests-matrix.yml
+++ b/.github/workflows/e2e-tests-matrix.yml
@@ -70,7 +70,7 @@ jobs:
       pmm_client_image: ${{ inputs.pmm_client_image || github.event.inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha || github.event.inputs.sha ||  'null' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database pgsql'
       tags_for_tests: '@settings|@cli'
 
@@ -84,7 +84,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version || github.event.inputs.pmm_client_version || 'latest-tarball' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha || github.event.inputs.sha ||  'null' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database ssl_mysql'
       tags_for_tests: '@ssl-mysql'
 
@@ -98,7 +98,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version || github.event.inputs.pmm_client_version || 'latest-tarball' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha || github.event.inputs.sha ||  'null' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database ssl_psmdb'
       tags_for_tests: '@ssl-mongo'
 
@@ -112,7 +112,7 @@ jobs:
       pmm_client_image: ${{ inputs.pmm_client_image || github.event.inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha || github.event.inputs.sha ||  'null' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database ssl_pdpgsql=16'
       tags_for_tests: '@ssl-postgres'
 
@@ -126,7 +126,7 @@ jobs:
       pmm_client_image: ${{ inputs.pmm_client_image || github.event.inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha || github.event.inputs.sha ||  'null' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--help'
       tags_for_tests: '@disconnect'
 
@@ -139,7 +139,7 @@ jobs:
       pmm_server_version: ${{ inputs.pmm_server_image || github.event.inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || github.event.inputs.pmm_client_version || 'latest-tarball' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database haproxy --database ps --database pxc'
       pmm_test_flag: '@pmm-ps-pxc-haproxy-integration'
 
@@ -152,7 +152,7 @@ jobs:
       pmm_server_version: ${{ inputs.pmm_server_image || github.event.inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || github.event.inputs.pmm_client_version || 'latest-tarball' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database ps=8.4 --database psmdb --database valkey'
       pmm_test_flag: '@new-navigation'
 
@@ -177,7 +177,7 @@ jobs:
       pmm_server_version: ${{ inputs.pmm_server_image || github.event.inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || github.event.inputs.pmm_client_version || 'latest-tarball' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database pdpgsql'
       pmm_test_flag: '@inventory|@image-renderer'
 
@@ -190,7 +190,7 @@ jobs:
       pmm_server_version: ${{ inputs.pmm_server_image || github.event.inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || github.event.inputs.pmm_client_version || 'latest-tarball' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database ps=8.4 --database psmdb --database pdpgsql'
       pmm_test_flag: '@LBAC'
 
@@ -204,5 +204,5 @@ jobs:
       pmm_client_image: ${{ inputs.pmm_client_image || github.event.inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
 

--- a/.github/workflows/e2e-tests-matrix.yml
+++ b/.github/workflows/e2e-tests-matrix.yml
@@ -55,6 +55,9 @@ on:
       sha:
         required: false
         type: string
+      job_timeout_minutes:
+        required: false
+        type: number
 
 jobs:
   settings_and_cli:
@@ -67,6 +70,7 @@ jobs:
       pmm_client_image: ${{ inputs.pmm_client_image || github.event.inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha || github.event.inputs.sha ||  'null' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database pgsql'
       tags_for_tests: '@settings|@cli'
 
@@ -80,6 +84,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version || github.event.inputs.pmm_client_version || 'latest-tarball' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha || github.event.inputs.sha ||  'null' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database ssl_mysql'
       tags_for_tests: '@ssl-mysql'
 
@@ -93,6 +98,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version || github.event.inputs.pmm_client_version || 'latest-tarball' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha || github.event.inputs.sha ||  'null' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database ssl_psmdb'
       tags_for_tests: '@ssl-mongo'
 
@@ -106,6 +112,7 @@ jobs:
       pmm_client_image: ${{ inputs.pmm_client_image || github.event.inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha || github.event.inputs.sha ||  'null' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database ssl_pdpgsql=16'
       tags_for_tests: '@ssl-postgres'
 
@@ -119,6 +126,7 @@ jobs:
       pmm_client_image: ${{ inputs.pmm_client_image || github.event.inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha || github.event.inputs.sha ||  'null' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--help'
       tags_for_tests: '@disconnect'
 
@@ -131,6 +139,7 @@ jobs:
       pmm_server_version: ${{ inputs.pmm_server_image || github.event.inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || github.event.inputs.pmm_client_version || 'latest-tarball' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database haproxy --database ps --database pxc'
       pmm_test_flag: '@pmm-ps-pxc-haproxy-integration'
 
@@ -143,6 +152,7 @@ jobs:
       pmm_server_version: ${{ inputs.pmm_server_image || github.event.inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || github.event.inputs.pmm_client_version || 'latest-tarball' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database ps=8.4 --database psmdb --database valkey'
       pmm_test_flag: '@new-navigation'
 
@@ -167,6 +177,7 @@ jobs:
       pmm_server_version: ${{ inputs.pmm_server_image || github.event.inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || github.event.inputs.pmm_client_version || 'latest-tarball' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database pdpgsql'
       pmm_test_flag: '@inventory|@image-renderer'
 
@@ -179,6 +190,7 @@ jobs:
       pmm_server_version: ${{ inputs.pmm_server_image || github.event.inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || github.event.inputs.pmm_client_version || 'latest-tarball' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database ps=8.4 --database psmdb --database pdpgsql'
       pmm_test_flag: '@LBAC'
 
@@ -192,4 +204,5 @@ jobs:
       pmm_client_image: ${{ inputs.pmm_client_image || github.event.inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
 

--- a/.github/workflows/fb-e2e-suite.yml
+++ b/.github/workflows/fb-e2e-suite.yml
@@ -74,7 +74,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
 #      setup_services: '--database psmdb,SETUP_TYPE=pss'
       setup_services: '--database psmdb,SETUP_TYPE=pss,COMPOSE_PROFILES=extra'
       tags_for_tests: '@bm-mongo'
@@ -105,7 +105,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database psmdb,SETUP_TYPE=pss'
       #      tags_for_tests: '@bm-common|@bm-locations' -- include bm-common once setup for mysql fixed
@@ -122,7 +122,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps,QUERY_SOURCE=slowlog'
       tags_for_tests: '@exporters'
@@ -138,7 +138,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database psmdb'
       tags_for_tests: '@mongodb-exporter'
@@ -154,7 +154,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps --database external --database haproxy'
       tags_for_tests: '@fb-instances'
@@ -170,7 +170,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database mysql'
       tags_for_tests: '@fb-alerting|@fb-settings'
@@ -199,7 +199,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps --database psmdb --database pdpgsql'
       tags_for_tests: '@user-password'
@@ -215,7 +215,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database pdpgsql'
       tags_for_tests: '@pgsm-pmm-integration'
@@ -231,7 +231,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database pgsql'
       tags_for_tests: '@pgss-pmm-integration'
@@ -262,7 +262,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database psmdb,SETUP_TYPE=pss'
       tags_for_tests: '@pmm-psmdb-replica-integration'
@@ -277,7 +277,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps --database psmdb'
       tags_for_tests: '@user-password'
@@ -293,7 +293,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps'
       tags_for_tests: '@dump'
@@ -309,7 +309,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps=8.0'
       tags_for_tests: '@service-account'
@@ -325,7 +325,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database psmdb,SETUP_TYPE=psa'
       tags_for_tests: '@pmm-psmdb-arbiter-integration'
@@ -354,7 +354,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps --database pdpgsql'
       tags_for_tests: '@rbac'
@@ -370,7 +370,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps=8.0'
       tags_for_tests: '@fb-encryption'
@@ -386,7 +386,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '-h'
       tags_for_tests: '@docker-configuration'
@@ -415,7 +415,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps=8.4 --database pdpgsql --database psmdb'
       tags_for_tests: '@nomad'

--- a/.github/workflows/fb-e2e-suite.yml
+++ b/.github/workflows/fb-e2e-suite.yml
@@ -90,7 +90,6 @@ jobs:
 #      pmm_client_version: ${{ inputs.pmm_client_version || 'dev-latest' }}
 #      pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:dev-latest' }}
 #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
 ###      sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
 #      setup_services: '--mongo-replica-for-backup --setup-bm-mysql'
 #      tags_for_tests: '@bm-mysql'

--- a/.github/workflows/fb-e2e-suite.yml
+++ b/.github/workflows/fb-e2e-suite.yml
@@ -54,6 +54,9 @@ on:
       sha:
         required: false
         type: string
+      job_timeout_minutes:
+        required: false
+        type: number
 
     secrets:
       LAUNCHABLE_TOKEN:
@@ -71,6 +74,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
 #      setup_services: '--database psmdb,SETUP_TYPE=pss'
       setup_services: '--database psmdb,SETUP_TYPE=pss,COMPOSE_PROFILES=extra'
       tags_for_tests: '@bm-mongo'
@@ -86,6 +90,7 @@ jobs:
 #      pmm_client_version: ${{ inputs.pmm_client_version || 'dev-latest' }}
 #      pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:dev-latest' }}
 #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
 ###      sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
 #      setup_services: '--mongo-replica-for-backup --setup-bm-mysql'
 #      tags_for_tests: '@bm-mysql'
@@ -101,6 +106,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database psmdb,SETUP_TYPE=pss'
       #      tags_for_tests: '@bm-common|@bm-locations' -- include bm-common once setup for mysql fixed
@@ -117,6 +123,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps,QUERY_SOURCE=slowlog'
       tags_for_tests: '@exporters'
@@ -132,6 +139,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database psmdb'
       tags_for_tests: '@mongodb-exporter'
@@ -147,6 +155,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps --database external --database haproxy'
       tags_for_tests: '@fb-instances'
@@ -162,6 +171,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database mysql'
       tags_for_tests: '@fb-alerting|@fb-settings'
@@ -190,6 +200,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps --database psmdb --database pdpgsql'
       tags_for_tests: '@user-password'
@@ -205,6 +216,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database pdpgsql'
       tags_for_tests: '@pgsm-pmm-integration'
@@ -220,6 +232,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database pgsql'
       tags_for_tests: '@pgss-pmm-integration'
@@ -250,6 +263,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database psmdb,SETUP_TYPE=pss'
       tags_for_tests: '@pmm-psmdb-replica-integration'
@@ -264,6 +278,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps --database psmdb'
       tags_for_tests: '@user-password'
@@ -279,6 +294,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps'
       tags_for_tests: '@dump'
@@ -294,6 +310,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps=8.0'
       tags_for_tests: '@service-account'
@@ -309,6 +326,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database psmdb,SETUP_TYPE=psa'
       tags_for_tests: '@pmm-psmdb-arbiter-integration'
@@ -337,6 +355,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps --database pdpgsql'
       tags_for_tests: '@rbac'
@@ -352,6 +371,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps=8.0'
       tags_for_tests: '@fb-encryption'
@@ -367,6 +387,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '-h'
       tags_for_tests: '@docker-configuration'
@@ -395,6 +416,7 @@ jobs:
       launchable_confidence: ${{ inputs.launchable_confidence || '100%' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       setup_services: '--database ps=8.4 --database pdpgsql --database psmdb'
       tags_for_tests: '@nomad'

--- a/.github/workflows/gssapi-psmdb-tests-matrix.yml
+++ b/.github/workflows/gssapi-psmdb-tests-matrix.yml
@@ -89,7 +89,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version_ol8 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol8-latest.tar.gz' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database psmdb,COMPOSE_PROFILES=extra,OL_VERSION=8,GSSAPI=true'
       tags_for_tests: '@bm-mongo'
 
@@ -102,7 +102,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version_ol9 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database psmdb,COMPOSE_PROFILES=extra,OL_VERSION=9,GSSAPI=true'
       tags_for_tests: '@bm-mongo'
 
@@ -115,7 +115,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version_ol8 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol8-latest.tar.gz' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database psmdb,OL_VERSION=8,GSSAPI=true'
       tags_for_tests: '@mongodb-exporter'
 
@@ -128,7 +128,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version_ol9 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database psmdb,OL_VERSION=9,GSSAPI=true'
       tags_for_tests: '@mongodb-exporter'
 
@@ -141,7 +141,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version_ol8 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol8-latest.tar.gz' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database psmdb,OL_VERSION=8,GSSAPI=true'
       tags_for_tests: '@pmm-psmdb-replica-integration'
 
@@ -154,7 +154,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version_ol9 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database psmdb,OL_VERSION=9,GSSAPI=true'
       tags_for_tests: '@pmm-psmdb-replica-integration'
 
@@ -166,7 +166,7 @@ jobs:
       pmm_server_version: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol8 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol8-latest.tar.gz' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database psmdb,OL_VERSION=8,GSSAPI=true'
       pmm_test_flag: '@rta'
       workers: 1
@@ -179,7 +179,7 @@ jobs:
       pmm_server_version: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol9 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       setup_services: '--database psmdb,OL_VERSION=9,GSSAPI=true'
       pmm_test_flag: '@rta'
       workers: 1
@@ -192,7 +192,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol8 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol8-latest.tar.gz' }}
@@ -207,7 +207,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol8 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol8-latest.tar.gz' }}
@@ -222,7 +222,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol8 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol8-latest.tar.gz' }}
@@ -237,7 +237,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol9 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz' }}
@@ -252,7 +252,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol9 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz' }}
@@ -267,7 +267,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol9 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz' }}
@@ -287,7 +287,7 @@ jobs:
       repository: ${{ inputs.repository || 'release'}}
       metrics_mode: "auto"
       package: "pmm3-client"
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       os: "ol-8"
 
   mongo_package_tests_integration_ol9:
@@ -302,5 +302,5 @@ jobs:
       repository: ${{ inputs.repository || 'release'}}
       metrics_mode: "auto"
       package: "pmm3-client"
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       os: "ol-9"

--- a/.github/workflows/gssapi-psmdb-tests-matrix.yml
+++ b/.github/workflows/gssapi-psmdb-tests-matrix.yml
@@ -75,6 +75,9 @@ on:
       sha:
         required: false
         type: string
+      job_timeout_minutes:
+        required: false
+        type: number
 
 jobs:
   mongo_bm_ol8:
@@ -86,6 +89,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version_ol8 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol8-latest.tar.gz' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database psmdb,COMPOSE_PROFILES=extra,OL_VERSION=8,GSSAPI=true'
       tags_for_tests: '@bm-mongo'
 
@@ -98,6 +102,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version_ol9 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database psmdb,COMPOSE_PROFILES=extra,OL_VERSION=9,GSSAPI=true'
       tags_for_tests: '@bm-mongo'
 
@@ -110,6 +115,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version_ol8 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol8-latest.tar.gz' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database psmdb,OL_VERSION=8,GSSAPI=true'
       tags_for_tests: '@mongodb-exporter'
 
@@ -122,6 +128,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version_ol9 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database psmdb,OL_VERSION=9,GSSAPI=true'
       tags_for_tests: '@mongodb-exporter'
 
@@ -134,6 +141,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version_ol8 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol8-latest.tar.gz' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database psmdb,OL_VERSION=8,GSSAPI=true'
       tags_for_tests: '@pmm-psmdb-replica-integration'
 
@@ -146,6 +154,7 @@ jobs:
       pmm_client_version: ${{ inputs.pmm_client_version_ol9 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database psmdb,OL_VERSION=9,GSSAPI=true'
       tags_for_tests: '@pmm-psmdb-replica-integration'
 
@@ -157,6 +166,7 @@ jobs:
       pmm_server_version: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol8 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol8-latest.tar.gz' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database psmdb,OL_VERSION=8,GSSAPI=true'
       pmm_test_flag: '@rta'
       workers: 1
@@ -169,6 +179,7 @@ jobs:
       pmm_server_version: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol9 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       setup_services: '--database psmdb,OL_VERSION=9,GSSAPI=true'
       pmm_test_flag: '@rta'
       workers: 1
@@ -181,6 +192,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol8 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol8-latest.tar.gz' }}
@@ -195,6 +207,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol8 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol8-latest.tar.gz' }}
@@ -209,6 +222,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol8 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol8-latest.tar.gz' }}
@@ -223,6 +237,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol9 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz' }}
@@ -237,6 +252,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol9 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz' }}
@@ -251,6 +267,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version_ol9 || 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz' }}
@@ -270,6 +287,7 @@ jobs:
       repository: ${{ inputs.repository || 'release'}}
       metrics_mode: "auto"
       package: "pmm3-client"
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       os: "ol-8"
 
   mongo_package_tests_integration_ol9:
@@ -284,4 +302,5 @@ jobs:
       repository: ${{ inputs.repository || 'release'}}
       metrics_mode: "auto"
       package: "pmm3-client"
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       os: "ol-9"

--- a/.github/workflows/integration-cli-tests.yml
+++ b/.github/workflows/integration-cli-tests.yml
@@ -77,7 +77,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -93,7 +93,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -109,7 +109,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -126,7 +126,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -143,7 +143,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -159,7 +159,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -176,7 +176,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -193,7 +193,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -210,7 +210,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -227,7 +227,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -244,7 +244,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -261,7 +261,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -278,7 +278,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -295,7 +295,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -312,7 +312,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -392,7 +392,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -409,7 +409,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -426,7 +426,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -443,7 +443,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -460,7 +460,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -477,7 +477,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -494,7 +494,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -511,7 +511,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -528,7 +528,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -545,7 +545,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes || 0 }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}

--- a/.github/workflows/integration-cli-tests.yml
+++ b/.github/workflows/integration-cli-tests.yml
@@ -56,6 +56,9 @@ on:
       sha:
         required: false
         type: string
+      job_timeout_minutes:
+        required: false
+        type: number
 
     secrets:
       LAUNCHABLE_TOKEN:
@@ -74,6 +77,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -89,6 +93,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -104,6 +109,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -120,6 +126,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -136,6 +143,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -151,6 +159,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -167,6 +176,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -183,6 +193,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -199,6 +210,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -215,6 +227,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -231,6 +244,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -247,6 +261,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -263,6 +278,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -279,6 +295,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -295,6 +312,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -311,7 +329,9 @@ jobs:
   #    with:
   #      sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:dev-latest' }}
   #      pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:dev-latest' }}
   #      pmm_client_version: ${{ inputs.pmm_client_version || 'dev-latest' }}
@@ -327,7 +347,9 @@ jobs:
   #    with:
   #      sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:dev-latest' }}
   #      pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:dev-latest' }}
   #      pmm_client_version: ${{ inputs.pmm_client_version || 'dev-latest' }}
@@ -343,7 +365,9 @@ jobs:
   #    with:
   #      sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:dev-latest' }}
   #      pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:dev-latest' }}
   #      pmm_client_version: ${{ inputs.pmm_client_version || 'dev-latest' }}
@@ -358,7 +382,9 @@ jobs:
   #    with:
   #      sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:dev-latest' }}
   #      pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:dev-latest' }}
   #      pmm_client_version: ${{ inputs.pmm_client_version || 'dev-latest' }}
@@ -374,6 +400,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -390,6 +417,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -406,6 +434,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -422,6 +451,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -438,6 +468,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -454,6 +485,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -470,6 +502,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -486,6 +519,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -502,6 +536,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}
@@ -518,6 +553,7 @@ jobs:
     with:
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
       pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || 'latest-tarball' }}

--- a/.github/workflows/integration-cli-tests.yml
+++ b/.github/workflows/integration-cli-tests.yml
@@ -329,9 +329,7 @@ jobs:
   #    with:
   #      sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:dev-latest' }}
   #      pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:dev-latest' }}
   #      pmm_client_version: ${{ inputs.pmm_client_version || 'dev-latest' }}
@@ -347,9 +345,7 @@ jobs:
   #    with:
   #      sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:dev-latest' }}
   #      pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:dev-latest' }}
   #      pmm_client_version: ${{ inputs.pmm_client_version || 'dev-latest' }}
@@ -365,9 +361,7 @@ jobs:
   #    with:
   #      sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:dev-latest' }}
   #      pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:dev-latest' }}
   #      pmm_client_version: ${{ inputs.pmm_client_version || 'dev-latest' }}
@@ -382,9 +376,7 @@ jobs:
   #    with:
   #      sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
-      job_timeout_minutes: ${{ inputs.job_timeout_minutes }}
   #      pmm_server_image: ${{ inputs.pmm_server_image || 'perconalab/pmm-server:dev-latest' }}
   #      pmm_client_image: ${{ inputs.pmm_client_image || 'perconalab/pmm-client:dev-latest' }}
   #      pmm_client_version: ${{ inputs.pmm_client_version || 'dev-latest' }}

--- a/.github/workflows/rc-testing-suite.yml
+++ b/.github/workflows/rc-testing-suite.yml
@@ -86,6 +86,7 @@ jobs:
       pmm_server_image: 'perconalab/pmm-server:${{ inputs.rc_version }}-rc'
       pmm_client_image: 'perconalab/pmm-client:${{ inputs.rc_version }}-rc'
       pmm_client_version: pmm3-rc
+      job_timeout_minutes: 120
 
   compatibility_integration_tests:
     if: ${{ !inputs.skip_compatibility }}
@@ -103,6 +104,7 @@ jobs:
       pmm_server_image: 'perconalab/pmm-server:${{ inputs.rc_version }}-rc'
       pmm_client_image: ${{ matrix.image }}
       pmm_client_version: ${{ matrix.version }}
+      job_timeout_minutes: 120
 
   e2e_tests_matrix:
     name: E2E Tests Matrix (CodeceptJS)

--- a/.github/workflows/rc-testing-suite.yml
+++ b/.github/workflows/rc-testing-suite.yml
@@ -116,6 +116,7 @@ jobs:
       pmm_client_image: 'perconalab/pmm-client:${{ inputs.rc_version }}-rc'
       pmm_client_version: pmm3-rc
       pmm_qa_branch: ${{ inputs.pmm_qa_branch }}
+      job_timeout_minutes: 120
 
   helm_tests:
     name: pmm3-helm
@@ -141,6 +142,7 @@ jobs:
       pmm_client_version_ol9: ${{ inputs.pmm_client_tarball_ol9 }}
       repository: 'release candidate'
       expected_version: ${{ inputs.rc_version }}
+      job_timeout_minutes: 120
 
   qa_integration_psmdb_pbm_full:
     name: PMM_PSMDB_PBM_FULL
@@ -150,6 +152,7 @@ jobs:
       pmm_qa_branch: ${{ inputs.pmm_qa_branch }}
       pmm_client_version: pmm3-rc
       pmm_server_image: 'perconalab/pmm-server:${{ inputs.rc_version }}-rc'
+      job_timeout_minutes: 120
 
   qa_integration_proxysql:
     name: PMM_PROXYSQL
@@ -161,6 +164,7 @@ jobs:
       pxc_glibc: ${{ inputs.pxc_glibc }}
       pmm_server_image: 'perconalab/pmm-server:${{ inputs.rc_version }}-rc'
       pmm_client_version: pmm3-rc
+      job_timeout_minutes: 120
 
   qa_integration_pdpgsql:
     name: PMM_PDPGSQL
@@ -171,3 +175,4 @@ jobs:
       pdpgsql_version: ${{ inputs.pdpgsql_version }}
       pmm_server_image: 'perconalab/pmm-server:${{ inputs.rc_version }}-rc'
       pmm_client_version: pmm3-rc
+      job_timeout_minutes: 120

--- a/.github/workflows/runner-e2e-tests-codeceptjs.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs.yml
@@ -86,7 +86,7 @@ jobs:
     name: "e2e tests: ${{ inputs.tags_for_tests || '@settings-fb' }}"
 #    runs-on: ubuntu-latest Mongo Replica setup fails in ubuntu-latest for some reason. Additional investigation needed
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: ${{ contains(inputs.pmm_server_image, '-rc') && 120 || 90 }}
     env:
       SHA: ${{ inputs.sha || 'null' }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/runner-e2e-tests-codeceptjs.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs.yml
@@ -86,7 +86,7 @@ jobs:
     name: "e2e tests: ${{ inputs.tags_for_tests || '@settings-fb' }}"
 #    runs-on: ubuntu-latest Mongo Replica setup fails in ubuntu-latest for some reason. Additional investigation needed
     runs-on: ubuntu-22.04
-    timeout-minutes: ${{ contains(inputs.pmm_server_image, '-rc') && 120 || 90 }}
+    timeout-minutes: 90
     env:
       SHA: ${{ inputs.sha || 'null' }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/runner-e2e-tests-codeceptjs.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs.yml
@@ -77,6 +77,10 @@ on:
       sha:
         required: false
         type: string
+      job_timeout_minutes:
+        description: 'Job timeout in minutes (includes queue wait); default 90'
+        required: false
+        type: number
     secrets:
       LAUNCHABLE_TOKEN:
         required: false
@@ -86,7 +90,7 @@ jobs:
     name: "e2e tests: ${{ inputs.tags_for_tests || '@settings-fb' }}"
 #    runs-on: ubuntu-latest Mongo Replica setup fails in ubuntu-latest for some reason. Additional investigation needed
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: ${{ inputs.job_timeout_minutes || 90 }}
     env:
       SHA: ${{ inputs.sha || 'null' }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/runner-e2e-tests-playwright.yml
+++ b/.github/workflows/runner-e2e-tests-playwright.yml
@@ -70,7 +70,7 @@ jobs:
   tests:
     name: "e2e tests: ${{ inputs.pmm_test_flag || '' }}"
     runs-on: ubuntu-22.04
-    timeout-minutes: ${{ contains(inputs.pmm_server_version, '-rc') && 120 || 60 }}
+    timeout-minutes: 60
     env:
       SHA: ${{ inputs.sha || 'null' }}
       PMM_BASE_URL: https://127.0.0.1

--- a/.github/workflows/runner-e2e-tests-playwright.yml
+++ b/.github/workflows/runner-e2e-tests-playwright.yml
@@ -63,6 +63,10 @@ on:
       launchable_confidence:
         type: string
         required: false
+      job_timeout_minutes:
+        description: 'Job timeout in minutes (includes queue wait); default 60'
+        required: false
+        type: number
     secrets:
       LAUNCHABLE_TOKEN:
         required: false
@@ -70,7 +74,7 @@ jobs:
   tests:
     name: "e2e tests: ${{ inputs.pmm_test_flag || '' }}"
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.job_timeout_minutes || 60 }}
     env:
       SHA: ${{ inputs.sha || 'null' }}
       PMM_BASE_URL: https://127.0.0.1

--- a/.github/workflows/runner-e2e-tests-playwright.yml
+++ b/.github/workflows/runner-e2e-tests-playwright.yml
@@ -70,7 +70,7 @@ jobs:
   tests:
     name: "e2e tests: ${{ inputs.pmm_test_flag || '' }}"
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: ${{ contains(inputs.pmm_server_version, '-rc') && 120 || 60 }}
     env:
       SHA: ${{ inputs.sha || 'null' }}
       PMM_BASE_URL: https://127.0.0.1

--- a/.github/workflows/runner-e2e-tests-podman.yml
+++ b/.github/workflows/runner-e2e-tests-podman.yml
@@ -66,13 +66,17 @@ on:
       sha:
         required: false
         type: string
+      job_timeout_minutes:
+        description: 'Job timeout in minutes (includes queue wait); default 60'
+        required: false
+        type: number
 
 jobs:
   ui-tests-e2e:
     name: "podman e2e tests: ${{ inputs.tags_for_tests || '@settings-fb' }}"
     #    runs-on: ubuntu-latest Mongo Replica setup fails in ubuntu-latest for some reason. Additional investigation needed
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.job_timeout_minutes || 60 }}
     env:
       SHA: ${{ inputs.sha || 'null' }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/runner-integration-cli-tests.yml
+++ b/.github/workflows/runner-integration-cli-tests.yml
@@ -40,6 +40,10 @@ on:
         description: "SHA (leave empty if running manually, default - 'null')"
         required: false
         type: string
+      job_timeout_minutes:
+        description: 'Job timeout in minutes (includes queue wait); default 40'
+        required: false
+        type: number
     secrets:
       LAUNCHABLE_TOKEN:
         required: false
@@ -48,7 +52,7 @@ jobs:
   cli-tests:
     name: ${{ inputs.test_name || inputs.cli_tag}}
     runs-on: ubuntu-22.04
-    timeout-minutes: ${{ contains(inputs.pmm_server_image, '-rc') && 120 || 40 }}
+    timeout-minutes: ${{ inputs.job_timeout_minutes || 40 }}
     env:
       SHA: ${{ github.event.inputs.sha || inputs.sha || github.event.pull_request.head.sha || github.event.pull_request.head.sha || github.sha || 'null' }}
       PMM_QA_BRANCH: ${{ inputs.pmm_qa_branch || 'main' }}

--- a/.github/workflows/runner-integration-cli-tests.yml
+++ b/.github/workflows/runner-integration-cli-tests.yml
@@ -48,7 +48,7 @@ jobs:
   cli-tests:
     name: ${{ inputs.test_name || inputs.cli_tag}}
     runs-on: ubuntu-22.04
-    timeout-minutes: 40
+    timeout-minutes: ${{ contains(inputs.pmm_server_image, '-rc') && 120 || 40 }}
     env:
       SHA: ${{ github.event.inputs.sha || inputs.sha || github.event.pull_request.head.sha || github.event.pull_request.head.sha || github.sha || 'null' }}
       PMM_QA_BRANCH: ${{ inputs.pmm_qa_branch || 'main' }}

--- a/.github/workflows/runner-package-test.yml
+++ b/.github/workflows/runner-package-test.yml
@@ -107,12 +107,16 @@ on:
         description: "SHA (leave empty if running manually, default - 'null')"
         required: false
         type: string
+      job_timeout_minutes:
+        description: 'Job timeout in minutes (includes queue wait); default 60'
+        required: false
+        type: number
 
 jobs:
   test:
     name: ${{ inputs.test_name || inputs.playbook}}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.job_timeout_minutes || 60 }}
     env:
       SHA: ${{ inputs.sha || 'null' }}
       PMM_SERVER_IMAGE: ${{ inputs.pmm_server_image }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

RC testing fans out 50+ parallel jobs. `timeout-minutes` includes queue wait time, so jobs with low explicit limits (20–90 min) were cancelled before a runner was assigned.

## Fix

Add an optional `job_timeout_minutes` input to each affected runner/QA workflow (defaults to the previous value when omitted). **Only** `rc-testing-suite.yml` passes `job_timeout_minutes: 120`.

| RC suite job | Child workflow | Default timeout |
|---|---|---|
| CLI + compatibility | `integration-cli-tests` → CLI runner | 40 |
| E2E matrix | `e2e-tests-matrix` → codeceptjs/playwright/fb runners | 60–90 |
| GSSAPI | `gssapi-psmdb-tests-matrix` → all runners | 20–90 |
| PMM_PSMDB_PBM_FULL | direct | 20 |
| PMM_PROXYSQL / PMM_PDPGSQL | direct | 40 |
| Helm | unchanged | GitHub default (6h) |

Helm was left out on purpose: it never had a low explicit timeout, so passing 120 would have *reduced* its budget from 6h.

## Test plan

- [ ] Re-run RC testing suite; previously queue-cancelled jobs should start
- [ ] Confirm nightly/FB workflows still use original per-suite defaults
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f21fdf3b-d598-49f3-83ff-d08d6dedc594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f21fdf3b-d598-49f3-83ff-d08d6dedc594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

