### PR TITLE
Wait out QAN's debounced search reload before reusing the field

### DIFF
--- a/codeceptjs-e2e/tests/pages/components/queryAnalytics/queryAnalyticsData.js
+++ b/codeceptjs-e2e/tests/pages/components/queryAnalytics/queryAnalyticsData.js
@@ -150,11 +150,22 @@ class QueryAnalyticsData {
     return await I.grabAttributeFrom(this.buttons.lastPage, 'title');
   }
 
+  // QAN searches as you type on a ~300ms debounce (percona/pmm#5537), so clearing a
+  // non-empty search field reloads the overview table, and the table unmounts its whole
+  // header — this input included — while loading. Let that reload finish before the field
+  // is touched again.
+  waitForSearchReload() {
+    I.wait(1);
+    queryAnalyticsPage.waitForLoaded();
+    I.waitForVisible(this.fields.searchBy, 30);
+  }
+
   searchByValue(value, refresh = false) {
     I.waitForVisible(this.elements.queryRow(0), 30);
     I.waitForVisible(this.fields.searchBy, 30);
     I.wait(1);
     I.clearField(this.fields.searchBy);
+    this.waitForSearchReload();
     I.click(this.fields.searchBy);
     I.fillField(this.fields.searchBy, value);
     I.pressKey('Enter');
@@ -165,6 +176,7 @@ class QueryAnalyticsData {
     I.waitForVisible(this.fields.searchBy, 30);
     I.wait(1);
     I.clearField(this.fields.searchBy);
+    this.waitForSearchReload();
     I.click(this.fields.searchBy);
     I.fillField(this.fields.searchBy, value);
   }

--- a/codeceptjs-e2e/tests/pages/components/queryAnalytics/queryAnalyticsData.js
+++ b/codeceptjs-e2e/tests/pages/components/queryAnalytics/queryAnalyticsData.js
@@ -150,10 +150,8 @@ class QueryAnalyticsData {
     return await I.grabAttributeFrom(this.buttons.lastPage, 'title');
   }
 
-  // QAN searches as you type on a ~300ms debounce (percona/pmm#5537), so clearing a
-  // non-empty search field reloads the overview table, and the table unmounts its whole
-  // header — this input included — while loading. Let that reload finish before the field
-  // is touched again.
+  // QAN searches as you type on a ~300ms debounce
+  // Remove when bug is addressed: https://perconadev.atlassian.net/browse/PMM-15336
   waitForSearchReload() {
     I.wait(1);
     queryAnalyticsPage.waitForLoaded();


### PR DESCRIPTION
## Failures fixed (investigator)

- source: nightly CI run [32083450029](https://github.com/percona/pmm-qa/actions/runs/32083450029) — `Nightly E2E tests Matrix (remote PMM Server)`, job `test execution / @qan|@menu|@valkey-nightly|@permissions-nightly|@pt-summary-nightly|@pbm-nightly` ([95550882143](https://github.com/percona/pmm-qa/actions/runs/32083450029/job/95550882143))
- tests:
  - `codeceptjs-e2e/tests/QAN/details_explain_test.js` / `@qan` — PMM-T1790 "Verify that there is any no error on Explains after switching between queries from different DB servers"
  - `codeceptjs-e2e/tests/QAN/overview_test.js` / `@qan` — PMM-T1061 "Verify Plan and PlanID with pg_stat_monitor"

Not a product problem — a stale interaction in our own page object. Both tests fail at
the identical line with the identical error, and have done so every night since the
feature below landed (runs [32083450029](https://github.com/percona/pmm-qa/actions/runs/32083450029),
[31981108239](https://github.com/percona/pmm-qa/actions/runs/31981108239),
[31916469379](https://github.com/percona/pmm-qa/actions/runs/31916469379),
[31852756475](https://github.com/percona/pmm-qa/actions/runs/31852756475)) — this is not flake.

## Root cause

```
Clickable element "//input[contains(@name, "search")]" was not found by text|CSS|XPath
  ✖ I.click("//input[contains(@name, "search")]")   at QueryAnalyticsData.searchByValue (queryAnalyticsData.js:158)
  ✔ I.clearField("//input[contains(@name, "search")]") at QueryAnalyticsData.searchByValue (queryAnalyticsData.js:157)
```

The field is visible, `clearField` succeeds on it, and ~600 ms later the very same
locator matches nothing.

[percona/pmm#5537](https://github.com/percona/pmm/pull/5537) (PMM-14848, merged
2026-08-11, ships in 3.10.0) made QAN **search as you type** on a 300 ms debounce —
`Search.tsx` now fires `handleSearch` from `onChange`, where it previously only fired on
form submit. So `clearField` on a *non-empty* search field is no longer inert: it
schedules a search, which reloads the overview table.

`QanTable/Table.tsx` renders the spinner and the table as mutually exclusive branches:

```tsx
{loading ? (<div data-testid="table-loading"><Spinner /></div>) : null}
{!loading ? (<div className="table"> … {headerGroups.map(RenderHeader)} … </div>) : null}
```

The search input lives inside the table's own column header (`Dimension` → `Search`), so
while loading the whole header — input included — is unmounted. `searchByValue` cleared
the field and then clicked it with no wait in between, racing the reload it had just
caused. The failure screenshot from the nightly shows exactly this: table area blank
behind a spinner.

That also explains why only these two of the ~15 `searchByValue` calls fail — they are
the only two that clear a field which actually had content (`'SELECT'` in T1790, `'pgsm_t1 t1'`
in T1061). Everywhere else the field is already empty, `fill('')` changes nothing, and no
reload is triggered.

## Fix

Wait for the reload the clear triggers, and for the input to come back, before touching
the field again. The sibling `click()` helper carried the identical sequence and the same
latent race, so it uses the new helper too.

## Verification

Throwaway Linode VM, `perconalab/pmm-server:3-dev-latest` at digest `sha256:0f28a1cad993…`
— the same image digest the failing nightly ran against — with `ps` + `pdpgsql` + `psmdb`
via the unmodified `pmm-framework`.

| Spec (`--grep @qan`) | `main` (57611b1) | this branch |
|---|---|---|
| `overview_test.js` | 20 passed, **1 failed** — PMM-T1061, trace identical to the nightly | **21 passed, 0 failed** |
| `details_explain_test.js` | **PMM-T1790 failed**, trace identical to the nightly | **PMM-T1790 passed** (65.8 s) |

Same 2 skips and the same 6 min wall clock in both overview runs — the added waits cost
nothing measurable and no other test changed state.

Two `PMM-T13` cases fail in `details_explain_test.js` on this VM both before *and* after
the change ("no examples found for this query"). They are an artifact of the repro box
holding far less query history than the nightly fleet, are not in the nightly's failure
list, and are untouched by this PR.

One caveat worth stating plainly: PMM-T1061 reproduces only when the whole spec file runs,
not when grepped alone — the race widens with dataset size, and the isolated run's reload
is too fast to lose the click. The next real nightly is the confirmation that both are
green under CI's much larger dataset.

---
_Generated by [Claude Code](https://claude.ai/code/session_014h6oG6ibboYHyctDcYCfEW)_