### PR TITLE
Add PBM and PMM user configuration for config servers

### DIFF
--- a/qa-integration/pmm_psmdb-pbm_setup/start-sharded-with-pmm.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/start-sharded-with-pmm.sh
@@ -310,16 +310,28 @@ docker compose -f docker-compose-sharded-with-pmm.yaml exec -T rscfg01 pmm-admin
 echo "adding some data"
 docker compose -f docker-compose-sharded-with-pmm.yaml exec -T mongos mgodatagen -f /etc/datagen/sharded.json --uri=mongodb://root:root@127.0.0.1:27017
 
-echo "triggering chunk migrations so the chunk-move dashboards have data"
+echo "triggering chunk migrations and splits so the chunk-move/split dashboards have data"
 docker compose -f docker-compose-sharded-with-pmm.yaml exec -T mongos mongo "mongodb://root:root@localhost" --quiet --eval '
     var coll = db.getSiblingDB("config").collections.findOne({ _id: "test.test" });
     var shards = db.getSiblingDB("config").shards.find().toArray().map(function (s) { return s._id; });
     db.getSiblingDB("config").chunks.find({ uuid: coll.uuid }).forEach(function (chunk) {
         var target = shards.filter(function (s) { return s !== chunk.shard; })[0];
         if (target) {
-            sh.moveChunk("test.test", chunk.min, target);
+            try {
+                sh.moveChunk("test.test", chunk.min, target);
+            } catch (e) {
+                print("moveChunk failed, skipping: " + e);
+            }
         }
     });
+    var doc = db.getSiblingDB("test").test.findOne();
+    if (doc) {
+        try {
+            sh.splitFind("test.test", { _id: doc._id });
+        } catch (e) {
+            print("splitFind failed, skipping: " + e);
+        }
+    }
 '
 
 tests=${TESTS:-yes}

--- a/qa-integration/pmm_psmdb-pbm_setup/start-sharded-with-pmm.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/start-sharded-with-pmm.sh
@@ -140,6 +140,74 @@ docker compose -f docker-compose-sharded-with-pmm.yaml exec -T rscfg01 mongo --q
 EOF
 sleep 60
 echo
+echo "configuring root user on primary rscfg01 configserver replicaset"
+docker compose -f docker-compose-sharded-with-pmm.yaml exec -T rscfg01 mongo --quiet << EOF
+    db.getSiblingDB("admin").createUser({ user: "root", pwd: "root", roles: [ "root", "userAdminAnyDatabase", "clusterAdmin" ] });
+EOF
+echo
+echo "configuring pbm and pmm roles on configserver replicaset rscfg"
+docker compose -f docker-compose-sharded-with-pmm.yaml exec -T rscfg01 mongo "mongodb://root:root@localhost/?replicaSet=rscfg" --quiet << EOF
+db.getSiblingDB("admin").createRole({
+    "role": "pbmAnyAction",
+    "privileges": [{
+        "resource": { "anyResource": true },
+	    "actions": [ "anyAction" ]
+        }],
+    "roles": []
+});
+db.getSiblingDB("admin").createRole({
+    role: "explainRole",
+    privileges: [{
+        resource: {
+            db: "",
+            collection: ""
+            },
+        actions: [
+            "listIndexes",
+            "listCollections",
+            "dbStats",
+            "dbHash",
+            "collStats",
+            "find"
+            ]
+        }],
+    roles:[]
+});
+EOF
+echo
+echo "creating pbm user for configserver replicaset rscfg"
+docker compose -f docker-compose-sharded-with-pmm.yaml exec -T rscfg01 mongo "mongodb://root:root@localhost/?replicaSet=rscfg" --quiet << EOF
+db.getSiblingDB("admin").createUser({
+    user: "${pbm_user}",
+    pwd: "${pbm_pass}",
+    "roles" : [
+        { "db" : "admin", "role" : "readWrite", "collection": "" },
+        { "db" : "admin", "role" : "backup" },
+        { "db" : "admin", "role" : "clusterMonitor" },
+        { "db" : "admin", "role" : "restore" },
+        { "db" : "admin", "role" : "pbmAnyAction" }
+    ]
+});
+EOF
+echo
+echo "creating pmm user for configserver replicaset rscfg"
+docker compose -f docker-compose-sharded-with-pmm.yaml exec -T rscfg01 mongo "mongodb://root:root@localhost/?replicaSet=rscfg" --quiet << EOF
+db.getSiblingDB("admin").createUser({
+    user: "${pmm_user}",
+    pwd: "${pmm_pass}",
+    roles: [
+        { role: "explainRole", db: "admin" },
+        { role: "clusterMonitor", db: "admin" },
+        { role: "read", db: "local" },
+        { "db" : "admin", "role" : "readWrite", "collection": "" },
+        { "db" : "admin", "role" : "backup" },
+        { "db" : "admin", "role" : "clusterMonitor" },
+        { "db" : "admin", "role" : "restore" },
+        { "db" : "admin", "role" : "pbmAnyAction" }
+    ]
+});
+EOF
+echo
 echo "adding shards and creating global mongo user"
 docker compose -f docker-compose-sharded-with-pmm.yaml exec -T mongos mongo --quiet << EOF
 db.getSiblingDB("admin").createUser({ user: "root", pwd: "root", roles: [ "root", "userAdminAnyDatabase", "clusterAdmin" ] });

--- a/qa-integration/pmm_psmdb-pbm_setup/start-sharded-with-pmm.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/start-sharded-with-pmm.sh
@@ -310,29 +310,32 @@ docker compose -f docker-compose-sharded-with-pmm.yaml exec -T rscfg01 pmm-admin
 echo "adding some data"
 docker compose -f docker-compose-sharded-with-pmm.yaml exec -T mongos mgodatagen -f /etc/datagen/sharded.json --uri=mongodb://root:root@127.0.0.1:27017
 
-echo "triggering chunk migrations and splits so the chunk-move/split dashboards have data"
-docker compose -f docker-compose-sharded-with-pmm.yaml exec -T mongos mongo "mongodb://root:root@localhost" --quiet --eval '
-    var coll = db.getSiblingDB("config").collections.findOne({ _id: "test.test" });
-    var shards = db.getSiblingDB("config").shards.find().toArray().map(function (s) { return s._id; });
-    db.getSiblingDB("config").chunks.find({ uuid: coll.uuid }).forEach(function (chunk) {
-        var target = shards.filter(function (s) { return s !== chunk.shard; })[0];
-        if (target) {
-            try {
-                sh.moveChunk("test.test", chunk.min, target);
-            } catch (e) {
-                print("moveChunk failed, skipping: " + e);
-            }
-        }
-    });
-    var doc = db.getSiblingDB("test").test.findOne();
-    if (doc) {
-        try {
-            sh.splitFind("test.test", { _id: doc._id });
-        } catch (e) {
-            print("splitFind failed, skipping: " + e);
-        }
+echo "writing chunk-activity generator so the chunk-move/split dashboards keep getting data"
+docker compose -f docker-compose-sharded-with-pmm.yaml exec -T mongos tee /tmp/keep_chunks_moving.js > /dev/null << 'JSEOF'
+var shards = db.getSiblingDB("config").shards.find().toArray().map(function (s) { return s._id; });
+var ins = db.getSiblingDB("test").test.insertOne({ ts: new Date() });
+shards.forEach(function (target) {
+    try {
+        sh.moveChunk("test.test", { _id: ins.insertedId }, target);
+    } catch (e) {
+        print("moveChunk to " + target + " failed, skipping: " + e);
     }
-'
+});
+try {
+    sh.splitFind("test.test", { _id: ins.insertedId });
+} catch (e) {
+    print("splitFind failed, skipping: " + e);
+}
+JSEOF
+docker compose -f docker-compose-sharded-with-pmm.yaml exec -T mongos tee /tmp/keep_chunks_moving.sh > /dev/null << 'SHEOF'
+#!/bin/bash
+while true; do
+    mongo "mongodb://root:root@localhost" --quiet /tmp/keep_chunks_moving.js > /tmp/keep_chunks_moving.log 2>&1
+    sleep 240
+done
+SHEOF
+echo "starting background chunk-activity generator"
+docker compose -f docker-compose-sharded-with-pmm.yaml exec -d mongos bash /tmp/keep_chunks_moving.sh
 
 tests=${TESTS:-yes}
 if [ $tests != "no" ]; then

--- a/qa-integration/pmm_psmdb-pbm_setup/start-sharded-with-pmm.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/start-sharded-with-pmm.sh
@@ -309,6 +309,19 @@ docker compose -f docker-compose-sharded-with-pmm.yaml exec -T rscfg01 pmm-admin
 
 echo "adding some data"
 docker compose -f docker-compose-sharded-with-pmm.yaml exec -T mongos mgodatagen -f /etc/datagen/sharded.json --uri=mongodb://root:root@127.0.0.1:27017
+
+echo "triggering chunk migrations so the chunk-move dashboards have data"
+docker compose -f docker-compose-sharded-with-pmm.yaml exec -T mongos mongo "mongodb://root:root@localhost" --quiet --eval '
+    var coll = db.getSiblingDB("config").collections.findOne({ _id: "test.test" });
+    var shards = db.getSiblingDB("config").shards.find().toArray().map(function (s) { return s._id; });
+    db.getSiblingDB("config").chunks.find({ uuid: coll.uuid }).forEach(function (chunk) {
+        var target = shards.filter(function (s) { return s !== chunk.shard; })[0];
+        if (target) {
+            sh.moveChunk("test.test", chunk.min, target);
+        }
+    });
+'
+
 tests=${TESTS:-yes}
 if [ $tests != "no" ]; then
     echo "running tests"

--- a/qa-integration/pmm_psmdb-pbm_setup/start-sharded.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/start-sharded.sh
@@ -315,16 +315,28 @@ docker compose -f docker-compose-sharded.yaml exec -T rscfg01 pmm-admin add mong
 echo "adding some data"
 docker compose -f docker-compose-sharded.yaml exec -T mongos mgodatagen -f /etc/datagen/sharded.json --uri=mongodb://root:root@127.0.0.1:27017
 
-echo "triggering chunk migrations so the chunk-move dashboards have data"
+echo "triggering chunk migrations and splits so the chunk-move/split dashboards have data"
 docker compose -f docker-compose-sharded.yaml exec -T mongos mongo "mongodb://root:root@localhost" --quiet --eval '
     var coll = db.getSiblingDB("config").collections.findOne({ _id: "test.test" });
     var shards = db.getSiblingDB("config").shards.find().toArray().map(function (s) { return s._id; });
     db.getSiblingDB("config").chunks.find({ uuid: coll.uuid }).forEach(function (chunk) {
         var target = shards.filter(function (s) { return s !== chunk.shard; })[0];
         if (target) {
-            sh.moveChunk("test.test", chunk.min, target);
+            try {
+                sh.moveChunk("test.test", chunk.min, target);
+            } catch (e) {
+                print("moveChunk failed, skipping: " + e);
+            }
         }
     });
+    var doc = db.getSiblingDB("test").test.findOne();
+    if (doc) {
+        try {
+            sh.splitFind("test.test", { _id: doc._id });
+        } catch (e) {
+            print("splitFind failed, skipping: " + e);
+        }
+    }
 '
 
 tests=${TESTS:-yes}

--- a/qa-integration/pmm_psmdb-pbm_setup/start-sharded.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/start-sharded.sh
@@ -314,6 +314,19 @@ docker compose -f docker-compose-sharded.yaml exec -T rscfg01 pmm-admin add mong
 
 echo "adding some data"
 docker compose -f docker-compose-sharded.yaml exec -T mongos mgodatagen -f /etc/datagen/sharded.json --uri=mongodb://root:root@127.0.0.1:27017
+
+echo "triggering chunk migrations so the chunk-move dashboards have data"
+docker compose -f docker-compose-sharded.yaml exec -T mongos mongo "mongodb://root:root@localhost" --quiet --eval '
+    var coll = db.getSiblingDB("config").collections.findOne({ _id: "test.test" });
+    var shards = db.getSiblingDB("config").shards.find().toArray().map(function (s) { return s._id; });
+    db.getSiblingDB("config").chunks.find({ uuid: coll.uuid }).forEach(function (chunk) {
+        var target = shards.filter(function (s) { return s !== chunk.shard; })[0];
+        if (target) {
+            sh.moveChunk("test.test", chunk.min, target);
+        }
+    });
+'
+
 tests=${TESTS:-yes}
 if [ $tests != "no" ]; then
     echo "running tests"

--- a/qa-integration/pmm_psmdb-pbm_setup/start-sharded.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/start-sharded.sh
@@ -315,29 +315,32 @@ docker compose -f docker-compose-sharded.yaml exec -T rscfg01 pmm-admin add mong
 echo "adding some data"
 docker compose -f docker-compose-sharded.yaml exec -T mongos mgodatagen -f /etc/datagen/sharded.json --uri=mongodb://root:root@127.0.0.1:27017
 
-echo "triggering chunk migrations and splits so the chunk-move/split dashboards have data"
-docker compose -f docker-compose-sharded.yaml exec -T mongos mongo "mongodb://root:root@localhost" --quiet --eval '
-    var coll = db.getSiblingDB("config").collections.findOne({ _id: "test.test" });
-    var shards = db.getSiblingDB("config").shards.find().toArray().map(function (s) { return s._id; });
-    db.getSiblingDB("config").chunks.find({ uuid: coll.uuid }).forEach(function (chunk) {
-        var target = shards.filter(function (s) { return s !== chunk.shard; })[0];
-        if (target) {
-            try {
-                sh.moveChunk("test.test", chunk.min, target);
-            } catch (e) {
-                print("moveChunk failed, skipping: " + e);
-            }
-        }
-    });
-    var doc = db.getSiblingDB("test").test.findOne();
-    if (doc) {
-        try {
-            sh.splitFind("test.test", { _id: doc._id });
-        } catch (e) {
-            print("splitFind failed, skipping: " + e);
-        }
+echo "writing chunk-activity generator so the chunk-move/split dashboards keep getting data"
+docker compose -f docker-compose-sharded.yaml exec -T mongos tee /tmp/keep_chunks_moving.js > /dev/null << 'JSEOF'
+var shards = db.getSiblingDB("config").shards.find().toArray().map(function (s) { return s._id; });
+var ins = db.getSiblingDB("test").test.insertOne({ ts: new Date() });
+shards.forEach(function (target) {
+    try {
+        sh.moveChunk("test.test", { _id: ins.insertedId }, target);
+    } catch (e) {
+        print("moveChunk to " + target + " failed, skipping: " + e);
     }
-'
+});
+try {
+    sh.splitFind("test.test", { _id: ins.insertedId });
+} catch (e) {
+    print("splitFind failed, skipping: " + e);
+}
+JSEOF
+docker compose -f docker-compose-sharded.yaml exec -T mongos tee /tmp/keep_chunks_moving.sh > /dev/null << 'SHEOF'
+#!/bin/bash
+while true; do
+    mongo "mongodb://root:root@localhost" --quiet /tmp/keep_chunks_moving.js > /tmp/keep_chunks_moving.log 2>&1
+    sleep 240
+done
+SHEOF
+echo "starting background chunk-activity generator"
+docker compose -f docker-compose-sharded.yaml exec -d mongos bash /tmp/keep_chunks_moving.sh
 
 tests=${TESTS:-yes}
 if [ $tests != "no" ]; then

--- a/qa-integration/pmm_psmdb-pbm_setup/start-sharded.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/start-sharded.sh
@@ -145,6 +145,74 @@ docker compose -f docker-compose-sharded.yaml exec -T rscfg01 mongo --quiet << E
 EOF
 sleep 60
 echo
+echo "configuring root user on primary rscfg01 configserver replicaset"
+docker compose -f docker-compose-sharded.yaml exec -T rscfg01 mongo --quiet << EOF
+    db.getSiblingDB("admin").createUser({ user: "root", pwd: "root", roles: [ "root", "userAdminAnyDatabase", "clusterAdmin" ] });
+EOF
+echo
+echo "configuring pbm and pmm roles on configserver replicaset rscfg"
+docker compose -f docker-compose-sharded.yaml exec -T rscfg01 mongo "mongodb://root:root@localhost/?replicaSet=rscfg" --quiet << EOF
+db.getSiblingDB("admin").createRole({
+    "role": "pbmAnyAction",
+    "privileges": [{
+        "resource": { "anyResource": true },
+	    "actions": [ "anyAction" ]
+        }],
+    "roles": []
+});
+db.getSiblingDB("admin").createRole({
+    role: "explainRole",
+    privileges: [{
+        resource: {
+            db: "",
+            collection: ""
+            },
+        actions: [
+            "listIndexes",
+            "listCollections",
+            "dbStats",
+            "dbHash",
+            "collStats",
+            "find"
+            ]
+        }],
+    roles:[]
+});
+EOF
+echo
+echo "creating pbm user for configserver replicaset rscfg"
+docker compose -f docker-compose-sharded.yaml exec -T rscfg01 mongo "mongodb://root:root@localhost/?replicaSet=rscfg" --quiet << EOF
+db.getSiblingDB("admin").createUser({
+    user: "${pbm_user}",
+    pwd: "${pbm_pass}",
+    "roles" : [
+        { "db" : "admin", "role" : "readWrite", "collection": "" },
+        { "db" : "admin", "role" : "backup" },
+        { "db" : "admin", "role" : "clusterMonitor" },
+        { "db" : "admin", "role" : "restore" },
+        { "db" : "admin", "role" : "pbmAnyAction" }
+    ]
+});
+EOF
+echo
+echo "creating pmm user for configserver replicaset rscfg"
+docker compose -f docker-compose-sharded.yaml exec -T rscfg01 mongo "mongodb://root:root@localhost/?replicaSet=rscfg" --quiet << EOF
+db.getSiblingDB("admin").createUser({
+    user: "${pmm_mongo_user}",
+    pwd: "${pmm_mongo_user_pass}",
+    roles: [
+        { role: "explainRole", db: "admin" },
+        { role: "clusterMonitor", db: "admin" },
+        { role: "read", db: "local" },
+        { "db" : "admin", "role" : "readWrite", "collection": "" },
+        { "db" : "admin", "role" : "backup" },
+        { "db" : "admin", "role" : "clusterMonitor" },
+        { "db" : "admin", "role" : "restore" },
+        { "db" : "admin", "role" : "pbmAnyAction" }
+    ]
+});
+EOF
+echo
 echo "adding shards and creating global mongo user"
 docker compose -f docker-compose-sharded.yaml exec -T mongos mongo --quiet << EOF
 db.getSiblingDB("admin").createUser({ user: "root", pwd: "root", roles: [ "root", "userAdminAnyDatabase", "clusterAdmin" ] });


### PR DESCRIPTION
Configure PBM and PMM users on the config server replica sets in sharded MongoDB deployments.

This change adds user and role setup for the config server replica set (`rscfg`) in both the PMM-integrated and standalone sharded cluster initialization scripts:

- Create root user on the config server primary
- Define custom roles (`pbmAnyAction` and `explainRole`) required by PBM and PMM
- Create PBM user with appropriate backup and cluster permissions
- Create PMM user with monitoring and diagnostic permissions

These configurations mirror the existing setup for shard replica sets, ensuring consistent authentication and authorization across all cluster components.

https://claude.ai/code/session_01LyoNZANW3DpCvzF2th7b8d