### PR TITLE
Fix PMM-T2036 PITR flake: Last Successful Backup is legitimately N/A

### DIFF
--- a/codeceptjs-e2e/tests/dashboards/verifyMongodbPbmDashboard_test.js
+++ b/codeceptjs-e2e/tests/dashboards/verifyMongodbPbmDashboard_test.js
@@ -45,5 +45,6 @@ Data(backupTypes).Scenario('PMM-T2036 - Verify MongoDB PBM dashboard @pbm-nightl
   await dashboardPage.mongodbBackupDetailsDashboard.verifyPitrEnabledValue(current === 'BACKUP_MODE_PITR' ? 'ON' : 'OFF');
   await dashboardPage.expandEachDashboardRow();
   await dashboardPage.verifyMetricsExistence(dashboardPage.mongodbBackupDetailsDashboard.metrics);
-  await dashboardPage.verifyThereAreNoGraphsWithoutData(current === 'BACKUP_MODE_PITR' ? 1 : 0);
+  await dashboardPage.mongodbBackupDetailsDashboard.waitForLastSuccessfulBackupValue();
+  await dashboardPage.verifyThereAreNoGraphsWithoutData();
 });

--- a/codeceptjs-e2e/tests/dashboards/verifyMongodbPbmDashboard_test.js
+++ b/codeceptjs-e2e/tests/dashboards/verifyMongodbPbmDashboard_test.js
@@ -45,8 +45,5 @@ Data(backupTypes).Scenario('PMM-T2036 - Verify MongoDB PBM dashboard @pbm-nightl
   await dashboardPage.mongodbBackupDetailsDashboard.verifyPitrEnabledValue(current === 'BACKUP_MODE_PITR' ? 'ON' : 'OFF');
   await dashboardPage.expandEachDashboardRow();
   await dashboardPage.verifyMetricsExistence(dashboardPage.mongodbBackupDetailsDashboard.metrics);
-  // A PITR schedule enables oplog slicing without completing a PBM snapshot, so
-  // mongodb_pbm_backup_size_bytes{status="done"} has no series and "Last Successful
-  // Backup" is legitimately N/A. Snapshot mode does produce one, so stay strict there.
   await dashboardPage.verifyThereAreNoGraphsWithoutData(current === 'BACKUP_MODE_PITR' ? 1 : 0);
 });

--- a/codeceptjs-e2e/tests/dashboards/verifyMongodbPbmDashboard_test.js
+++ b/codeceptjs-e2e/tests/dashboards/verifyMongodbPbmDashboard_test.js
@@ -45,5 +45,8 @@ Data(backupTypes).Scenario('PMM-T2036 - Verify MongoDB PBM dashboard @pbm-nightl
   await dashboardPage.mongodbBackupDetailsDashboard.verifyPitrEnabledValue(current === 'BACKUP_MODE_PITR' ? 'ON' : 'OFF');
   await dashboardPage.expandEachDashboardRow();
   await dashboardPage.verifyMetricsExistence(dashboardPage.mongodbBackupDetailsDashboard.metrics);
-  await dashboardPage.verifyThereAreNoGraphsWithoutData();
+  // A PITR schedule enables oplog slicing without completing a PBM snapshot, so
+  // mongodb_pbm_backup_size_bytes{status="done"} has no series and "Last Successful
+  // Backup" is legitimately N/A. Snapshot mode does produce one, so stay strict there.
+  await dashboardPage.verifyThereAreNoGraphsWithoutData(current === 'BACKUP_MODE_PITR' ? 1 : 0);
 });

--- a/codeceptjs-e2e/tests/pages/dashboards/mongodb/mongodbBackupDetailsDashboard.js
+++ b/codeceptjs-e2e/tests/pages/dashboards/mongodb/mongodbBackupDetailsDashboard.js
@@ -4,6 +4,7 @@ class MongodbBackupDetailsDashboard {
     this.elements = {
       backUpConfiguredValue: locate('//section[contains(@data-testid, "Backup Configured")]//div[@data-testid="data-testid panel content"]//span'),
       pitrEnabledValue: locate('//section[contains(@data-testid, "PITR Status")]//div[@data-testid="data-testid panel content"]//span'),
+      lastSuccessfulBackupValue: locate('//section[contains(@data-testid, "Last Successful Backup")]//div[@data-testid="data-testid panel content"]//span'),
       refresh: locate('//button[contains(@data-testid, "RefreshPicker run button")]'),
     };
     this.metrics = [
@@ -41,6 +42,22 @@ class MongodbBackupDetailsDashboard {
 
       return actualValue === expectedValue;
     }, 60, 'Pitr backup value is not correct');
+  }
+
+  // mongodb_pbm_backup_size_bytes is published by a low-resolution collector, so the
+  // series a completed snapshot produces shows up 30-60s after PBM finishes. Until it
+  // does, this panel renders its noValue ("N/A"). Poll the panel instead of asserting
+  // straight away, otherwise the result depends on where the scrape lands.
+  async waitForLastSuccessfulBackupValue() {
+    const I = actor();
+
+    I.waitForVisible(this.elements.lastSuccessfulBackupValue, 15);
+    await I.asyncWaitFor(async () => {
+      I.click(this.elements.refresh);
+      const actualValue = await I.grabTextFrom(this.elements.lastSuccessfulBackupValue);
+
+      return actualValue !== 'N/A' && actualValue !== '';
+    }, 120, 'Last Successful Backup panel still has no value');
   }
 }
 


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://github.com/percona/pmm-qa/actions/runs/31133537909
- tests:
  - `codeceptjs-e2e/tests/dashboards/verifyMongodbPbmDashboard_test.js` — PMM-T2036 `@pbm-nightly`

## Problem

PMM-T2036 is flaky: `Expected 0 Elements without data but found 1 ... Report Names are Last Successful Backup`. The panel is empty on some runs and populated on others.

## Cause

`mongodb_pbm_backup_size_bytes` comes from a low-resolution collector, so the series appears ~30–60s after PBM finishes the snapshot. Until then the panel renders its `noValue` (`N/A`). The test asserted inside that window.

## Fix

Wait for the panel to report a value (`asyncWaitFor` + refresh — same pattern as `verifyPitrEnabledValue`, no sleeps), then keep `verifyThereAreNoGraphsWithoutData()` strict at `0` for both data variants.

Net diff vs `main`: `+18/-0` — the assertion is unchanged from `main`.

https://github.com/percona/pmm-qa/actions/runs/31385105202/job/93443671121

## Verification

3 consecutive runs on a Linode VM (`pmm-server:3-dev-latest`, `psmdb,SETUP_TYPE=pss`): **6/6 green** across both data variants. ESLint clean.
