### PR TITLE
Keep RTA mongo load and T1883 dashboard data from going idle

### DIFF
--- a/codeceptjs-e2e/tests/administration/serviceAccounts_test.js
+++ b/codeceptjs-e2e/tests/administration/serviceAccounts_test.js
@@ -8,6 +8,11 @@ let serviceAccountUsername = '';
 const newServiceName = 'mysql_service_service_token1';
 const loadDatabase = 'pmm_t1883_load';
 
+// PMM-T1883 leaves a detached write loop running; stop it even when the scenario fails.
+After(async ({ I }) => {
+  await I.verifyCommand(`sudo docker exec $(docker ps | grep ps_pmm | awk '{print $NF}') pkill -f "${loadDatabase}.write_load" || true`);
+});
+
 Scenario('PMM-T1883 - Configuring pmm-agent to use service account @service-account', async ({
   I, codeceptjsConfig, serviceAccountsPage, dashboardPage, inventoryAPI, nodesOverviewPage, credentials,
 }) => {

--- a/codeceptjs-e2e/tests/administration/serviceAccounts_test.js
+++ b/codeceptjs-e2e/tests/administration/serviceAccounts_test.js
@@ -6,6 +6,7 @@ Before(async ({ I }) => {
 
 let serviceAccountUsername = '';
 const newServiceName = 'mysql_service_service_token1';
+const loadDatabase = 'pmm_t1883_load';
 
 Scenario('PMM-T1883 - Configuring pmm-agent to use service account @service-account', async ({
   I, codeceptjsConfig, serviceAccountsPage, dashboardPage, inventoryAPI, nodesOverviewPage, credentials,
@@ -46,6 +47,13 @@ Scenario('PMM-T1883 - Configuring pmm-agent to use service account @service-acco
   await dashboardPage.waitForDashboardOpened();
   await dashboardPage.expandEachDashboardRow();
   await dashboardPage.waitForGraphsToHaveData(19, 300);
+
+  const mysqlCredentials = `-h 127.0.0.1 --port 3306 -u${credentials.perconaServer.root.username} -p${credentials.perconaServer.root.password}`;
+
+  await I.verifyCommand(`sudo docker exec ${psContainerName} mysql ${mysqlCredentials} -e "CREATE DATABASE IF NOT EXISTS ${loadDatabase}; CREATE TABLE IF NOT EXISTS ${loadDatabase}.write_load (id INT AUTO_INCREMENT PRIMARY KEY, value CHAR(36))"`);
+  // The InnoDB I/O panels below are ratios of the read/write/fsync rates, so an idle server makes
+  // them 0/0 and they render as "No data". Keep committing while the dashboard is polled.
+  await I.verifyCommand(`sudo docker exec -d ${psContainerName} timeout 420 bash -c 'while true; do mysql ${mysqlCredentials} -e "INSERT INTO ${loadDatabase}.write_load (value) VALUES (UUID())"; sleep 1; done'`);
 
   const url = I.buildUrlWithParams(dashboardPage.mySQLInstanceOverview.clearUrl, {
     from: 'now-1m',

--- a/e2e_tests/helpers/mongodb.helper.ts
+++ b/e2e_tests/helpers/mongodb.helper.ts
@@ -83,6 +83,10 @@ export default class MongoDBHelper {
     await this.ensureCollectionHasDocuments(collectionName, dbName, numDocs);
 
     const collection = this.client.db(dbName).collection(collectionName);
+    // The collection is shared by the whole suite and only ever grows, so the $where runs for
+    // every document present, not just the numDocs this call asked for. Budget maxTimeMS from
+    // the real count, otherwise the server kills the query it was told to keep running.
+    const scannedDocs = Math.max(numDocs, await collection.countDocuments());
     const escapedLabel = queryLabel.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
     const whereFn = [
       'function() {',
@@ -95,7 +99,14 @@ export default class MongoDBHelper {
 
     return collection
       .find({ $where: whereFn })
-      .maxTimeMS(delayMs * 3)
-      .toArray();
+      .maxTimeMS(scannedDocs * chunkMs * 3)
+      .toArray()
+      // Callers start these queries fire-and-forget, so a rejection would land as an unhandled
+      // rejection on whichever test is running by then, not on the one that started the query.
+      .catch((error: unknown) => {
+        console.log(`simulateLongRunningQuery("${queryLabel}") ended early: ${String(error)}`);
+
+        return [];
+      });
   };
 }

--- a/e2e_tests/helpers/mongodb.helper.ts
+++ b/e2e_tests/helpers/mongodb.helper.ts
@@ -80,31 +80,31 @@ export default class MongoDBHelper {
     } = options;
     const numDocs = Math.max(1, Math.ceil(delayMs / chunkMs));
 
-    await this.ensureCollectionHasDocuments(collectionName, dbName, numDocs);
-
-    const collection = this.client.db(dbName).collection(collectionName);
-    // The collection is shared by the whole suite and only ever grows, so the $where runs for
-    // every document present, not just the numDocs this call asked for. Budget maxTimeMS from
-    // the real count, otherwise the server kills the query it was told to keep running.
-    const scannedDocs = Math.max(numDocs, await collection.countDocuments());
-    const escapedLabel = queryLabel.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    const whereFn = [
-      'function() {',
-      `  var __rtaLabel = "${escapedLabel}";`,
-      `  var end = new Date().getTime() + ${chunkMs};`,
-      '  while (new Date().getTime() < end) {}',
-      '  return true;',
-      '}',
-    ].join(' ');
-
     try {
+      await this.ensureCollectionHasDocuments(collectionName, dbName, numDocs);
+
+      const collection = this.client.db(dbName).collection(collectionName);
+      // The collection is shared by the whole suite and only ever grows, so the $where runs for
+      // every document present, not just the numDocs this call asked for. Budget maxTimeMS from
+      // the real count, otherwise the server kills the query it was told to keep running.
+      const scannedDocs = Math.max(numDocs, await collection.countDocuments());
+      const escapedLabel = queryLabel.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      const whereFn = [
+        'function() {',
+        `  var __rtaLabel = "${escapedLabel}";`,
+        `  var end = new Date().getTime() + ${chunkMs};`,
+        '  while (new Date().getTime() < end) {}',
+        '  return true;',
+        '}',
+      ].join(' ');
+
       return await collection
         .find({ $where: whereFn })
         .maxTimeMS(scannedDocs * chunkMs * 3)
         .toArray();
     } catch (error) {
-      // Callers start these queries fire-and-forget, so an escaping rejection would land as an
-      // unhandled rejection on whichever test runs by then, not the one that started the query.
+      // Callers start these queries fire-and-forget, so an escaping rejection from any of these
+      // steps would land on whichever test runs by then, not the one that started the query.
       console.log(`simulateLongRunningQuery("${queryLabel}") ended early: ${String(error)}`);
 
       return [];

--- a/e2e_tests/helpers/mongodb.helper.ts
+++ b/e2e_tests/helpers/mongodb.helper.ts
@@ -97,16 +97,17 @@ export default class MongoDBHelper {
       '}',
     ].join(' ');
 
-    return collection
-      .find({ $where: whereFn })
-      .maxTimeMS(scannedDocs * chunkMs * 3)
-      .toArray()
-      // Callers start these queries fire-and-forget, so a rejection would land as an unhandled
-      // rejection on whichever test is running by then, not on the one that started the query.
-      .catch((error: unknown) => {
-        console.log(`simulateLongRunningQuery("${queryLabel}") ended early: ${String(error)}`);
+    try {
+      return await collection
+        .find({ $where: whereFn })
+        .maxTimeMS(scannedDocs * chunkMs * 3)
+        .toArray();
+    } catch (error) {
+      // Callers start these queries fire-and-forget, so an escaping rejection would land as an
+      // unhandled rejection on whichever test runs by then, not the one that started the query.
+      console.log(`simulateLongRunningQuery("${queryLabel}") ended early: ${String(error)}`);
 
-        return [];
-      });
+      return [];
+    }
   };
 }


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4529](https://github.com/Percona-Lab/pmm-submodules/pull/4529) — run [32064897776](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32064897776), checks `E2E / RTA tests / e2e tests: @rta` (job [95494517196](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32064897776/job/95494517196)) and `E2E / Service Accounts tests / e2e tests: @service-account` (job [95494516721](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32064897776/job/95494516721))
- tests:
  - `e2e_tests/tests/qan/rta/overview.test.ts:286` / `@rta` — PMM-T2266 "Verify RTA elapsed-time decimal filter and URL restoration"
  - `codeceptjs-e2e/tests/administration/serviceAccounts_test.js:10` / `@service-account` — PMM-T1883 "Configuring pmm-agent to use service account"

Two unrelated failures in the same FB run, both in our own test setup. Neither is a
product problem: both tags pass on other FB builds from the same day
([32033692968](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32033692968),
[32066972305](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32066972305)),
and both root causes are in pmm-qa.

## @rta — a killed background mongo query fails an unrelated test

`simulateLongRunningQuery` budgets `maxTimeMS` from the requested `delayMs`, but its
`$where` scan covers **every** document in the shared `admin.test` collection, which
`details.test.ts` seeds up to 6 (`ensureCollectionHasDocuments('test', 'admin', 6)`).
So PMM-T2184's `delayMs: TEN_SECONDS` query (2 docs' worth of budget → `maxTimeMS`
30 s) actually scans 6 docs at `chunkMs` 5 s each ≈ 30 s and the server kills it:

```
MongoServerError: Executor error during find command: admin.test :: caused by :: operation exceeded time limit
```

Callers start these queries fire-and-forget (`void mongoDbHelper.simulateLongRunningQuery(...)`),
so the rejection arrives unhandled and Playwright charges it to whichever test is running
by then — PMM-T2266 in CI, PMM-T2265 in the local repro. That test never touches mongo,
which is why the failure looks unrelated to its own assertions. Playwright then marks it
`flaky` (the retry passes) but Launchable's gate still counts the recorded first-attempt
failure, so the check goes red.

Fix: budget `maxTimeMS` from the documents actually scanned, and catch at the source so a
fire-and-forget query can never surface as an unhandled rejection.

## @service-account — three InnoDB ratio panels are 0/0 on an idle server

PMM-T1883 asserts MySQL Instances Overview over a `now-1m` window right after adding the
service, tolerating 1 empty panel. CI reported 3:

```
Expected 1 Elements without data but found 3 ... Report Names are
Top InnoDB I/O Data Reads, Top InnoDB I/O Data Writes, Top Data Fsyncs
```

All three are ratios of the same three rates, e.g.

```promql
clamp_max(max(rate(mysql_global_status_innodb_data_reads[$interval]) /
  (rate(..._data_reads[$interval]) + rate(..._data_writes[$interval]) + rate(..._data_fsyncs[$interval]))), 1)
```

Nothing generates MySQL activity for the service the test just added, so on an idle
Percona Server all three rates are 0, the expression is 0/0, and all three panels render
"No data" — whether the test passes depends on whether the idle server happens to flush
during the window.

Fix: generate writes on the new service while the dashboard is polled. Deliberately **not**
raising the tolerated-empty-panel count — that would switch off a real "PMM shows no data
here" signal.

## Verification

Repro VM (Linode, `perconalab/pmm-server-fb:PR-4529-9e69786` + client tarball
`pmm-client-PR-4529-9e69786.tar.gz`, `pmm-framework --database psmdb` / `--database ps=8.0`,
same steps as `runner-e2e-tests-playwright.yml` / `runner-e2e-tests-codeceptjs.yml`):

| | before | after |
|---|---|---|
| `@rta` (21 tests) | reproduced on the first run — same `MongoServerError`, landing on PMM-T2265 → `1 flaky` | 21/21 passed, twice, zero mongo errors |
| `@service-account` (3 tests) | passed (idle margin held that time), but the three ratio panels evaluated **empty** at `$interval=15s` while the rest of the dashboard had data — the exact CI state | 3/3 passed on a freshly recreated server + `ps=8.0`; panels populated (writes ≈ 13.8/s, fsyncs ≈ 8.4/s) throughout the poll window |

The `@service-account` failure is intermittent, so the repro is at the metric level rather
than a red test: querying the panel expressions against the live FB server showed all three
rates at exactly 0 → empty result, then values as soon as the new load step ran. The final
`@service-account` run used a rebuilt server and a fresh `ps=8.0` container rather than the
long-lived state from earlier iterations, but only the next real FB/nightly run can confirm
it end-to-end in CI.

`npx eslint` clean for both changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_011pBdLbb82SttxdQG1119DQ)_