### PR TITLE
Skip PMM-T289 upgrade test

### DIFF
--- a/codeceptjs-e2e/tests/upgrade/upgradePMM_test.js
+++ b/codeceptjs-e2e/tests/upgrade/upgradePMM_test.js
@@ -36,7 +36,7 @@ Before(async ({ I }) => {
   await I.Authorize();
 });
 
-Scenario(
+Scenario.skip(
   'PMM-T289 - Verify Whats New link is presented on Update Widget @pmm-upgrade',
   async ({ I, homePage }) => {
     const locators = homePage.getLocators(versionMinor);


### PR DESCRIPTION
Mark the PMM-T289 upgrade test as skipped by changing Scenario to Scenario.skip in codeceptjs-e2e/tests/upgrade/upgradePMM_test.js. This prevents the 'Verify Whats New link is presented on Update Widget' test from running in E2E suites as the link is no longer present in the panel