### PR TITLE
PMM-15198 Add mongos indexstats shard-label CLI tests

### DIFF
--- a/cli/tests/mongoDb-psmdb-shard.spec.ts
+++ b/cli/tests/mongoDb-psmdb-shard.spec.ts
@@ -22,6 +22,39 @@ test.describe('Percona Server MongoDB (PSMDB) CLI tests', { tag: '@shard-psmdb' 
     expect(actualEdition, `Scraped metrics must contain ${edition}!`).toContain(edition);
   });
 
+  test('PMM-15198 Verify mongos indexstats series are unique per shard', async ({}) => {
+    const metricName = 'mongodb_indexstats_accesses_ops';
+    await expect(async () => {
+      const metrics = await cli.getMetrics('mongos', 'pmm', 'mypass', 'rscfg01');
+      const series = metrics.split('\n').filter((line) => line.startsWith(`${metricName}{`));
+      expect(series.length, `Scraped mongos metrics must contain ${metricName} series!`).toBeGreaterThan(0);
+
+      // $indexStats through mongos returns one document per shard for the same index, so
+      // without the shard label those documents collapse into one series and the exporter
+      // rejects the duplicates instead of exposing them.
+      const shardsPerIndex = new Map<string, Set<string>>();
+      for (const line of series) {
+        const labels = line.substring(line.indexOf('{') + 1, line.lastIndexOf('}'));
+        const shard = labels.match(/\bshard="([^"]*)"/)?.[1];
+        expect(shard, `Every ${metricName} series scraped through mongos must carry a non-empty shard label, got: ${line}`).toBeTruthy();
+        const index = labels.replace(/,?\bshard="[^"]*"/, '');
+        shardsPerIndex.set(index, (shardsPerIndex.get(index) ?? new Set()).add(shard!));
+      }
+
+      const shardedIndexes = [...shardsPerIndex.values()].filter((shards) => shards.size > 1);
+      expect(shardedIndexes.length, `At least one index of the sharded setup must be reported by more than one shard, got: ${series.join('\n')}`).toBeGreaterThan(0);
+    }).toPass({
+      intervals: [2_000],
+      timeout: 120_000,
+    });
+  });
+
+  test('PMM-15198 Verify mongos exporter does not report duplicate metric errors', async ({}) => {
+    const duplicateMetricError = 'was collected before with the same name and label values';
+    const result = await cli.exec(`docker exec rscfg01 grep -c '${duplicateMetricError}' /var/log/pmm-agent.log || true`);
+    expect(Number(result.getStdOutLines()[0]), `pmm-agent log of the mongos host must not contain "${duplicateMetricError}"!`).toBe(0);
+  });
+
   //
   test.skip('PMM-T1853 Collect Data about Sharded collections in MongoDB', async ({}) => {
     const expectedValue = 'mongodb_shards_collection_chunks_count';


### PR DESCRIPTION
## Blocked — do not merge yet

These tests assert the behaviour added by **percona/mongodb_exporter#1321** (FB: Percona-Lab/pmm-submodules#4507). They fail against a client built from current GA/`main`, and should only merge once that exporter fix is in.

## What

Two regression tests in the existing `@shard-psmdb` CLI spec (`cli/tests/mongoDb-psmdb-shard.spec.ts`), which already runs against `pmm-framework --database psmdb,SETUP_TYPE=sharding`:

1. **`PMM-15198 Verify mongos indexstats series are unique per shard`** — scrapes the mongos service's `mongodb_exporter` and asserts every `mongodb_indexstats_accesses_ops` series carries a non-empty `shard` label, and that at least one index is reported by more than one shard.
2. **`PMM-15198 Verify mongos exporter does not report duplicate metric errors`** — asserts the mongos host's `pmm-agent.log` contains no `was collected before with the same name and label values`.

## Why

`$indexStats` through `mongos` returns one document per shard for the same index. Without a `shard` label those documents collapse into a single Prometheus series, so the exporter rejected the duplicates and flooded the mongos host's `/var/log/messages` every scrape — PMM-15198. One shard's sample was also silently lost. Nothing in the pipeline caught either symptom.

## CI verification — fails on GA, passes on FB

`integration-cli-tests.yml` dispatched twice on this branch with `pmm_qa_branch=claude/lucid-brown-s6jdjj`, changing only the PMM build:

| Job | GA — [run 31395474187](https://github.com/percona/pmm-qa/actions/runs/31395474187)<br>`percona/pmm-server:3.9.0` + client `3.9.0` | FB — [run 31395514332](https://github.com/percona/pmm-qa/actions/runs/31395514332)<br>`perconalab/pmm-server-fb:PR-4507-f1d4898` + FB client tarball |
|---|---|---|
| `PSMDB Shard 7.x` | **failure** — 2 failed, 1 passed | **success** — 3 passed |
| `PSMDB Shard 8.x` | **failure** — 2 failed, 1 passed | **success** — 3 passed |
| whole 25-job matrix | 25/25 completed, exactly these 2 failed | 25/25 completed, 0 failed |

The failures are the new assertions, not a broken environment — the pre-existing `@PMM-T1539` mongos test passed in all four jobs. On GA both new tests fail with their intended messages:

```
Error: Every mongodb_indexstats_accesses_ops series scraped through mongos must carry a
non-empty shard label, got: mongodb_indexstats_accesses_ops{cl_id="...",cl_role="mongos",
collection="test",database="test",key_name="_id_"} 0

Error: pmm-agent log of the mongos host must not contain "was collected before with the
same name and label values"!
  Expected: 0
  Received: 162
```

That second number is the bug itself reproducing in CI: **162** duplicate-metric errors in the mongos host's agent log within a single run, on both 7.x and 8.x. On the FB build the same three tests pass in ~3 s.

Client/server provenance was read out of each job's own environment block (`PMM_CLIENT_VERSION`, `PMM_SERVER_IMAGE`) rather than inferred from dispatch order.

One known rough edge: when the shard label is genuinely missing, test 1 only fails after its 120 s `toPass` window expires, so a real regression costs ~2 min per job. Happy to drop that to a shorter timeout if reviewers prefer.

Manual QA for PMM-15198 (live sharded cluster, per-shard series, backward compatibility on non-sharded deployments, dashboards) is recorded on the Jira ticket.