### PR TITLE
Stabilize PMM-T1061, PMM-T269, and nightly PMM-Client setup

### DIFF
--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -103,13 +103,19 @@ jobs:
         run: echo "PATH_TO_PMM_QA=$(pwd)" >> $GITHUB_ENV
 
       - name: Setup PMM-Client against remote PMM Server
-        working-directory: pmm-qa/qa-integration/pmm_qa
-        run: |
-          sudo bash -x pmm3-client-setup.sh \
-            --pmm_server_ip "${SERVER_IP}" \
-            --client_version "${{ env.PMM_CLIENT_VERSION }}" \
-            --admin_password "${{ env.ADMIN_PASSWORD }}" \
-            --use_metrics_mode no
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          retry_wait_seconds: '10'
+          max_attempts: 2
+          retry_on: 'error'
+          command: |
+            cd pmm-qa/qa-integration/pmm_qa
+            sudo bash -x pmm3-client-setup.sh \
+              --pmm_server_ip "${SERVER_IP}" \
+              --client_version "${{ env.PMM_CLIENT_VERSION }}" \
+              --admin_password "${{ env.ADMIN_PASSWORD }}" \
+              --use_metrics_mode no
 
       - name: Run setup for E2E tests (start client services on this runner)
         uses: nick-fields/retry@v3

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Setup PMM-Client against remote PMM Server
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 15
+          timeout_minutes: 10
           retry_wait_seconds: '10'
           max_attempts: 2
           retry_on: 'error'

--- a/codeceptjs-e2e/tests/QAN/common_test.js
+++ b/codeceptjs-e2e/tests/QAN/common_test.js
@@ -20,7 +20,7 @@ Scenario('PMM-T269 - Verify QAN UI Elements are displayed @qan', async ({ I, que
     await queryAnalyticsPage.filters.applyShowAllLinkIfItIsVisible(filter);
     const countFilters = await I.grabNumberOfVisibleElements(queryAnalyticsPage.filters.fields.filterCheckBoxesInGroup(filter));
 
-    if (countFilters === 0) {
+    if (countFilters === 0 || filter === 'Service Name') {
       continue;
     }
 
@@ -30,8 +30,6 @@ Scenario('PMM-T269 - Verify QAN UI Elements are displayed @qan', async ({ I, que
     I.assertTrue((await queryAnalyticsPage.data.getRowCount()) > 0, `No values for filter: "${filter}" were displayed`);
     await queryAnalyticsPage.filters.selectFilterInGroupAtPosition(filter, randomFilterValue);
   }
-
-  queryAnalyticsPage.filters.resetAllFilters();
 
   const serverNodeName = homePage.pmmServerName;
   const services = (await inventoryAPI.apiGetServices()).data.services;
@@ -51,7 +49,7 @@ Scenario('PMM-T269 - Verify QAN UI Elements are displayed @qan', async ({ I, que
 
   queryAnalyticsPage.filters.selectContainFilterInGroup(serviceFilter, 'Service Name');
   I.wait(3);
-  const displayedServiceName = await I.grabTextFrom(queryAnalyticsPage.filters.fields.filterCheckBoxesInGroup('Service Name'));
+  const displayedServiceName = await I.grabTextFrom(queryAnalyticsPage.filters.fields.checkedFilters());
 
   I.assertContain(
     displayedServiceName,

--- a/codeceptjs-e2e/tests/QAN/common_test.js
+++ b/codeceptjs-e2e/tests/QAN/common_test.js
@@ -32,7 +32,6 @@ Scenario('PMM-T269 - Verify QAN UI Elements are displayed @qan', async ({ I, que
   }
 
   queryAnalyticsPage.filters.resetAllFilters();
-  queryAnalyticsPage.waitForLoaded();
 
   const serverNodeName = homePage.pmmServerName;
   const services = (await inventoryAPI.apiGetServices()).data.services;
@@ -51,13 +50,13 @@ Scenario('PMM-T269 - Verify QAN UI Elements are displayed @qan', async ({ I, que
   I.assertTrue(serviceLabels.length > 0, `No Service Name filters found for node "${serverNodeName}"`);
 
   queryAnalyticsPage.filters.selectContainFilterInGroup(serviceFilter, 'Service Name');
-  queryAnalyticsPage.waitForLoaded();
-  I.waitForVisible(queryAnalyticsPage.filters.fields.checkedFilters(), 30);
-  const checkedServiceFilters = await I.grabTextFromAll(queryAnalyticsPage.filters.fields.checkedFilters());
+  I.wait(3);
+  const displayedServiceName = await I.grabTextFrom(queryAnalyticsPage.filters.fields.filterCheckBoxesInGroup('Service Name'));
 
-  I.assertTrue(
-    checkedServiceFilters.some((label) => label.includes(serviceFilter) || serviceFilter.includes(label)),
-    `Checked Service Name filters [${checkedServiceFilters.join(', ')}] do not include "${serviceFilter}"`,
+  I.assertContain(
+    displayedServiceName,
+    serviceFilter,
+    `Displayed filter value: "${displayedServiceName}" does not contain expected value: "${serviceFilter}"`,
   );
   I.assertTrue((await queryAnalyticsPage.data.getRowCount()) > 0, `No QAN rows displayed after filtering by ${serviceFilter}`);
 });

--- a/codeceptjs-e2e/tests/QAN/common_test.js
+++ b/codeceptjs-e2e/tests/QAN/common_test.js
@@ -31,6 +31,9 @@ Scenario('PMM-T269 - Verify QAN UI Elements are displayed @qan', async ({ I, que
     await queryAnalyticsPage.filters.selectFilterInGroupAtPosition(filter, randomFilterValue);
   }
 
+  queryAnalyticsPage.filters.resetAllFilters();
+  queryAnalyticsPage.waitForLoaded();
+
   const serverNodeName = homePage.pmmServerName;
   const services = (await inventoryAPI.apiGetServices()).data.services;
 
@@ -48,13 +51,13 @@ Scenario('PMM-T269 - Verify QAN UI Elements are displayed @qan', async ({ I, que
   I.assertTrue(serviceLabels.length > 0, `No Service Name filters found for node "${serverNodeName}"`);
 
   queryAnalyticsPage.filters.selectContainFilterInGroup(serviceFilter, 'Service Name');
-  I.wait(3);
-  const displayedServiceName = await I.grabTextFrom(queryAnalyticsPage.filters.fields.filterCheckBoxesInGroup('Service Name'));
+  queryAnalyticsPage.waitForLoaded();
+  I.waitForVisible(queryAnalyticsPage.filters.fields.checkedFilters(), 30);
+  const checkedServiceFilters = await I.grabTextFromAll(queryAnalyticsPage.filters.fields.checkedFilters());
 
-  I.assertContain(
-    displayedServiceName,
-    serviceFilter,
-    `Displayed filter value: "${displayedServiceName}" does not contain expected value: "${serviceFilter}"`,
+  I.assertTrue(
+    checkedServiceFilters.some((label) => label.includes(serviceFilter) || serviceFilter.includes(label)),
+    `Checked Service Name filters [${checkedServiceFilters.join(', ')}] do not include "${serviceFilter}"`,
   );
   I.assertTrue((await queryAnalyticsPage.data.getRowCount()) > 0, `No QAN rows displayed after filtering by ${serviceFilter}`);
 });

--- a/codeceptjs-e2e/tests/QAN/overview_test.js
+++ b/codeceptjs-e2e/tests/QAN/overview_test.js
@@ -36,8 +36,9 @@ Scenario(
     queryAnalyticsPage.waitForLoaded();
     await adminPage.applyTimeRange('Last 12 hours');
     queryAnalyticsPage.waitForLoaded();
-    queryAnalyticsPage.data.searchByValue('query_plan');
+    queryAnalyticsPage.data.searchByValue('pgsm_t1 t1');
     queryAnalyticsPage.waitForLoaded();
+    I.waitForVisible(queryAnalyticsPage.data.elements.queryRowValue(1), 60);
     queryAnalyticsPage.data.mouseOverInfoIcon(1);
 
     const tooltipQueryId = await queryAnalyticsPage.data.getTooltipQueryId();

--- a/qa-integration/pmm_qa/percona-distribution-postgresql/data/pdpgsql_run_queries.sh
+++ b/qa-integration/pmm_qa/percona-distribution-postgresql/data/pdpgsql_run_queries.sh
@@ -1,8 +1,44 @@
 #!/bin/sh
 
+psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'contrib_regression'" | grep -q 1 \
+  || psql -U postgres -c "CREATE DATABASE contrib_regression;"
+
+psql -U postgres -d contrib_regression -c "CREATE EXTENSION IF NOT EXISTS pg_stat_monitor;"
+psql -U postgres -d contrib_regression -c "ALTER SYSTEM SET pg_stat_monitor.pgsm_track TO 'all';"
+psql -U postgres -d contrib_regression -c "SELECT pg_reload_conf();"
+
+seed_plan_tables() {
+  psql -U postgres -d contrib_regression -v ON_ERROR_STOP=0 <<'EOSQL'
+CREATE TABLE IF NOT EXISTS pgsm_t1 (a INTEGER);
+CREATE TABLE IF NOT EXISTS pgsm_t2 (b INTEGER);
+CREATE TABLE IF NOT EXISTS pgsm_t3 (c INTEGER);
+CREATE TABLE IF NOT EXISTS pgsm_t4 (d INTEGER);
+INSERT INTO pgsm_t1(a) SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM pgsm_t1);
+INSERT INTO pgsm_t2(b) SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM pgsm_t2);
+INSERT INTO pgsm_t3(c) SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM pgsm_t3);
+INSERT INTO pgsm_t4(d) SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM pgsm_t4);
+EOSQL
+}
+
+seed_plan_tables
+
 while true; do
-  psql -U postgres -d school -c "SELECT s.first_name, s.last_name FROM students s JOIN enrollments e ON s.student_id = e.student_id JOIN classes c ON e.class_id = c.class_id WHERE c.name = 'Mathematics';"
-  psql -U postgres -d school -c "INSERT INTO classes (name, teacher) VALUES ('Physics', 'Mr. Demo');"
-  psql -U postgres -d school -c "DELETE FROM enrollments WHERE enrollment_id IN (SELECT enrollment_id FROM enrollments LIMIT 1);"
+  seed_plan_tables
+
+  # PMM-T1061: capture query plans in pg_stat_monitor.
+  psql -U postgres -d contrib_regression -c \
+    "SELECT a,b,c,d FROM pgsm_t1 t1, pgsm_t2 t2, pgsm_t3 t3, pgsm_t4 t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;" >/dev/null 2>&1 || true
+
+  # PMM-T1061: second part of the scenario.
+  psql -U postgres -d contrib_regression -c "SELECT * FROM pg_stat_database;" >/dev/null 2>&1 || true
+
+  # PMM-T13 PDPGSQL QAN workload on school DB.
+  psql -U postgres -d school -c \
+    "SELECT s.first_name, s.last_name FROM students s JOIN enrollments e ON s.student_id = e.student_id JOIN classes c ON e.class_id = c.class_id WHERE c.name = 'Mathematics';" >/dev/null 2>&1 || true
+  psql -U postgres -d school -c \
+    "INSERT INTO classes (name, teacher) VALUES ('Physics', 'Mr. Demo');" >/dev/null 2>&1 || true
+  psql -U postgres -d school -c \
+    "DELETE FROM enrollments WHERE enrollment_id IN (SELECT enrollment_id FROM enrollments LIMIT 1);" >/dev/null 2>&1 || true
+
   sleep 30
 done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

- **PMM-T1061** fails on `pdpgsql`: QAN search `query_plan` matched the agent collector SQL unreliably; workload did not generate deterministic PGSM plan queries.
- **Nightly setup** can hang when `pmm3-client-setup.sh` blocks on apt with no timeout, stalling all 14 shards.
- **PMM-T269** flakes on nightly: assert read the first Service Name checkbox (not the selected one); `resetAllFilters()` also fails when the random loop leaves no active filters (button disabled).

## How

- Add PGSM join workload to `pdpgsql_run_queries.sh`; search `pgsm_t1 t1` in `overview_test.js`.
- Wrap nightly PMM-Client setup in `nick-fields/retry@v3` (10 min, 2 attempts).
- PMM-T269: skip `Service Name` in the random filter loop; assert via `checkedFilters()` instead of `resetAllFilters()`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f89165ad-98c2-45b5-87a6-2111ac8b179f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f89165ad-98c2-45b5-87a6-2111ac8b179f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

