### PR TITLE
docs(migration): attach GitHub Actions run to migration PR

### DIFF
--- a/.cursor/skills/codeceptjs-migration/branch-workflow.md
+++ b/.cursor/skills/codeceptjs-migration/branch-workflow.md
@@ -90,13 +90,25 @@ The PR body must include:
 - execution commands and results;
 - final review result.
 
+## Attach CI execution
+
+PRs to `main` auto-trigger `e2e-tests-matrix.yml`. After `gh pr create`, resolve the workflow run and link it on the PR:
+
+```bash
+PR_NUM=$(gh pr view --json number -q .number)
+RUN_URL=$(gh run list --workflow e2e-tests-matrix.yml --branch "$(git branch --show-current)" --limit 1 --json url -q '.[0].url')
+[ -n "$RUN_URL" ] && gh pr comment "$PR_NUM" --body "GitHub Actions: ${RUN_URL}"
+```
+
+Include the run URL in the tracker Notes. Do not wait for CI to finish before marking `done`.
+
 ## Tracker completion
 
 After the PR exists, on the control branch:
 
 1. merge the frozen migration branch;
 2. update `e2e_tests/graphify-out/` from the merged tree;
-3. update the row to `done` and record the PR URL or number, actual target and setup, review, MCP, test, and graph-update results;
+3. update the row to `done` and record the PR URL or number, GitHub Actions run URL, actual target and setup, review, MCP, test, and graph-update results;
 4. commit and push only the tracker and target graph artifacts after the merge commit.
 
 If the PR opened but the control-branch graph or tracker update failed, report publication as incomplete and do not claim completion.

--- a/.cursor/skills/codeceptjs-migration/run.md
+++ b/.cursor/skills/codeceptjs-migration/run.md
@@ -106,7 +106,7 @@ Only after `FINAL_REVIEW_PASS`, the runner:
 2. updates workflow coverage per `branch-workflow.md`;
 3. checks that only migration-related code, source-retirement, and workflow files are included;
 4. commits and pushes the migration branch;
-5. opens a PR targeting `main`;
+5. opens a PR targeting `main` and attaches the E2E tests Matrix Actions run URL per `branch-workflow.md`;
 6. merges the frozen migration branch into control;
 7. runs `graphify . --update` from `e2e_tests/` on control, then deletes generated graph files except `graph.json` and `manifest.json`; and
 8. updates the tracker row to `done` with the PR link, then commits and pushes the tracker and target graph artifacts on control.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a minimal post-publish step to the migration automation: after opening a PR to `main`, resolve the `e2e-tests-matrix.yml` workflow run on the migration branch and link it via a PR comment and tracker Notes.

CI completion is not a gate for marking the tracker `done`.

## Changes

- `branch-workflow.md`: new **Attach CI execution** section with `gh run list` + `gh pr comment`
- `run.md`: publish step references the attach rule
- Tracker completion notes now include the Actions run URL
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae4b3d20-9b6d-4b2c-be08-63772865aaa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae4b3d20-9b6d-4b2c-be08-63772865aaa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

