### PR TITLE
Consolidate Dependabot into one monthly PR per update stream

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,6 @@
 version: 2
 
 updates:
-  # All three JS suites are updated together: one accumulating PR per month for
-  # version updates, and one accumulating PR for security fixes. Security
-  # updates are alert-driven and ignore the schedule, so they need their own
-  # group — without `applies-to: security-updates` each alert opens its own PR.
   - package-ecosystem: npm
     directories:
       - /cli

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ multi-ecosystem-groups:
   all-dependencies:
     schedule:
       interval: monthly
+    open-pull-requests-limit: 1
     labels:
       - dependencies
 
@@ -16,7 +17,6 @@ updates:
     patterns:
       - "*"
     multi-ecosystem-group: all-dependencies
-    open-pull-requests-limit: 1
     groups:
       security-updates:
         applies-to: security-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,23 @@
 version: 2
 
+multi-ecosystem-groups:
+  all-dependencies:
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies
+
 updates:
   - package-ecosystem: npm
     directories:
       - /cli
       - /codeceptjs-e2e
       - /e2e_tests
-    schedule:
-      interval: monthly
-      time: "06:00"
-      timezone: Etc/UTC
+    patterns:
+      - "*"
+    multi-ecosystem-group: all-dependencies
     open-pull-requests-limit: 1
-    labels:
-      - dependencies
     groups:
-      all-dependencies:
-        applies-to: version-updates
-        patterns:
-          - "*"
       security-updates:
         applies-to: security-updates
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,28 @@
 version: 2
 
-multi-ecosystem-groups:
-  all-dependencies:
-    schedule:
-      interval: weekly
-    labels:
-      - dependencies
-
 updates:
+  # All three JS suites are updated together: one accumulating PR per month for
+  # version updates, and one accumulating PR for security fixes. Security
+  # updates are alert-driven and ignore the schedule, so they need their own
+  # group — without `applies-to: security-updates` each alert opens its own PR.
   - package-ecosystem: npm
     directories:
       - /cli
       - /codeceptjs-e2e
       - /e2e_tests
-    patterns:
-      - "*"
-    multi-ecosystem-group: all-dependencies
-
-  - package-ecosystem: pip
-    directory: /qa-integration/pmm_qa
-    patterns:
-      - "*"
-    multi-ecosystem-group: all-dependencies
+    schedule:
+      interval: monthly
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 1
+    labels:
+      - dependencies
+    groups:
+      all-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Makes Dependabot stop opening a new PR per dependency, and moves the schedule to **monthly**.

## Why

The existing config already groups **version updates** via `multi-ecosystem-groups`, and that part works — #1107 is a single PR, *"Bump the all-dependencies group across 3 directories with 47 updates"*, touching `cli`, `codeceptjs-e2e` and `e2e_tests` together.

The defect is that **security updates are alert-driven and are not covered by a multi-ecosystem group**. They ignore the schedule and are not grouped, so every Dependabot advisory opened its own PR. That is 10 of the 11 open Dependabot PRs:

| PR | Bump |
|----|------|
| #1148 | js-yaml 4.1.0 → 4.3.1 (`/cli`) |
| #1134 | fast-uri 3.1.2 → 3.1.5 (`/codeceptjs-e2e`) |
| #1133 | undici 7.25.0 → 7.29.0 (`/codeceptjs-e2e`) |
| #1132 | brace-expansion 1.1.11 → 1.1.18 (`/cli`) |
| #1131 | brace-expansion (`/codeceptjs-e2e`) |
| #1119 | braces 3.0.2 → 3.0.3 (`/codeceptjs-e2e`) |
| #1118 | playwright 1.45.0 → 1.55.1 (`/codeceptjs-e2e`) |
| #1117 | flatted 3.2.5 → 3.4.3 (`/codeceptjs-e2e`) |
| #1115 | lodash 4.17.21 → 4.18.1 (`/codeceptjs-e2e`) |
| #1114 | tar 7.5.20 → 7.5.21 (`/codeceptjs-e2e`) |
| #1107 | the grouped version-update PR (47 updates) |

## Changes

- **Add a `groups` entry with `applies-to: security-updates`** on the npm update. This is the actual fix — the security stream now accumulates into one PR that Dependabot rebases as new advisories land, instead of one PR per advisory.
- **`multi-ecosystem-groups` is kept as-is** for the version-update stream. It is the documented mechanism for a consolidated pull request and is already producing one here (#1107), so it is not swapped for something whose behaviour cannot be verified before merge.
- Schedule **weekly → monthly**.
- `open-pull-requests-limit: 1` on the group, as a backstop on the version-update stream.
- Drop the `pip` entry. `qa-integration/pmm_qa/requirements.txt` was removed in PMM-15275 (#1136), so it matched no manifest.

## Effect

Steady state goes from *one PR per dependency* to **at most two open Dependabot PRs**: one monthly version-update PR and one security-fix PR. Security fixes still arrive as soon as an advisory is published — they are not delayed to the monthly cadence, they just land in one shared PR.

Once this merges, the 11 PRs above can be closed. #1157 applies all of those updates at once and takes them through CI.

## Testing

Config-only change, verified three ways:

1. Validates against schemastore's [`dependabot-2.0.json`](https://json.schemastore.org/dependabot-2.0.json).
2. **Dependabot itself parses `.github/dependabot.yml` on the PR** and reports errors as a check. It rejected an earlier revision of this branch with *"open-pull-requests-limit should only be set on the associated multi-ecosystem group"*, which is fixed in `05fb72d`. It raised no objection to `groups` sitting alongside `multi-ecosystem-group`.
3. The schema confirms `multi-ecosystem-group` and `groups` are both properties of an update entry with no mutual exclusion — the only constraints are that `patterns` is required with `multi-ecosystem-group`, and `schedule` is required without it.

The end state is observable on the repo's Dependabot page after merge ("Last checked" / next scheduled run).