### PR TITLE
PMM-7 Fix PMM-T2227 tarball upgrade version check

### DIFF
--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -575,13 +575,17 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, async () =>
       ? process.env.PMM_CLIENT_VERSION
       : 'https://pmm-build-cache.s3.us-east-2.amazonaws.com/PR-BUILDS/pmm-client/pmm-client-latest.tar.gz';
     const expectedUpgradeVersion = JSON.parse(
-      (await cli.exec(`docker run --rm ${clientImage} pmm-admin --version --json`)).stdout,
+      (await cli.exec(`docker run --rm --entrypoint pmm-admin ${clientImage} --version --json`)).stdout,
     ).Version;
 
     await cli.exec('docker network create pmm-qa || true');
     await cli.exec('docker network connect pmm-qa pmm-server || true');
     await cli.exec(`docker rm -f ${containerName} 2>/dev/null || true`);
     await cli.exec(`docker run --rm -d --name="${containerName}" --network="pmm-qa" --privileged --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /var/lib/containerd antmelekhin/docker-systemd:almalinux-10`);
+    await expect(async () => {
+      const status = await cli.exec(`docker inspect -f '{{.State.Running}}' ${containerName}`);
+      expect(status.stdout.trim()).toBe('true');
+    }).toPass({ intervals: [1_000], timeout: 60_000 });
     const latestReleasedVersion = (await cli.exec('wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags -O - | jq -r .results[].name | grep -v latest | sort -V | tail -n1')).stdout.trim();
     await cli.exec(`docker cp ../package_tests/scripts/pmm3_client_install_tarball.sh ${containerName}:/`);
     await cli.exec(`docker exec ${containerName} dnf install -y wget`);

--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -7,6 +7,13 @@ const PGSQL_USER = 'postgres';
 const PGSQL_PASSWORD = 'pass+this';
 const ipPort = async () => ((await cli.exec('docker ps')).stdout.includes('pdpgsql_pmm_') ? '127.0.0.1:5432' : '127.0.0.1:5447');
 
+const getClientImageVersion = (): string => {
+  const clientImage = process.env.CLIENT_IMAGE ?? 'perconalab/pmm-client:3-dev-latest';
+  return JSON.parse(
+    cli.execute(`docker run --rm --entrypoint pmm-admin ${clientImage} --version --json`).stdout,
+  ).Version;
+};
+
 test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, async () => {
   test.beforeAll(async ({}) => {
     const result = await cli.exec('docker ps | grep pdpgsql_pmm | awk \'{print $NF}\'');
@@ -17,10 +24,9 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, async () =>
 
   let PMM_VERSION = `${process.env.CLIENT_VERSION}`;
   if (/latest-tarball|3-dev-latest|pmm3-rc|https:/.test(PMM_VERSION)) {
-    // TODO: refactor to use docker hub API to remove file-update dependency
-    // See: https://github.com/Percona-QA/package-testing/blob/master/playbooks/pmm2-client_integration_upgrade_custom_path.yml#L41
-    PMM_VERSION = cli.execute('curl -s https://raw.githubusercontent.com/Percona-Lab/pmm-submodules/v3/VERSION')
-      .stdout.trim();
+    PMM_VERSION = process.env.CLIENT_IMAGE
+      ? getClientImageVersion()
+      : cli.execute('curl -s https://raw.githubusercontent.com/Percona-Lab/pmm-submodules/v3/VERSION').stdout.trim();
   }
 
   test('Verify pt summary for mysql mongodb and pgsql', async ({}) => {
@@ -570,13 +576,10 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, async () =>
 
   test('PMM-T2227 - Verify tarball upgrade @generic', async ({}) => {
     const containerName = 'tarball_client';
-    const clientImage = process.env.CLIENT_IMAGE ?? 'perconalab/pmm-client:3-dev-latest';
     const tarballURL = process.env.PMM_CLIENT_VERSION?.includes('http')
       ? process.env.PMM_CLIENT_VERSION
       : 'https://pmm-build-cache.s3.us-east-2.amazonaws.com/PR-BUILDS/pmm-client/pmm-client-latest.tar.gz';
-    const expectedUpgradeVersion = JSON.parse(
-      (await cli.exec(`docker run --rm --entrypoint pmm-admin ${clientImage} --version --json`)).stdout,
-    ).Version;
+    const expectedUpgradeVersion = getClientImageVersion();
 
     await cli.exec('docker network create pmm-qa || true');
     await cli.exec('docker network connect pmm-qa pmm-server || true');

--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -570,34 +570,51 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, async () =>
 
   test('PMM-T2227 - Verify tarball upgrade @generic', async ({}) => {
     const containerName = 'tarball_client';
+    const clientImage = process.env.CLIENT_IMAGE ?? 'perconalab/pmm-client:3-dev-latest';
+    const tarballURL = process.env.PMM_CLIENT_VERSION?.includes('http')
+      ? process.env.PMM_CLIENT_VERSION
+      : 'https://pmm-build-cache.s3.us-east-2.amazonaws.com/PR-BUILDS/pmm-client/pmm-client-latest.tar.gz';
+    const expectedUpgradeVersion = JSON.parse(
+      (await cli.exec(`docker run --rm ${clientImage} pmm-admin --version --json`)).stdout,
+    ).Version;
+
     await cli.exec('docker network create pmm-qa || true');
-    await cli.exec('docker network connect pmm-server pmm-qa');
+    await cli.exec('docker network connect pmm-qa pmm-server || true');
+    await cli.exec(`docker rm -f ${containerName} 2>/dev/null || true`);
     await cli.exec(`docker run --rm -d --name="${containerName}" --network="pmm-qa" --privileged --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /var/lib/containerd antmelekhin/docker-systemd:almalinux-10`);
-    const latestReleasedVersion = (await cli.exec('wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags -O - | jq -r .results[].name | grep -v latest | sort -V | tail -n1')).stdout;
+    const latestReleasedVersion = (await cli.exec('wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags -O - | jq -r .results[].name | grep -v latest | sort -V | tail -n1')).stdout.trim();
     await cli.exec(`docker cp ../package_tests/scripts/pmm3_client_install_tarball.sh ${containerName}:/`);
     await cli.exec(`docker exec ${containerName} dnf install -y wget`);
-    await cli.exec(`docker exec ${containerName} /pmm3_client_install_tarball.sh -v ${latestReleasedVersion}`);
+    await (await cli.exec(`docker exec ${containerName} /pmm3_client_install_tarball.sh -v '${latestReleasedVersion}'`)).assertSuccess();
     await cli.exec(`docker exec ${containerName} pmm-agent setup --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml --force --server-insecure-tls --server-address=pmm-server:8443 --server-username=admin --server-password=admin 127.0.0.1 generic tarball_node`);
     await cli.exec(`docker exec -d ${containerName} pmm-agent --debug --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml`);
     const adminStatus = await cli.exec(`docker exec ${containerName} pmm-admin status`);
-    const oldVersion = await cli.exec(`docker exec ${containerName} pmm-admin version | grep "Version:"`);
+    const oldVersion = await cli.exec(`docker exec ${containerName} pmm-admin version | grep "^Version:"`);
     const oldPid = await cli.exec(`docker exec ${containerName} ps -C pmm-agent -o pid=`);
 
     await adminStatus.outContains('Connected');
     await oldVersion.outContains(latestReleasedVersion);
-    const tarballURL = process.env.PMM_CLIENT_VERSION!.includes('http') ? process.env.PMM_CLIENT_VERSION : 'https://pmm-build-cache.s3.us-east-2.amazonaws.com/PR-BUILDS/pmm-client/pmm-client-latest.tar.gz';
-
-    await cli.exec(`docker exec ${containerName} /pmm3_client_install_tarball.sh -v ${tarballURL} -u`);
-    await cli.exec(`docker exec ${containerName} pkill -f pmm-agent`);
+    await (await cli.exec(`docker exec ${containerName} /pmm3_client_install_tarball.sh -v '${tarballURL}' -u`)).assertSuccess();
+    await cli.exec(`docker exec ${containerName} pkill -9 -f pmm-agent || true`);
+    await expect(async () => {
+      const ps = await cli.exec(`docker exec ${containerName} pgrep -c pmm-agent || true`);
+      expect(parseInt(ps.stdout.trim(), 10) || 0).toBe(0);
+    }).toPass({ intervals: [500], timeout: 10_000 });
     await cli.exec(`docker exec -d ${containerName} pmm-agent --debug --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml`);
 
-    const newPid = await cli.exec(`docker exec ${containerName} ps -C pmm-agent -o pid=`);
-    const latestVersion = (await cli.exec('curl -s https://raw.githubusercontent.com/Percona-Lab/pmm-submodules/v3/VERSION')).stdout.trim();
     const newAdminStatus = await cli.exec(`docker exec ${containerName} pmm-admin status`);
-    const newVersion = await cli.exec(`docker exec ${containerName} pmm-admin version | grep "Version:"`);
+    const newVersion = await cli.exec(`docker exec ${containerName} pmm-admin version | grep "^Version:"`);
+    const oldPidValue = oldPid.stdout.trim();
 
-    await newPid.outNotContains(oldPid.stdout);
+    await expect(async () => {
+      const newPid = await cli.exec(`docker exec ${containerName} ps -C pmm-agent -o pid=`);
+      const pids = newPid.getStdOutLines().map((pid) => pid.trim());
+      expect(pids, 'PMM Agent should be running after upgrade').toHaveLength(1);
+      expect(pids[0], `PMM Agent was not restarted. Old PID: ${oldPidValue}, New PID: ${pids[0]}`).not.toBe(oldPidValue);
+    }).toPass({ intervals: [1_000], timeout: 30_000 });
     await newAdminStatus.outContains('Connected');
-    await newVersion.outContains(latestVersion);
+    await newVersion.outContains(expectedUpgradeVersion);
+
+    await cli.exec(`docker rm -f ${containerName}`);
   });
 });


### PR DESCRIPTION
## Why

FB `CLI / Integration / Generic` failed on PMM-T2227 because the test compared the post-upgrade `pmm-admin version` against `pmm-submodules/v3/VERSION` (e.g. `3.9.0`/`3.9.1`) instead of the tarball/client image actually under test. FB and dev tarballs report feature-branch versions (e.g. `3.9.0-v3-*` or `3.9.0-PMM-*`), so the assertion failed even when upgrade succeeded. The same VERSION-file mismatch also broke `pmm-admin --version` and `summary --version` in the Generic suite.

## How

- Resolve expected client version from `CLIENT_IMAGE` via `docker run --entrypoint pmm-admin ... --version --json`.
- Quote tarball URLs passed to `pmm3_client_install_tarball.sh`.
- Fix `docker network connect` argument order and harden pmm-agent restart/PID checks after upgrade.
- Wait for `tarball_client` to be running before install steps; remove the container on completion.

Triggered by FB failure on [Percona-Lab/pmm-submodules#4505](https://github.com/Percona-Lab/pmm-submodules/pull/4505) (`CLI tests Generic`).

CI: FB integration run 30909007760 — PMM-T2227 passed; follow-up commit fixes two related version-string tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade validation by confirming containers start successfully and agents shut down and restart as expected.
  * Added verification that upgraded installations report the correct client version.
  * Added cleanup of temporary test containers after upgrade checks.

* **Tests**
  * Added support for configurable upgrade URLs and client image versions.
  * Enhanced checks to confirm the agent process is replaced during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->