### PR TITLE
Increase nightly E2E setup step timeout to 20 minutes

### DIFF
--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Run setup for E2E tests (start client services on this runner)
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 10
+          timeout_minutes: 20
           retry_wait_seconds: '10'
           max_attempts: 2
           retry_on: 'error'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Increases the `nick-fields/retry` per-attempt timeout for the nightly remote setup step from 10 to 20 minutes.

Recent nightly runs showed multiple shards hitting the 10-minute limit during `pmm-framework.py` provisioning (valkey, ps-gr, ps-myrocks, external). Several other shards already run close to the limit on successful runs (ps-gr up to 9.7 min, pdpgsql-patroni up to 9.4 min).

## Test plan

- [ ] Merge and trigger `pmm3-ui-tests-nightly-gha` against this branch
- [ ] Confirm setup shards complete without `Timeout of 600000ms hit`
- [ ] Verify valkey and ps-gr setup jobs finish successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d70a00a-8e4b-49ab-9214-b26c25e052b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d70a00a-8e4b-49ab-9214-b26c25e052b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

