### PR TITLE
Make e2e client/framework setup steps survive a hung command

### DIFF
--- a/.github/workflows/ha-e2e-tests.yml
+++ b/.github/workflows/ha-e2e-tests.yml
@@ -147,10 +147,15 @@ jobs:
           timeout_minutes: 10
           retry_wait_seconds: '10'
           max_attempts: 2
-          retry_on: 'error'
+          retry_on: 'any'
           command: |
             cd pmm-qa/qa-integration/pmm_qa
-            sudo bash -x pmm3-client-setup.sh \
+            # Inner timeout must fire before timeout_minutes above: a step the
+            # action times out itself is killed via tree-kill, which cannot
+            # signal the root-owned `sudo` child and dies on EPERM, taking the
+            # whole retry loop with it. Self-terminating returns exit 124 and
+            # leaves the retry loop intact.
+            sudo timeout -k 30 9m bash -x pmm3-client-setup.sh \
               --pmm_server_ip "${SERVER_IP}" \
               --client_version "${PMM_CLIENT_VERSION}" \
               --admin_password "${ADMIN_PASSWORD}" \
@@ -163,11 +168,11 @@ jobs:
           timeout_minutes: 20
           retry_wait_seconds: '10'
           max_attempts: 2
-          retry_on: 'error'
+          retry_on: 'any'
           command: |
             cd pmm-qa/qa-integration/pmm_qa
             mkdir -m 777 -p /tmp/backup_data || true
-            ./pmm-framework/pmm-framework \
+            timeout -k 30 19m ./pmm-framework/pmm-framework \
               --parallel \
               --pmm-server-ip "${SERVER_IP}" \
               --pmm-server-password "${ADMIN_PASSWORD}" \

--- a/.github/workflows/ha-e2e-tests.yml
+++ b/.github/workflows/ha-e2e-tests.yml
@@ -150,11 +150,6 @@ jobs:
           retry_on: 'any'
           command: |
             cd pmm-qa/qa-integration/pmm_qa
-            # Inner timeout must fire before timeout_minutes above: a step the
-            # action times out itself is killed via tree-kill, which cannot
-            # signal the root-owned `sudo` child and dies on EPERM, taking the
-            # whole retry loop with it. Self-terminating returns exit 124 and
-            # leaves the retry loop intact.
             sudo timeout -k 30 9m bash -x pmm3-client-setup.sh \
               --pmm_server_ip "${SERVER_IP}" \
               --client_version "${PMM_CLIENT_VERSION}" \

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -108,10 +108,15 @@ jobs:
           timeout_minutes: 10
           retry_wait_seconds: '10'
           max_attempts: 2
-          retry_on: 'error'
+          retry_on: 'any'
           command: |
             cd pmm-qa/qa-integration/pmm_qa
-            sudo bash -x pmm3-client-setup.sh \
+            # Inner timeout must fire before timeout_minutes above: a step the
+            # action times out itself is killed via tree-kill, which cannot
+            # signal the root-owned `sudo` child and dies on EPERM, taking the
+            # whole retry loop with it. Self-terminating returns exit 124 and
+            # leaves the retry loop intact.
+            sudo timeout -k 30 9m bash -x pmm3-client-setup.sh \
               --pmm_server_ip "${SERVER_IP}" \
               --client_version "${{ env.PMM_CLIENT_VERSION }}" \
               --admin_password "${{ env.ADMIN_PASSWORD }}" \
@@ -123,11 +128,11 @@ jobs:
           timeout_minutes: 20
           retry_wait_seconds: '10'
           max_attempts: 2
-          retry_on: 'error'
+          retry_on: 'any'
           command: |
             cd pmm-qa/qa-integration/pmm_qa
             mkdir -m 777 -p /tmp/backup_data || true
-            ./pmm-framework/pmm-framework \
+            timeout -k 30 19m ./pmm-framework/pmm-framework \
               --parallel \
               --pmm-server-ip "${SERVER_IP}" \
               --pmm-server-password "${{ env.ADMIN_PASSWORD }}" \

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -111,11 +111,6 @@ jobs:
           retry_on: 'any'
           command: |
             cd pmm-qa/qa-integration/pmm_qa
-            # Inner timeout must fire before timeout_minutes above: a step the
-            # action times out itself is killed via tree-kill, which cannot
-            # signal the root-owned `sudo` child and dies on EPERM, taking the
-            # whole retry loop with it. Self-terminating returns exit 124 and
-            # leaves the retry loop intact.
             sudo timeout -k 30 9m bash -x pmm3-client-setup.sh \
               --pmm_server_ip "${SERVER_IP}" \
               --client_version "${{ env.PMM_CLIENT_VERSION }}" \


### PR DESCRIPTION
## Failures fixed (investigator)

- source: nightly CI run [32086846152](https://github.com/percona/pmm-qa/actions/runs/32086846152) (Nightly E2E tests Matrix, 2026-08-18)
- tests:
  - `.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml` / `setup / valkey` — setup step "Setup PMM-Client against remote PMM Server" (job [95561056169](https://github.com/percona/pmm-qa/actions/runs/32086846152/job/95561056169))

## What failed

`setup / valkey` hung in `apt-get update` (no response from `azure.archive.ubuntu.com`, then `archive.ubuntu.com`) and never recovered. At exactly `timeout_minutes: 10` the step died — and because `fail-fast: true` on the setup matrix, all 12 other setup shards were cancelled and both `test execution / …` jobs failed waiting on setup. **One shard's transient network stall took down the entire 14-shard nightly.** No test ever ran.

The apt stall itself is external infra flake — nothing to fix here, and not reproducible on demand. What *is* ours is that the retry wrapping that step could not fire.

## Why the retry never fired

The step is wrapped in `nick-fields/retry@v3` with `max_attempts: 2`, yet the log shows only `##[group]Attempt 1` and then:

```
Error: kill EPERM
    at process.kill (node:internal/process/per_thread:277:13)
    at killPid (…/nick-fields/retry/v3/dist/index.js:1941:17)
    at killAll (…/nick-fields/retry/v3/dist/index.js:1915:27)
```

Two independent reasons, both fixed here:

1. **`retry_on: 'error'` excludes timeouts by construction.** The action's documented values are `any` (default) / `timeout` / `error`; `error` retries only a non-zero exit, never the action's own timeout. The one failure mode these setup steps are most exposed to — a network hang — was the one they could never retry.
2. **The `sudo` child makes the timeout path fatal.** On timeout the action kills the command with tree-kill *before* it evaluates `retry_on`. The command runs as `sudo bash -x pmm3-client-setup.sh`, so the process tree is root-owned and the runner-user Node process cannot signal it. The `EPERM` escapes as an uncaught exception and terminates the action outright — so fixing (1) alone would still not have produced a retry.

## The fix

Give each wrapped command an inner `timeout` that fires *before* the action's `timeout_minutes` (9m inside 10m, 19m inside 20m). A hang then self-terminates with exit 124, which the action sees as an ordinary command failure — no tree-kill, no `EPERM`, retry loop intact. `retry_on` is also widened to `any` so an action-level timeout is not silently unretryable either.

Applied to all four retry blocks that share this shape, in `runner-e2e-tests-codeceptjs-remote-nightly-setup.yml` and `ha-e2e-tests.yml`.

## Verification

On a throwaway Linode VM (`perconalab/pmm-server:3-dev-latest`, pmm-admin 3.9.1):

- **Failure mode reproduced directly.** Killing the parent of a `sudo` command leaves a root-owned orphan, and the non-root caller gets `kill: Operation not permitted` — the `EPERM` the action dies on.
- **New shape behaves as intended.** `sudo timeout -k 30 <n> …` returns `EXIT_CODE=124` to the non-root caller with no orphan left behind.
- **Happy path unaffected.** Both wrapped commands still exit 0 as changed: `sudo timeout -k 30 9m bash -x pmm3-client-setup.sh …` → 0, and `timeout -k 30 19m ./pmm-framework/pmm-framework --database valkey` → `[1/1] valkey: OK`, exit 0.

What only a real CI run can confirm: that a genuine runner-side network stall now produces an Attempt 2 rather than a dead job. The apt hang cannot be induced on demand, so that part rests on the mechanism above, not on an observed retry.

## Not fixed here (separate, already tracked)

The nightly has *also* been red every night since 2026-08-11 for an unrelated reason, which tonight's run never reached because setup died first: `PMM-T1061` and `PMM-T1790` fail in `QueryAnalyticsData.searchByValue()` with `Clickable element "//input[contains(@name, "search")]" was not found`. That is a PMM product regression from PMM-14848 / percona/pmm#5537 — the QAN search input unmounts on its own debounced refetch — tracked as **PMM-15336** (In Progress). The tests are correct and are deliberately left untouched; relaxing them would hide that defect.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXYonxvBpXSiCJkC2QuJNc)_