### PR TITLE
PMM-15241 Add update-snooze test and HelpPage locator

### DIFF
--- a/e2e_tests/helpers/mocks.helper.ts
+++ b/e2e_tests/helpers/mocks.helper.ts
@@ -59,6 +59,50 @@ export default class mocksHelper {
     await this.page.route(apiEndpoints.management.services, fulfillNoServices);
   };
 
+  mockSnoozedUpdate = async (updateVersion: string): Promise<{ snoozedAt: number }> => {
+    const state = { snoozedAt: 0, snoozedVersion: '' };
+
+    await this.page.context().unroute(apiEndpoints.users.me);
+    await this.page.context().unroute(apiEndpoints.server.updates);
+    await this.page.route(apiEndpoints.users.me, async (route) => {
+      if (route.request().method() === 'PUT') {
+        const body = route.request().postDataJSON() as { snoozed_pmm_version?: string };
+
+        state.snoozedAt = Date.now();
+        state.snoozedVersion = body.snoozed_pmm_version ?? '';
+      }
+
+      await route.fulfill({
+        body: JSON.stringify({
+          alerting_tour_completed: true,
+          product_tour_completed: true,
+          snoozed_at: state.snoozedAt ? new Date(state.snoozedAt).toISOString() : null,
+          snoozed_pmm_version: state.snoozedVersion,
+          user_id: 1,
+        }),
+        contentType: 'application/json',
+        status: 200,
+      });
+    });
+    await this.page.route(apiEndpoints.server.updates, (route) =>
+      route.fulfill({
+        body: JSON.stringify({
+          installed: {},
+          last_check: new Date().toISOString(),
+          latest: {
+            timestamp: new Date(0).toISOString(),
+            version: updateVersion,
+          },
+          update_available: true,
+        }),
+        contentType: 'application/json',
+        status: 200,
+      }),
+    );
+
+    return state;
+  };
+
   mockUpdateAvailable = async (updateAvailable: boolean): Promise<void> => {
     await this.page.route(apiEndpoints.server.updates, async (route: Route) => {
       const installedTimestamp = new Date();

--- a/e2e_tests/pages/helpCenter.page.ts
+++ b/e2e_tests/pages/helpCenter.page.ts
@@ -13,6 +13,7 @@ export default class HelpPage extends BasePage {
     exportLogs: this.page.getByRole('link', { name: 'Export logs' }),
     manageDatasets: this.page.getByRole('link', { name: 'Manage datasets' }),
     nextTip: this.page.getByTestId('tour-next-step-button'),
+    remindMeLater: this.page.getByTestId('update-modal-remind-me-button'),
     shareYourThoughts: this.page.getByRole('link', { name: 'Share your thoughts' }),
     startPmmTour: this.page.getByTestId('tips-card-start-product-tour-button'),
     startTourButton: this.page.getByTestId('welcome-card-start-tour'),

--- a/e2e_tests/tests/helpCenter.test.ts
+++ b/e2e_tests/tests/helpCenter.test.ts
@@ -163,49 +163,11 @@ pmmTest('PMM-T2134 Verify Update check @new-navigation', async ({ helpPage, mock
 
 pmmTest(
   'PMM-T2263 Verify update notification remains snoozed after refresh @new-navigation',
-  async ({ helpPage, page }) => {
-    let snoozedAt = 0;
-    let snoozedVersion = '';
+  async ({ helpPage, mocks, page }) => {
     const snoozeDuration = Timeouts.ONE_MINUTE;
     const updateVersion = `test-update-${Date.now()}`;
+    const snooze = await mocks.mockSnoozedUpdate(updateVersion);
 
-    await page.context().unroute(apiEndpoints.users.me);
-    await page.context().unroute(apiEndpoints.server.updates);
-    await page.route(apiEndpoints.users.me, async (route) => {
-      if (route.request().method() === 'PUT') {
-        const body = route.request().postDataJSON() as { snoozed_pmm_version?: string };
-
-        snoozedAt = Date.now();
-        snoozedVersion = body.snoozed_pmm_version ?? '';
-      }
-
-      await route.fulfill({
-        body: JSON.stringify({
-          alerting_tour_completed: true,
-          product_tour_completed: true,
-          snoozed_at: snoozedAt ? new Date(snoozedAt).toISOString() : null,
-          snoozed_pmm_version: snoozedVersion,
-          user_id: 1,
-        }),
-        contentType: 'application/json',
-        status: 200,
-      });
-    });
-    await page.route(apiEndpoints.server.updates, (route) =>
-      route.fulfill({
-        body: JSON.stringify({
-          installed: {},
-          last_check: new Date().toISOString(),
-          latest: {
-            timestamp: new Date(0).toISOString(),
-            version: updateVersion,
-          },
-          update_available: true,
-        }),
-        contentType: 'application/json',
-        status: 200,
-      }),
-    );
     await page.evaluate(
       (duration) => localStorage.setItem('pmm-ui.dev.updateSnoozeDurationMs', String(duration)),
       snoozeDuration,
@@ -215,7 +177,7 @@ pmmTest(
     await expect(helpPage.buttons.remindMeLater).toBeVisible({ timeout: Timeouts.THIRTY_SECONDS });
     await helpPage.buttons.remindMeLater.click();
     await expect(helpPage.buttons.remindMeLater).toBeHidden();
-    expect(snoozedAt).toBeGreaterThan(0);
+    expect(snooze.snoozedAt).toBeGreaterThan(0);
 
     await Promise.all([
       page.waitForResponse(apiEndpoints.users.me),
@@ -227,7 +189,7 @@ pmmTest(
     });
     await expect(helpPage.buttons.remindMeLater).toBeHidden();
 
-    snoozedAt = Date.now() - snoozeDuration - 1;
+    snooze.snoozedAt = Date.now() - snoozeDuration - 1;
     await page.reload();
     await expect(helpPage.buttons.remindMeLater).toBeVisible({ timeout: Timeouts.THIRTY_SECONDS });
   },

--- a/e2e_tests/tests/helpCenter.test.ts
+++ b/e2e_tests/tests/helpCenter.test.ts
@@ -1,5 +1,6 @@
 import pmmTest from '@fixtures/pmmTest';
 import { expect } from '@playwright/test';
+import apiEndpoints from '@helpers/apiEndpoints';
 import { Timeouts } from '@helpers/timeouts';
 
 pmmTest.beforeEach(async ({ grafanaHelper, page }) => {
@@ -159,3 +160,75 @@ pmmTest('PMM-T2134 Verify Update check @new-navigation', async ({ helpPage, mock
     });
   }
 });
+
+pmmTest(
+  'PMM-T2263 Verify update notification remains snoozed after refresh @new-navigation',
+  async ({ helpPage, page }) => {
+    let snoozedAt = 0;
+    let snoozedVersion = '';
+    const snoozeDuration = Timeouts.ONE_MINUTE;
+    const updateVersion = `test-update-${Date.now()}`;
+
+    await page.context().unroute(apiEndpoints.users.me);
+    await page.context().unroute(apiEndpoints.server.updates);
+    await page.route(apiEndpoints.users.me, async (route) => {
+      if (route.request().method() === 'PUT') {
+        const body = route.request().postDataJSON() as { snoozed_pmm_version?: string };
+
+        snoozedAt = Date.now();
+        snoozedVersion = body.snoozed_pmm_version ?? '';
+      }
+
+      await route.fulfill({
+        body: JSON.stringify({
+          alerting_tour_completed: true,
+          product_tour_completed: true,
+          snoozed_at: snoozedAt ? new Date(snoozedAt).toISOString() : null,
+          snoozed_pmm_version: snoozedVersion,
+          user_id: 1,
+        }),
+        contentType: 'application/json',
+        status: 200,
+      });
+    });
+    await page.route(apiEndpoints.server.updates, (route) =>
+      route.fulfill({
+        body: JSON.stringify({
+          installed: {},
+          last_check: new Date().toISOString(),
+          latest: {
+            timestamp: new Date(0).toISOString(),
+            version: updateVersion,
+          },
+          update_available: true,
+        }),
+        contentType: 'application/json',
+        status: 200,
+      }),
+    );
+    await page.evaluate(
+      (duration) => localStorage.setItem('pmm-ui.dev.updateSnoozeDurationMs', String(duration)),
+      snoozeDuration,
+    );
+    await page.reload();
+
+    await expect(helpPage.buttons.remindMeLater).toBeVisible({ timeout: Timeouts.THIRTY_SECONDS });
+    await helpPage.buttons.remindMeLater.click();
+    await expect(helpPage.buttons.remindMeLater).toBeHidden();
+    expect(snoozedAt).toBeGreaterThan(0);
+
+    await Promise.all([
+      page.waitForResponse(apiEndpoints.users.me),
+      page.waitForResponse(apiEndpoints.server.updates),
+      page.reload(),
+    ]);
+    await page.waitForFunction((delay) => performance.now() >= delay, Timeouts.TEN_SECONDS, {
+      timeout: Timeouts.FIFTEEN_SECONDS,
+    });
+    await expect(helpPage.buttons.remindMeLater).toBeHidden();
+
+    snoozedAt = Date.now() - snoozeDuration - 1;
+    await page.reload();
+    await expect(helpPage.buttons.remindMeLater).toBeVisible({ timeout: Timeouts.THIRTY_SECONDS });
+  },
+);


### PR DESCRIPTION
Add a remind-me-later locator to HelpPage and a new Playwright test (PMM-T2263) that verifies the update notification stays snoozed across page reloads and reappears after the snooze duration. The test mocks users.me and server.updates endpoints, sets pmm-ui.dev.updateSnoozeDurationMs in localStorage, and uses Timeouts helpers. Also import apiEndpoints in the test file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for update notification snoozing.
  * Verified notifications stay hidden after being postponed and refreshed, then reappear when the snooze period expires.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->