### PR TITLE
Fix PDPGSQL query load setup for QAN nightly tests

### DIFF
--- a/qa-integration/pmm_qa/percona-distribution-postgresql/data/pdpgsql_run_queries.sh
+++ b/qa-integration/pmm_qa/percona-distribution-postgresql/data/pdpgsql_run_queries.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+while true; do
+  psql -U postgres -d school -c "SELECT s.first_name, s.last_name FROM students s JOIN enrollments e ON s.student_id = e.student_id JOIN classes c ON e.class_id = c.class_id WHERE c.name = 'Mathematics';"
+  psql -U postgres -d school -c "INSERT INTO classes (name, teacher) VALUES ('Physics', 'Mr. Demo');"
+  psql -U postgres -d school -c "DELETE FROM enrollments WHERE enrollment_id IN (SELECT enrollment_id FROM enrollments LIMIT 1);"
+  sleep 30
+done

--- a/qa-integration/pmm_qa/percona-distribution-postgresql/tasks/install-percona-distribution-postgresql-single.yml
+++ b/qa-integration/pmm_qa/percona-distribution-postgresql/tasks/install-percona-distribution-postgresql-single.yml
@@ -69,13 +69,10 @@
   become: true
   loop: "{{ range(1, nodes_count | int + 1) | list }}"
 
-- name: Run queries for generating data
-  shell: docker exec {{ container_prefix }}{{ item }} bash ./data/pgsm_run_queries.sh &
-  become: true
-  loop: "{{ range(1, nodes_count | int + 1) | list }}"
-
-- name: Copy a file into the container
-  shell: docker cp ./data/pgsql_load.sql {{ container_prefix }}{{ item }}:/pgsql_load.sql
+- name: Copy query load scripts into the container
+  shell: |
+    docker cp ./data/pgsql_load.sql {{ container_prefix }}{{ item }}:/pgsql_load.sql
+    docker cp ./data/pdpgsql_run_queries.sh {{ container_prefix }}{{ item }}:/pdpgsql_run_queries.sh
   become: true
   loop: "{{ range(1, nodes_count | int + 1) | list }}"
 
@@ -86,6 +83,11 @@
 
 - name: Run SQL script using docker exec
   shell: docker exec {{ container_prefix }}{{ item }} psql -U postgres -d school -f /pgsql_load.sql > /dev/null
+  become: true
+  loop: "{{ range(1, nodes_count | int + 1) | list }}"
+
+- name: Run queries for generating data
+  shell: docker exec {{ container_prefix }}{{ item }} bash /pdpgsql_run_queries.sh &
   become: true
   loop: "{{ range(1, nodes_count | int + 1) | list }}"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

PDPGSQL nightly setup tried to run `./data/pgsm_run_queries.sh` inside the container without copying it first, so query load never started (`No such file or directory`). QAN and PostgreSQL dashboard tests then failed intermittently on missing query data.

## How

- Copy `pgsql_load.sql` and a new `pdpgsql_run_queries.sh` into the container before seeding.
- Seed the `school` database with `pgsql_load.sql`.
- Start continuous query load against `school` (queries used by PMM-T13 / PMM-T2050) instead of the shared `pgsm_run_queries.sh` script, which targets other databases.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f89165ad-98c2-45b5-87a6-2111ac8b179f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f89165ad-98c2-45b5-87a6-2111ac8b179f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

