### PR TITLE
Fix Dependabot setuptools security update in qa-integration

### DIFF
--- a/qa-integration/pmm_qa/requirements.txt
+++ b/qa-integration/pmm_qa/requirements.txt
@@ -1,3 +1,3 @@
-setuptools>=65.0.0,<74
+setuptools>=83.0.0,<84
 ansible-runner==2.3.2
 requests==2.26.0


### PR DESCRIPTION
## Why

Dependabot security updates for `setuptools` in `qa-integration/pmm_qa` were failing on `main` with `dependency_file_not_supported`. The `setuptools>=65.0.0,<74` constraint blocked the patched version (83.0.0) required by GHSA security advisories.

## How

- Bumped `setuptools` constraint to `>=83.0.0,<84` in `qa-integration/pmm_qa/requirements.txt`
- Verified `pip install -r requirements.txt` resolves to setuptools 83.0.0