### PR TITLE
PMM-7 update mongodb version resolver function

### DIFF
--- a/qa-integration/pmm_qa/pmm-framework/lib/runners.sh
+++ b/qa-integration/pmm_qa/pmm-framework/lib/runners.sh
@@ -76,16 +76,18 @@ version_is_greater() {
 
 # Expand a PSMDB major version into its newest full version.
 #
-# The PSMDB setup scripts want a complete version such as '8.0-12.1', but specs
-# name the major series ('8.0'). This asks the Percona products API which
-# patches exist and picks the highest.
+# The PSMDB setup scripts want a complete version such as '8.0.26-11', but
+# specs name the major series ('8.0'). This asks the same admin-ajax.php
+# endpoint the percona.com downloads page itself calls (Percona removed the
+# old products-api.php when the site was rebuilt on WordPress/Breakdance) for
+# every published patch of that series, and picks the highest.
 #
 # 'latest' and '' pass through untouched -- they are meaningful to the setup
 # script as-is. This is the only network call the framework makes, and the only
 # reason `curl` is required (preflight checks for it only when a PSMDB setup is
 # requested).
 #
-# Usage:  version=$(latest_psmdb_version 8.0)   # -> 8.0-12.1
+# Usage:  version=$(latest_psmdb_version 8.0)   # -> 8.0.26-11
 # Stdout: the resolved version
 # Exits:  via die() when the API call fails or no patch matches
 latest_psmdb_version() {
@@ -97,25 +99,31 @@ latest_psmdb_version() {
 
   local response latest='' latest_patch='' candidate patch
   response=$(curl --fail --silent --show-error \
-    --data-urlencode "version=percona-server-mongodb-$requested" \
-    'https://www.percona.com/products-api.php') ||
+    --data-urlencode 'action=percona_downloads' \
+    --data-urlencode "product_id=percona-server-mongodb-$requested" \
+    --data-urlencode 'hydrate=1' \
+    'https://www.percona.com/wp-admin/admin-ajax.php') ||
     die "Failed to query the Percona products API for PSMDB $requested."
 
-  # The API answers with an HTML form: pull out the value="..." entries, strip
-  # the product prefix, and keep only entries for the requested series.
+  # The API answers with JSON; pull the quoted entries out of the 'versions'
+  # array, strip the product prefix, and keep only entries for the requested
+  # series. Patches look like '<major.minor>.<patch>-<build>'; the trailing
+  # '-build' is turned into '.build' so version_is_greater can compare it as
+  # just another dotted component.
   while IFS= read -r candidate; do
-    patch=${candidate#"$requested-"}
+    patch=${candidate#"$requested."}
+    patch=${patch//-/.}
     if [[ -z $latest ]] || version_is_greater "$patch" "$latest_patch"; then
       latest=$candidate
       latest_patch=$patch
     fi
   done < <(
     printf '%s' "$response" |
-      grep -Eo 'value="[^"]+"' |
-      cut -d'"' -f2 |
-      cut -d'|' -f1 |
+      grep -Eo '"versions"[[:space:]]*:[[:space:]]*\[[^]]*\]' |
+      grep -Eo '"percona-server-mongodb-[^"]+"' |
+      tr -d '"' |
       sed 's/^percona-server-mongodb-//' |
-      grep -E "^${requested//./\\.}-[0-9]+([.][0-9]+)*$"
+      grep -E "^${requested//./\\.}\.[0-9]+(-[0-9]+)?$"
   )
   [[ -n $latest ]] ||
     die "Could not resolve the latest PSMDB patch for '$requested'."

--- a/qa-integration/pmm_qa/pmm-framework/tests/cli.bats
+++ b/qa-integration/pmm_qa/pmm-framework/tests/cli.bats
@@ -93,13 +93,15 @@ load helpers/test_helper
 }
 
 @test "resolves latest PSMDB patch without Python" {
+  # Same patch, two builds: only correct if 'patch-build' is compared as
+  # 'patch.build' rather than as one opaque, arithmetic-subtraction-prone
+  # token (see the "-" to "." conversion in latest_psmdb_version()).
   curl() {
-    printf '%s\n' \
-      '<option value="percona-server-mongodb-8.0-8.1|old">old</option>' \
-      '<option value="percona-server-mongodb-8.0-12.1|new">new</option>'
+    printf '%s' \
+      '{"success":true,"data":{"versions":["percona-server-mongodb-8.0.4-1","percona-server-mongodb-8.0.4-2"]}}'
   }
 
-  [[ $(latest_psmdb_version 8.0) == 8.0-12.1 ]]
+  [[ $(latest_psmdb_version 8.0) == 8.0.4-2 ]]
 }
 
 @test "selects the existing requests-capable interpreter for Ansible modules" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retrieval of the latest Percona Server for MongoDB version.
  * Correctly identifies the highest available build within a requested major series.
  * Supports version responses using the updated format and build suffixes.

* **Tests**
  * Added coverage to verify that the highest build is selected when multiple builds share the same patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->