### PR TITLE
Add MongoDB unused-indexes dashboard test

### DIFF
--- a/.github/workflows/e2e-tests-matrix.yml
+++ b/.github/workflows/e2e-tests-matrix.yml
@@ -134,6 +134,18 @@ jobs:
       setup_services: '--database haproxy --database ps --database pxc'
       pmm_test_flag: '@pmm-ps-pxc-haproxy-integration'
 
+  psmdb_integration:
+    name: PSMDB integration tests
+    uses: ./.github/workflows/runner-e2e-tests-playwright.yml
+    secrets:
+      LAUNCHABLE_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN }}
+    with:
+      pmm_server_version: ${{ inputs.pmm_server_image || github.event.inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
+      pmm_client_version: ${{ inputs.pmm_client_version || github.event.inputs.pmm_client_version || 'latest-tarball' }}
+      pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
+      setup_services: '--database psmdb'
+      pmm_test_flag: '@pmm-psmdb-integration'
+
   new-navigation:
     name: New Navigation UI tests
     uses: ./.github/workflows/runner-e2e-tests-playwright.yml
@@ -192,4 +204,3 @@ jobs:
       pmm_client_image: ${{ inputs.pmm_client_image || github.event.inputs.pmm_client_image || 'perconalab/pmm-client:3-dev-latest' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
       sha: ${{ inputs.sha || github.event.pull_request.head.sha ||  'null' }}
-

--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -94,6 +94,7 @@ For test, page-object, fixture, and helper conventions, see [CONTRIBUTING.md](./
 - `@nightly`
 - `@pmm-ps-integration`
 - `@pmm-ps-pxc-haproxy-integration`
+- `@pmm-psmdb-integration`
 - `@pmm-valkey-integration`
 - `@post-release`
 - `@rta`

--- a/e2e_tests/helpers/mongodb.helper.ts
+++ b/e2e_tests/helpers/mongodb.helper.ts
@@ -24,6 +24,21 @@ export default class MongoDBHelper {
     });
   }
 
+  createIndexStats = async (dbName: string, collectionName: string) => {
+    const collection = this.client.db(dbName).collection(collectionName);
+
+    await collection.insertOne({ queried_field_qa: 'seed' });
+
+    const unusedIndex = await collection.createIndex({ unused_field_qa: 1 });
+    const usedIndex = await collection.createIndex({ queried_field_qa: 1 });
+
+    await collection.find({ queried_field_qa: 'seed' }).hint(usedIndex).toArray();
+
+    return { unusedIndex, usedIndex };
+  };
+
+  dropDatabase = async (dbName: string) => this.client.db(dbName).dropDatabase();
+
   /**
    * Ensures the collection has at least n documents. Used so a find with $where
    * (per-document delay) runs long enough without exceeding server JS time limit per doc.

--- a/e2e_tests/pages/dashboards/dashboards.page.ts
+++ b/e2e_tests/pages/dashboards/dashboards.page.ts
@@ -6,6 +6,7 @@ import { Timeouts } from '@helpers/timeouts';
 import BasePage from '@pages/base.page';
 import { ValkeyDashboards, ValkeyDashboardsType } from '@valkey';
 import { MysqlDashboards, MysqlDashboardsType } from '@pages/dashboards/mysql';
+import { MongoDashboards, MongoDashboardsType } from '@pages/dashboards/mongo';
 import Panels from '@components/dashboards/panels';
 import HomeDashboard from '@pages/dashboards/home';
 import pmmTest from '@fixtures/pmmTest';
@@ -21,6 +22,7 @@ const hasKnownNoDataMarker = (panelText: string) =>
 
 export default class Dashboards extends BasePage {
   readonly home = new HomeDashboard(this.page);
+  readonly mongo: MongoDashboardsType = MongoDashboards;
   readonly mysql: MysqlDashboardsType = MysqlDashboards;
   readonly os: OperatingSystemDashboardsType = OperatingSystemDashboards;
   readonly valkey: ValkeyDashboardsType = ValkeyDashboards;

--- a/e2e_tests/pages/dashboards/mongo/index.ts
+++ b/e2e_tests/pages/dashboards/mongo/index.ts
@@ -1,0 +1,10 @@
+import DashboardInterface from '@interfaces/dashboard';
+import MongodbUnusedIndexes from './mongodbUnusedIndexes';
+
+export const MongoDashboards = {
+  unusedIndexes: new MongodbUnusedIndexes(),
+};
+
+export type MongoDashboardsType = typeof MongoDashboards & Record<string, DashboardInterface>;
+
+export default MongoDashboards;

--- a/e2e_tests/pages/dashboards/mongo/mongodbUnusedIndexes.ts
+++ b/e2e_tests/pages/dashboards/mongo/mongodbUnusedIndexes.ts
@@ -1,0 +1,16 @@
+import { GrafanaPanel } from '@interfaces/grafanaPanel';
+import DashboardInterface from '@interfaces/dashboard';
+
+export default class MongodbUnusedIndexes implements DashboardInterface {
+  url = 'graph/d/mongodb-unused-indexes/mongodb-unused-indexes';
+  metrics: GrafanaPanel[] = [
+    { name: 'About Unused Indexes', type: 'text' },
+    { name: 'Instance Uptime', type: 'stat' },
+    { name: 'Unused Indexes', type: 'stat' },
+    { name: 'Indexes Monitored', type: 'stat' },
+    { name: 'Unused Indexes by Collection', type: 'table' },
+    { name: 'Index Accesses Since Restart', type: 'timeSeries' },
+    { name: 'Least Used Indexes', type: 'table' },
+  ];
+  noDataMetrics = [];
+}

--- a/e2e_tests/pages/navigation.page.ts
+++ b/e2e_tests/pages/navigation.page.ts
@@ -78,6 +78,7 @@ export default class LeftNavigation extends BasePage {
       otherDashboards: { locator: this.page.getByTestId('navitem-mongo-other-dashboards') },
       overview: { locator: this.page.getByTestId('navitem-mongo-overview') },
       summary: { locator: this.page.getByTestId('navitem-mongo-summary') },
+      unusedIndexes: { locator: this.page.getByTestId('navitem-mongo-unused-indexes') },
     },
     mysql: {
       commandHandler: { locator: this.page.getByTestId('navitem-mysql-command-handler-counters-compare') },

--- a/e2e_tests/testdata/dashboards.registry.ts
+++ b/e2e_tests/testdata/dashboards.registry.ts
@@ -20,6 +20,12 @@ export const DASHBOARDS: DashboardEntry[] = [
     folder: 'MongoDB',
     url: 'graph/d/mongodb-collections-overview/mongodb-collections-overview',
   },
+  {
+    cluster: 'replicaset',
+    folder: 'MongoDB',
+    replicationSet: 'rs',
+    url: 'graph/d/mongodb-unused-indexes/mongodb-unused-indexes',
+  },
   { folder: 'MongoDB', url: 'graph/d/mongodb-inmemory/mongodb-inmemory-details' },
   {
     cluster: 'replicaset',

--- a/e2e_tests/tests/dashboards/mongo/mongodbUnusedIndexes.test.ts
+++ b/e2e_tests/tests/dashboards/mongo/mongodbUnusedIndexes.test.ts
@@ -1,0 +1,50 @@
+import pmmTest from '@fixtures/pmmTest';
+import { expect } from '@playwright/test';
+import { Timeouts } from '@helpers/timeouts';
+
+const collection = 'users';
+
+pmmTest.beforeEach(async ({ grafanaHelper }) => {
+  await grafanaHelper.authorize();
+});
+
+pmmTest(
+  'PMM-T2262 Verify MongoDB Unused Indexes dashboard @nightly @dashboards',
+  async ({ api, dashboard, mongoDbHelper, page, urlHelper }) => {
+    const database = `pmm_qa_unused_indexes_${Date.now()}`;
+    const service = await api.inventoryApi.getServiceDetailsByPartialName('rs101');
+    const unusedIndexes = dashboard.mongo.unusedIndexes;
+
+    try {
+      const indexes = await mongoDbHelper.createIndexStats(database, collection);
+      const metric = `mongodb_indexstats_accesses_ops{database="${database}", key_name="${indexes.unusedIndex}", service_name="${service.service_name}"}`;
+
+      await api.grafanaApi.waitForMetric(metric, Timeouts.TWO_MINUTES);
+      await page.goto(
+        urlHelper.buildUrlWithParameters(unusedIndexes.url, {
+          cluster: service.cluster,
+          database,
+          environment: service.environment,
+          from: 'now-5m',
+          refresh: '5s',
+          replicationSet: service.replication_set,
+          serviceName: service.service_name,
+        }),
+      );
+      await dashboard.verifyAllPanelsHaveData(unusedIndexes.noDataMetrics);
+
+      for (const panel of unusedIndexes.metrics) {
+        await expect(dashboard.builders.panelByExactName(panel.name)).toHaveCount(1);
+      }
+
+      const candidates = dashboard.builders.panelByExactName('Unused Indexes by Collection');
+
+      await expect(dashboard.builders.panelByExactName('Indexes Monitored')).toContainText('2');
+      await expect(dashboard.builders.panelByExactName('Unused Indexes')).toContainText('1');
+      await expect(candidates).toContainText(indexes.unusedIndex);
+      await expect(candidates).not.toContainText(indexes.usedIndex);
+    } finally {
+      await mongoDbHelper.dropDatabase(database);
+    }
+  },
+);

--- a/e2e_tests/tests/dashboards/mongo/mongodbUnusedIndexes.test.ts
+++ b/e2e_tests/tests/dashboards/mongo/mongodbUnusedIndexes.test.ts
@@ -9,7 +9,7 @@ pmmTest.beforeEach(async ({ grafanaHelper }) => {
 });
 
 pmmTest(
-  'PMM-T2262 Verify MongoDB Unused Indexes dashboard @nightly @dashboards',
+  'PMM-T2262 Verify MongoDB Unused Indexes dashboard @nightly @dashboards @pmm-psmdb-integration',
   async ({ api, dashboard, mongoDbHelper, page, urlHelper }) => {
     const database = `pmm_qa_unused_indexes_${Date.now()}`;
     const service = await api.inventoryApi.getServiceDetailsByPartialName('rs101');


### PR DESCRIPTION
Add end-to-end test and supporting pieces for the MongoDB "Unused Indexes" dashboard (PMM-T2262). Changes:

- New test: e2e_tests/tests/dashboards/mongo/mongodbUnusedIndexes.test.ts — seeds DB, waits for metric, verifies panels and counts, and cleans up DB.
- Helper: e2e_tests/helpers/mongodb.helper.ts — add createIndexStats() to create used/unused indexes and dropDatabase().
- Page objects: e2e_tests/pages/dashboards/mongo/* (page + registry) and include mongo in dashboards.page.ts.
- Navigation locator and dashboards registry entry added.

Purpose: validate unused-index detection and dashboard panels for MongoDB.