### PR TITLE
Fix PMM-T2227 tarball upgrade check by trimming version lookup

### DIFF
--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -573,7 +573,7 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, async () =>
     await cli.exec('docker network create pmm-qa || true');
     await cli.exec('docker network connect pmm-server pmm-qa');
     await cli.exec(`docker run --rm -d --name="${containerName}" --network="pmm-qa" --privileged --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /var/lib/containerd antmelekhin/docker-systemd:almalinux-10`);
-    const latestReleasedVersion = (await cli.exec('wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags -O - | jq -r .results[].name | grep -v latest | sort -V | tail -n1')).stdout;
+    const latestReleasedVersion = (await cli.exec('wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags -O - | jq -r .results[].name | grep -v latest | sort -V | tail -n1')).stdout.trim();
     await cli.exec(`docker cp ../package_tests/scripts/pmm3_client_install_tarball.sh ${containerName}:/`);
     await cli.exec(`docker exec ${containerName} dnf install -y wget`);
     await cli.exec(`docker exec ${containerName} /pmm3_client_install_tarball.sh -v ${latestReleasedVersion}`);


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://github.com/percona/pmm-qa/actions/runs/31136998104 (`PMM Integration Tests`, job `CLI / Integration / Generic`)
- tests:
  - `cli/tests/generic.spec.ts:571` / `@generic` — PMM-T2227 - Verify tarball upgrade

## What failed

The nightly `integration-cli-tests.yml` run reports green, but the test step contains a real failure that Launchable hides — the test is quarantined, so `launchable gate` prints `PASSED | Quarantined (Ignored) 1 | Actionable Failures 0`, and the test step itself runs with `|| true`. The same 1-failed/1-quarantined pattern is in the previous nightly run (`31059341390`) too, so this is a persistent failure, not a flake.

```
1) tests/generic.spec.ts:571:7 › PMM-T2227 - Verify tarball upgrade @generic › Verify command output contains 3.9.0
   Error: Stdout does not contain 3.9.0
   Expected substring: "3.9.0\n"
   Received string:    "Version: 3.9.0-v3-83cf42bbe\nPMMVersion: 3.9.0-v3-83cf42bbe\n"
   at cli/tests/generic.spec.ts:587
```

## Why

`latestReleasedVersion` came from the docker-hub tag lookup **without** `.trim()`, so it carried the trailing newline and `outContains` searched for `"3.9.0\n"` rather than `"3.9.0"`. That only ever matched while the released tarball reported a bare version number at end of line. The tarball the install script pulls for a released version (`downloads.percona.com/downloads/TESTING/pmm/pmm-client-3.9.0.tar.gz`) now reports `3.9.0-v3-83cf42bbe`, so the version number is no longer at end of line and the assertion fails every run.

The client version itself is correct — `3.9.0-v3-<sha>` is ordinary build metadata for a non-final build — so this is a test bug, not a PMM defect. The `latestVersion` lookup a few lines below already used `.trim()`; this brings the released-version lookup in line with it. Trimming also removes the stray newline that was being interpolated into the `install_tarball -v <version>` command.

## Reproduced and verified

Throwaway Linode VM, PMM Server `perconalab/pmm-server:3-dev-latest`, client `latest-tarball`, host client + `--database pdpgsql=16` (what the test's `beforeAll` requires), following `runner-integration-cli-tests.yml`:

- at `main` — failed with exactly the CI error above, same expected/received strings
- with this fix, same VM — `✓ 1 tests/generic.spec.ts:571:7 › PMM-T2227 - Verify tarball upgrade @generic (23.4s)` / `1 passed`; the upgrade path ran through: installed `3.9.0-v3-83cf42bbe`, upgraded to `3.9.1-v3-c24fc62f0`, agent reconnected with a new PID

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpWmLrQsBTxn4GqBYspq1n