### PR TITLE
PMM-12279 Add e2e test for MySQL Performance Schema memory panels

### DIFF
--- a/e2e_tests/pages/dashboards/mysql/index.ts
+++ b/e2e_tests/pages/dashboards/mysql/index.ts
@@ -6,6 +6,7 @@ import PXCGaleraNodesCompare from './pxcGaleraNodesCompare';
 import MySQLUserDetails from './mysqlUserDetails';
 import MysqlGroupReplicationSummary from './mysqlGroupReplicationSummary';
 import MysqlMyRocksDetails from './mysqlMyRocksDetails';
+import MysqlPerformanceSchemaDetails from './mysqlPerformanceSchemaDetails';
 import MysqlReplicationSummary from './mysqlReplicationSummary';
 import HaproxyInstanceSummary from './haproxyInstanceSummary';
 import MysqlWaitEventAnalysesDetails from './mysqlWaitEventAnalysesDetails';
@@ -22,6 +23,7 @@ export const MysqlDashboards = {
   mysqlInstancesCompare: new MySQLInstancesCompare(),
   mysqlInstanceSummary: new MysqlInstanceSummary(),
   mysqlMyRocksDetails: new MysqlMyRocksDetails(),
+  mysqlPerformanceSchemaDetails: new MysqlPerformanceSchemaDetails(),
   mysqlReplicationSummary: new MysqlReplicationSummary(),
   mysqlUserDetails: new MySQLUserDetails(),
   mysqlWaitEventAnalysesDetails: new MysqlWaitEventAnalysesDetails(),

--- a/e2e_tests/pages/dashboards/mysql/mysqlPerformanceSchemaDetails.ts
+++ b/e2e_tests/pages/dashboards/mysql/mysqlPerformanceSchemaDetails.ts
@@ -1,0 +1,64 @@
+import { GrafanaPanel } from '@interfaces/grafanaPanel';
+import DashboardInterface from '@interfaces/dashboard';
+
+export default class MysqlPerformanceSchemaDetails implements DashboardInterface {
+  url = 'graph/d/mysql-performance-schema/mysql-performance-schema-details';
+  // Primary memory panel: mysql_perf_schema_memory_events_used_bytes. Populated whenever
+  // memory instruments are enabled server-side (default on PS/MySQL 8.0+), so it must
+  // render real data end-to-end (collector -> VictoriaMetrics -> panel).
+  memoryCurrentUsedPanel = 'Memory Usage — Current Bytes Used (Top 15 by Event)';
+  // Panels added in PMM-12279 (perf_schema.memory_events collector -> memory panels).
+  // Names are copied verbatim from the dashboard JSON; the first one uses an em dash (U+2014).
+  memoryMetrics: GrafanaPanel[] = [
+    { name: 'Memory Usage — Current Bytes Used (Top 15 by Event)', type: 'timeSeries' },
+    { name: 'Memory Allocation Rate (Top 10 by Event)', type: 'timeSeries' },
+    { name: 'Memory Free Rate (Top 10 by Event)', type: 'timeSeries' },
+  ];
+  metrics: GrafanaPanel[] = [
+    { name: 'Performance Schema File IO (Events)', type: 'timeSeries' },
+    { name: 'Performance Schema File IO (Load)', type: 'timeSeries' },
+    { name: 'Performance Schema File IO (Bytes)', type: 'timeSeries' },
+    { name: 'Performance Schema Status Variables (Events)', type: 'timeSeries' },
+    { name: 'Performance Schema Waits (Events)', type: 'timeSeries' },
+    { name: 'Performance Schema Waits (Load)', type: 'timeSeries' },
+    { name: 'Index Access Operations (Load)', type: 'timeSeries' },
+    { name: 'Table Access Operations (Load)', type: 'timeSeries' },
+    { name: 'Performance Schema SQL & External Locks (Events)', type: 'timeSeries' },
+    { name: 'Performance Schema SQL and External Locks (Seconds)', type: 'timeSeries' },
+    { name: 'MySQL Uptime', type: 'stat' },
+    { name: 'Version', type: 'text' },
+    { name: 'Current QPS', type: 'stat' },
+    { name: 'File Handlers Used', type: 'stat' },
+    { name: 'Table Open Cache Miss Ratio', type: 'stat' },
+    { name: 'Table Open Cache Size', type: 'stat' },
+    { name: 'Table Definition Cache Size', type: 'stat' },
+    { name: 'Service', type: 'text' },
+    { name: 'MySQL Connections', type: 'timeSeries' },
+    { name: 'MySQL Client Thread Activity', type: 'timeSeries' },
+    { name: 'MySQL Handlers', type: 'timeSeries' },
+    { name: 'Top Command Counters', type: 'timeSeries' },
+    { name: 'Process States', type: 'timeSeries' },
+    { name: 'MySQL Network Traffic', type: 'timeSeries' },
+    { name: 'System Uptime', type: 'stat' },
+    { name: 'Load Average', type: 'stat' },
+    { name: 'RAM', type: 'stat' },
+    { name: 'Memory Available', type: 'stat' },
+    { name: 'Virtual Memory', type: 'stat' },
+    { name: 'Disk Space', type: 'stat' },
+    { name: 'Min Space Available', type: 'stat' },
+    { name: 'Node', type: 'text' },
+    { name: 'CPU Usage', type: 'timeSeries' },
+    { name: 'CPU Saturation and Max Core Usage', type: 'timeSeries' },
+    { name: 'Disk I/O and Swap Activity', type: 'timeSeries' },
+    { name: 'Network Traffic', type: 'timeSeries' },
+    ...this.memoryMetrics,
+  ];
+  // The two rate panels only plot series whose alloc/free rate is > 0, so under low load
+  // they can legitimately be empty. They are allow-listed here for any full-dashboard
+  // verifyAllPanelsHaveData() check; the feature test asserts data on memoryCurrentUsedPanel.
+  noDataMetrics: string[] = [
+    'Memory Allocation Rate (Top 10 by Event)',
+    'Memory Free Rate (Top 10 by Event)',
+  ];
+  metricsWithData = this.metrics.filter((metric) => !this.noDataMetrics.includes(metric.name));
+}

--- a/e2e_tests/tests/dashboards/mysql/mysqlDashboards.test.ts
+++ b/e2e_tests/tests/dashboards/mysql/mysqlDashboards.test.ts
@@ -186,3 +186,29 @@ pmmTest(
     await dashboard.verifyPanelValues(dashboard.mysql.mysqlMyRocksDetails.metricsWithData);
   },
 );
+
+// TODO: replace PMM-T0000 with the Zephyr test-case id reserved for PMM-12279.
+pmmTest(
+  'PMM-T0000 - Verify Performance Schema Memory panels on MySQL Performance Schema Details Dashboard (PMM-12279) @pmm-ps-integration',
+  async ({ api, dashboard, page, urlHelper }) => {
+    const { service_name } = await api.inventoryApi.getServiceDetailsByRegex('ps_pmm');
+
+    await page.goto(
+      urlHelper.buildUrlWithParameters(dashboard.mysql.mysqlPerformanceSchemaDetails.url, {
+        from: 'now-15m',
+        refresh: '5s',
+        serviceName: service_name,
+      }),
+    );
+
+    // Feature under test: the "Performance Schema Memory" row and its three panels are present.
+    await dashboard.verifyMetricsPresent(dashboard.mysql.mysqlPerformanceSchemaDetails.memoryMetrics);
+
+    // End-to-end proof (perf_schema.memory_events collector -> VictoriaMetrics -> panel):
+    // Current Bytes Used is populated whenever memory instruments are enabled server-side,
+    // which is the default on PS/MySQL 8.0+, so it must render real data.
+    await dashboard.verifyNamedPanelsHaveData([
+      dashboard.mysql.mysqlPerformanceSchemaDetails.memoryCurrentUsedPanel,
+    ]);
+  },
+);


### PR DESCRIPTION
## What

Adds Playwright (`e2e_tests/`) coverage for the **Performance Schema Memory** panels introduced in [percona/pmm#5649](https://github.com/percona/pmm/pull/5649), which enables the `perf_schema.memory_events` collector and adds memory panels to the **MySQL Performance Schema Details** dashboard.

Jira: [PMM-12279](https://perconadev.atlassian.net/browse/PMM-12279)

## Changes

- **New page object** `pages/dashboards/mysql/mysqlPerformanceSchemaDetails.ts` for the *MySQL Performance Schema Details* dashboard (uid `mysql-performance-schema`). Includes the full panel inventory plus a `memoryMetrics` subset for the three new panels. The dashboard previously had **no** e2e coverage.
- **Registered** it in `pages/dashboards/mysql/index.ts`.
- **New scenario** in `tests/dashboards/mysql/mysqlDashboards.test.ts` (tag `@pmm-ps-integration`):
  - asserts the three memory panels are present, and
  - asserts *Memory Usage — Current Bytes Used (Top 15 by Event)* renders real data end-to-end (collector → VictoriaMetrics → panel).

## How to test

```bash
cd e2e_tests
npx playwright test --grep "PMM-12279"
```
Requires a PMM environment with a Percona Server / MySQL 8.0+ service added with `--query-source=perfschema` (the `ps_pmm` service in the `@pmm-ps-integration` setup). Memory instruments are enabled by default on PS/MySQL 8.0+, so the Current Bytes Used panel is populated without extra server config.

## Notes / follow-ups

- **Zephyr id:** the scenario currently uses placeholder `PMM-T0000` (marked with a `TODO`). Needs to be replaced with the reserved test-case id before merge.
- **Rate panels:** *Memory Allocation Rate* and *Memory Free Rate* use `rate(...) > 0`, so they can legitimately be empty under idle load. They are allow-listed in `noDataMetrics`; the test asserts data only on the always-populated Current Bytes Used panel to avoid flakiness.
- No `qa-integration` provisioning changes were needed. Enabling `performance-schema-instrument='memory/%=ON'` on the test server (to also exercise the rate panels) can be a later hardening step.

Depends on percona/pmm#5649 being merged for the panels to exist in the shipped dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PMM-12279]: https://perconadev.atlassian.net/browse/PMM-12279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ