### PR TITLE
Pin service_name in PMM-T1333 Collections Overview test

### DIFF
--- a/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
+++ b/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
@@ -63,10 +63,14 @@ Scenario(
   }) => {
     const mongoService = await inventoryAPI.getServiceDetailsByPartialDetails({ cluster: 'replicaset', service_name: 'rs101' });
 
+    // Pin service_name: sibling suites leave behind services that still report
+    // mongodb_mongod_replset_my_state (which populates the picker) but no
+    // mongodb_top_* metrics, and one of them always sorts ahead of rs101.
     I.amOnPage(
       I.buildUrlWithParams(dashboardPage.mongoDbCollectionsOverview.clearUrl, {
         from: 'now-5m',
         node_name: mongoService.node_name,
+        service_name: mongoService.service_name,
         refresh: '5s',
       }),
     );

--- a/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
+++ b/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
@@ -63,9 +63,6 @@ Scenario(
   }) => {
     const mongoService = await inventoryAPI.getServiceDetailsByPartialDetails({ cluster: 'replicaset', service_name: 'rs101' });
 
-    // Pin service_name: sibling suites leave behind services that still report
-    // mongodb_mongod_replset_my_state (which populates the picker) but no
-    // mongodb_top_* metrics, and one of them always sorts ahead of rs101.
     I.amOnPage(
       I.buildUrlWithParams(dashboardPage.mongoDbCollectionsOverview.clearUrl, {
         from: 'now-5m',


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://github.com/percona/pmm-qa/actions/runs/31291022169 (`E2E tests Matrix`, scheduled, `main`)
- tests:
  - `codeceptjs-e2e/tests/verifyMongodbDashboards_test.js` / `@mongodb-exporter` `@nightly` `@gssapi-nightly` — PMM-T1333

## What was failing

```
Expected 2 Elements without data but found 4 on Dashboard
.../graph/d/mongodb-collections-overview/mongodb-collections-overview?from=now-5m&to=now
  &var-node_name=rs101._19470&...&var-service_name=mongodb_test_collections_flag&var-database=$__all
Report Names are Top 5 Hottest Collections by Read  (Total),Top 5 Hottest Collections by Write (Total),
Top 5 Hottest Collections by Read (Rate),Top 5 Hottest Collections by Write (Rate)
```

Note the job's own test step reported **success** — only the later `Record launchable test results` step failed (Launchable gate: 1 actionable failure, 0 quarantined), so the failure is invisible in the job summary.

## Root cause — the test inspects a service a sibling suite left behind

PMM-T1333 looks up `rs101` but passes only `node_name` into the URL, leaving `var-service_name` to Grafana's auto-selection. In `MongoDB_Collections_Overview.json` that variable is `multi=false, includeAll=false`, sorted alphabetically, and populated by:

```
label_values(mongodb_mongod_replset_my_state{...}, service_name)
```

Other suites in the same `@mongodb-exporter` job register and then remove their own MongoDB services, and every one of them sorts ahead of `rs101_*`. Observed on the reproduction VM right after the job's other suites had run:

```
mongodb_test_collections_flag, mongodb_test_pass_plus, rs101_27690, rs102_27690, rs103_27690, testing_force_flag
```

So the picker lands on `mongodb_test_collections_flag` (from `verifyMongoDBCollectionFlags_test.js`), never on `rs101`. The mismatch that makes it fail:

| Metric | `mongodb_test_collections_flag` | `rs101_27690` |
|---|---|---|
| `mongodb_mongod_replset_my_state` — fills the picker | yes | yes |
| `mongodb_top_queries_count` — drives the 4 failing panels | **no** | yes |
| `mongodb_dbstats_dataSize` | no | yes |

The leftover service reports the replset metric that puts it in the picker, but not the `mongodb_top_*` metrics the four "Top 5 Hottest Collections" panels need — hence 4 empty panels instead of 2. The dashboard is behaving correctly; it is being pointed at the wrong service.

This is why the test failed intermittently rather than every night: it only passed when the leftover service happened to still have `mongodb_top_*` samples inside the `from=now-5m` window.

## Fix

Pin `service_name` to the service the test had already looked up, matching the existing idiom in e.g. `tests/verifyPTSummaryPanels_test.js`.

## Verification

Reproduced and verified on a throwaway VM against the same server build as the failing run (image digest `sha256:78e79af6…d246d4`, the build Launchable recorded), client `3.9.1-v3-bca0e18b5`, `pmm-framework --database psmdb`, running the full `--grep "@mongodb-exporter"` selection so the leftover-service ordering is reproduced rather than running PMM-T1333 alone.

| Run | Result |
|---|---|
| Before fix, at `main` (`5aaba99`) | `FAIL — 14 passed, 1 failed, 37 skipped` — PMM-T1333, identical assertion and panels to CI |
| After fix, same selection and ordering | `✔ PMM-T1333 … in 47702ms` |

The after-fix run also shows `PMM-T1241`'s `BeforeSuite` failing with `User "test_user@admin" already exists`. That is an artifact of running the suite twice against one PMM server — `verifyMongoDB_test.js` creates that Mongo user and never drops it, and CI starts each job on a fresh server. Dropping the user and re-running that suite passes (`CODECEPT_EXIT=0`), and this change touches only `verifyMongodbDashboards_test.js`.

ESLint clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2bQCTAnk24BQ8aPtL1jfG

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2bQCTAnk24BQ8aPtL1jfG)_