### PR TITLE
Drop blanket apt-get upgrade from podman e2e Setup tools

### DIFF
--- a/.github/workflows/runner-e2e-tests-podman.yml
+++ b/.github/workflows/runner-e2e-tests-podman.yml
@@ -118,7 +118,6 @@ jobs:
               /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
           curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get -y upgrade
           sudo apt-get install -y clickhouse-client podman
           sudo curl -s https://raw.githubusercontent.com/datacharmer/dbdeployer/master/scripts/dbdeployer-install.sh | bash
           ls -la


### PR DESCRIPTION
Removes `sudo apt-get -y upgrade` from the `Setup tools` step of `runner-e2e-tests-podman.yml`.

## Why

[Run 31699074729](https://github.com/percona/pmm-qa/actions/runs/31699074729/job/94443609386) failed in `Setup tools`, before PMM Server was ever provisioned:

```
error: cannot perform the following tasks:
- Fetch and check assertions for snap "bare" (5) (cannot fetch assertion: got unexpected
  HTTP status code 503 via GET to "https://api.snapcraft.io/v2/assertions/snap-revision/...")
dpkg: error processing archive /tmp/apt-dpkg-install-YtAnvL/0-firefox_1%3a1snap1-0ubuntu2_amd64.deb (--unpack):
 new firefox package pre-installation script subprocess returned error exit status 1
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

On `ubuntu-22.04` runners the `firefox` deb is a transitional package whose `preinst` shells out to snapd. The blanket upgrade pulls it in, snapd could not reach `api.snapcraft.io`, `dpkg` failed, and the step exited 100 — taking `Setup PMM3-Server` through `Execute e2e tests` down as skipped.

## Why removal rather than a retry or a hold

Nothing in the step needs the upgrade. The packages the job actually installs — `clickhouse-client`, `podman`, and the list on the preceding `apt-get install` line — resolve fine without it. In exchange for no benefit it:

- makes the job depend on Snapcraft CDN availability for a browser these tests never use (they run Chrome via Playwright);
- silently bumps the browser under test — the same log shows `google-chrome-stable` going `150.0.7871.128` → `151.0.7922.137`. A UI test job upgrading Chrome to whatever shipped that morning is an uncontrolled variable;
- costs a couple of minutes of wall clock on every podman run.

## Scope

`runner-e2e-tests-podman.yml:121` was the only `apt-get upgrade`/`dist-upgrade` in `.github/workflows/`, so no other runner is affected. The failure itself is rare — zero other `Setup tools` failures across the last 25 `e2e-tests-matrix` runs (25 podman jobs sampled) — so this is hardening against a known-bad dependency rather than a fix for something currently broken.

One line deleted; YAML re-parsed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuyhRULjpXJMcTjs33ARAz

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuyhRULjpXJMcTjs33ARAz)_