### PR TITLE
Fix PMM-T2222 flake: wait for pmm-agent log after inventory change

### DIFF
--- a/cli/tests/mongoDb-psmdb.spec.ts
+++ b/cli/tests/mongoDb-psmdb.spec.ts
@@ -244,6 +244,7 @@ test.describe('Percona Server MongoDB (PSMDB) CLI tests', { tag: '@psmdb' }, asy
     await agentId.exitCodeEquals(0);
     const chaneAgent = await cli.exec(`docker exec ${containerName} pmm-admin inventory change agent mongodb-exporter ${agentId.stdout} --connection-timeout=4s`);
     await chaneAgent.exitCodeEquals(0);
+    await cli.exec('sleep 5');
     const dataSourceName = await cli.exec(`docker exec ${containerName} cat /var/log/pmm-agent.log | grep MONGODB_URI | grep ${agentId.stdout.trim()} | grep connectTimeoutMS=4000`);
     await dataSourceName.assertSuccess();
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`PMM-T2222` in `cli/tests/mongoDb-psmdb.spec.ts` fails intermittently because the test reads `/var/log/pmm-agent.log` immediately after `pmm-admin inventory change agent`, before pmm-agent has written the updated `MONGODB_URI` with `connectTimeoutMS=4000`.

## How

Add `await cli.exec('sleep 5');` after the inventory change command, matching the same pattern already used in `PMM-T2221` in the same file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f584b2f-dce5-4217-b038-633e26d11ca6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f584b2f-dce5-4217-b038-633e26d11ca6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

