### PR TITLE
Apply the PMM version gate to every spec, not just the first one

### DIFF
--- a/e2e_tests/api/server.api.ts
+++ b/e2e_tests/api/server.api.ts
@@ -3,7 +3,7 @@ import GrafanaHelper from '@helpers/grafana.helper';
 import { Timeouts } from '@helpers/timeouts';
 import apiEndpoints from '@helpers/apiEndpoints';
 
-interface PmmVersion {
+export interface PmmVersion {
   major: number;
   minor: number;
   patch: number;

--- a/e2e_tests/fixtures/pmmTest.ts
+++ b/e2e_tests/fixtures/pmmTest.ts
@@ -25,7 +25,8 @@ import SettingsPage from '@pages/ha/settings.page';
 import HighAvailabilityPage from '@pages/ha/highAvailability.page';
 import UpdatesPage from '@pages/updates.page';
 import DownloadsPage from '@pages/downloads.page';
-import { serverVersionBelow } from '@helpers/version.helper';
+import ServerApi from '@api/server.api';
+import { getServerVersion, serverVersionBelow } from '@helpers/version.helper';
 import { minPmmVersion } from '@helpers/versionGates';
 
 const pmmTest = base.extend<{
@@ -52,6 +53,7 @@ const pmmTest = base.extend<{
   nodesPage: NodesPage;
   realTimeAnalyticsPage: RealTimeAnalyticsPage;
   vacuumDashboardPage: VacuumDashboard;
+  versionGate: undefined;
   updatesPage: UpdatesPage;
   downloadsPage: DownloadsPage;
 }>({
@@ -168,14 +170,24 @@ const pmmTest = base.extend<{
     await use(urlHelper);
   },
   vacuumDashboardPage: async ({ page }, use) => await use(new VacuumDashboard(page)),
-});
+  // Registering this as a beforeEach hook would only gate the first spec file that imports this
+  // module, since the module is evaluated once and the hook attaches to the file loading at that
+  // moment. An auto fixture applies to every test instead.
+  versionGate: [
+    async ({ request }, use, testInfo) => {
+      const testId = testInfo.title.match(/PMM-T\d+/)?.[0];
+      const minVersion = testId ? minPmmVersion[testId] : undefined;
 
-pmmTest.beforeEach(async ({ api }, testInfo) => {
-  const testId = testInfo.title.match(/PMM-T\d+/)?.[0];
-  const minVersion = testId ? minPmmVersion[testId] : undefined;
-  if (!minVersion) return;
+      if (minVersion) {
+        const version = await getServerVersion(new ServerApi(request));
 
-  pmmTest.skip(serverVersionBelow(await api.serverApi.getPmmVersion(), minVersion), `Requires PMM Server ${minVersion}+`);
+        testInfo.skip(serverVersionBelow(version, minVersion), `Requires PMM Server ${minVersion}+`);
+      }
+
+      await use(undefined);
+    },
+    { auto: true },
+  ],
 });
 
 export default pmmTest;

--- a/e2e_tests/helpers/version.helper.ts
+++ b/e2e_tests/helpers/version.helper.ts
@@ -3,9 +3,17 @@ import ServerApi, { PmmVersion } from '@api/server.api';
 let cachedVersion: Promise<PmmVersion> | undefined;
 
 // One request per worker process: the promise is cached, so parallel tests share the same
-// in-flight call instead of each hitting the server.
-export const getServerVersion = (serverApi: ServerApi): Promise<PmmVersion> =>
-  (cachedVersion ??= serverApi.getPmmVersion());
+// in-flight call instead of each hitting the server. A failed lookup is not cached, otherwise
+// one transient error would fail every gated test in the worker.
+export const getServerVersion = (serverApi: ServerApi): Promise<PmmVersion> => {
+  cachedVersion ??= serverApi.getPmmVersion().catch((error: unknown) => {
+    cachedVersion = undefined;
+
+    throw error;
+  });
+
+  return cachedVersion;
+};
 
 export const serverVersionBelow = (
   version: { major: number; minor: number; patch: number },

--- a/e2e_tests/helpers/version.helper.ts
+++ b/e2e_tests/helpers/version.helper.ts
@@ -1,3 +1,12 @@
+import ServerApi, { PmmVersion } from '@api/server.api';
+
+let cachedVersion: Promise<PmmVersion> | undefined;
+
+// One request per worker process: the promise is cached, so parallel tests share the same
+// in-flight call instead of each hitting the server.
+export const getServerVersion = (serverApi: ServerApi): Promise<PmmVersion> =>
+  (cachedVersion ??= serverApi.getPmmVersion());
+
 export const serverVersionBelow = (
   version: { major: number; minor: number; patch: number },
   minVersion: string,

--- a/e2e_tests/helpers/versionGates.ts
+++ b/e2e_tests/helpers/versionGates.ts
@@ -1,5 +1,6 @@
 // Specs keyed by their PMM-T id skip when the running server is below this version.
 export const minPmmVersion: Record<string, string> = {
+  'PMM-T2029': '3.10.0',
   'PMM-T2202': '3.10.0',
   'PMM-T2262': '3.10.0',
   'PMM-T2263': '3.10.0',


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [RC Testing Suite run 32139905215](https://github.com/percona/pmm-qa/actions/runs/32139905215) (server `perconalab/pmm-server:3.9.1-rc`), jobs [95752836680](https://github.com/percona/pmm-qa/actions/runs/32139905215/job/95752836680) (`OL9 PSMDB @rta`), [95752836460](https://github.com/percona/pmm-qa/actions/runs/32139905215/job/95752836460) (`OL8 PSMDB @rta`), [95719954746](https://github.com/percona/pmm-qa/actions/runs/32139905215/job/95719954746) (`FB E2E @rta`), [95719950852](https://github.com/percona/pmm-qa/actions/runs/32139905215/job/95719950852) (`@new-navigation`), [95719953756](https://github.com/percona/pmm-qa/actions/runs/32139905215/job/95719953756) (`@pmm-ps-integration`)
- source: [PSMDB GSSAPI E2E Tests Matrix run 32208328543](https://github.com/percona/pmm-qa/actions/runs/32208328543) (server `perconalab/pmm-server:3-dev-latest`, which reports `3.9.1-v3-cbf31f02a`), job [95935771133](https://github.com/percona/pmm-qa/actions/runs/32208328543/job/95935771133) (`OL8 PSMDB @rta`)
- tests:
  - `e2e_tests/tests/qan/rta/overview.test.ts:245` / `@rta` — PMM-T2265
  - `e2e_tests/tests/qan/rta/overview.test.ts:286` / `@rta` — PMM-T2266
  - `e2e_tests/tests/qan/rta/session.test.ts:55` / `@rta` — PMM-T2267
  - `e2e_tests/tests/helpCenter.test.ts:164` / `@new-navigation` — PMM-T2263
  - `e2e_tests/tests/navigation.test.ts:148` / `@new-navigation` — PMM-T2202
  - `e2e_tests/tests/dashboards/mysql/mysqlDashboards.test.ts:147` / `@pmm-ps-integration` — PMM-T2029
  - `e2e_tests/tests/qan/storedMetrics/urlState.test.ts:15` / `@rta` — PMM-T2268 (from the nightly above; already in `minPmmVersion`, so this PR needs no extra change for it)

Every one of these asserts behavior that is genuinely absent from 3.9.1: the feature PR is an ancestor of the `pmm-3.9.1` tip but was reverted on that branch. The first five are already in `minPmmVersion` at `3.10.0` and should have been skipped — the gate never runs for them. PMM-T2029 was missing from the list.

## The gate only ever covered one file

`fixtures/pmmTest.ts` registers the check as a module-scope hook:

```ts
pmmTest.beforeEach(async ({ api }, testInfo) => { … pmmTest.skip(serverVersionBelow(…), …) });
```

The module is evaluated once — while the **first** spec file that imports it is being loaded — and Playwright attaches the hook to that file's root suite. Every other spec file gets no gate.

Verified in this repo with two throwaway specs importing `@fixtures/pmmTest`, on `main` (hook body replaced with a log line so the browser dependency doesn't mask it):

```
GATE HOOK ATTACHED-AND-RAN for: PMM-T2265 gate probe in first file @tmpgate
  -> would gate on 3.10.0
  ✓  1 tests/tmpgate/aOverview.test.ts › PMM-T2265 gate probe in first file
GATE HOOK ATTACHED-AND-RAN for: PMM-T9999 ungated probe @tmpgate
  ✓  2 tests/tmpgate/aOverview.test.ts › PMM-T9999 ungated probe
  ✓  3 tests/tmpgate/bSession.test.ts  › PMM-T2267 gate probe in second file   ← hook never ran
```

Running `bSession.test.ts` on its own does get the hook, so which file it lands on is just load order — it is not stable across runs or worker restarts.

That matches the CI run exactly: the gate commit (`1b66224`) is an ancestor of the run's SHA (`b8f6c3b`), `versionGates.ts` at that SHA lists `PMM-T2265: '3.10.0'`, the server reported `Version: 3.9.1`, and there is no `Requires PMM Server 3.10.0+` anywhere in any job log — every gated test ran. In the `@rta` job the hook had landed on `tests/inventory/services.test.ts` (PMM-T2159, not gated), so nothing was gated at all.

## Change

Move the check into an auto fixture, which applies to every test regardless of load order, and memoize the version lookup:

- `helpers/version.helper.ts` — `getServerVersion()` caches the promise, so it is one request per worker process rather than one per gated test, and concurrent tests in a worker share the in-flight call.
- `fixtures/pmmTest.ts` — `versionGate` auto fixture; tests whose id is not in `minPmmVersion` make no request at all. It depends on `request` rather than `api` so it does not pull a browser `page` into tests that never open one (the old hook did, via `api: ({ page, request })`).
- `api/server.api.ts` — export `PmmVersion` so the helper can type the cache.
- `helpers/versionGates.ts` — add `PMM-T2029`. It calls `dashboard.selectVariableValue('Environment', …)` on MySQL Replication Summary; the Environment picker comes from [percona/pmm#5647](https://github.com/percona/pmm/pull/5647) (PMM-13932), reverted on `pmm-3.9.1` (`6edca30`), where the variable is still `hide: 2` and never renders. Same class as the entries already there.

The existing `3.10.0` values are otherwise left alone — they are correct. [percona/pmm#5537](https://github.com/percona/pmm/pull/5537) (RTA URL state), [#5694](https://github.com/percona/pmm/pull/5694) (update-popup snooze, PMM-T2263) and [#5636](https://github.com/percona/pmm/pull/5636) (MongoDB Unused Indexes, reached via the PMM-T2202 menu walk) are all reverted on `pmm-3.9.1` (`6d729c8`, `949bd7a`, `7a17a2a`).

## Verification

Same two throwaway specs, this time with the real fixture and a stub server on `/v1/version` returning `3.9.1`:

```
-  1 [chromium] › tests/tmpgate/aOverview.test.ts › PMM-T2265 gate probe in first file @tmpgate
✓  2 [chromium] › tests/tmpgate/aOverview.test.ts › PMM-T9999 ungated probe @tmpgate (26ms)
-  3 [chromium] › tests/tmpgate/bSession.test.ts  › PMM-T2267 gate probe in second file @tmpgate
2 skipped · 1 passed

stub server log:
VERSION_CALL 1 /v1/version      ← one call for the whole run
```

Both gated tests skip, in both files; the ungated test triggers no request. The probe specs were removed before committing.

`npx tsc --noEmit` and `npx eslint` clean on the changed files. What this cannot prove locally is the real suite against a real server — the next RC/nightly run is what confirms these tests skip on 3.9.x and still run on 3.10.

## Confirmed live on a real 3.9.1 server

The nightly added above is the same defect, observed end to end on a throwaway Linode VM running
`perconalab/pmm-server:3-dev-latest` at digest `sha256:2cf5b658…` — byte-identical to the image the failing
nightly used — with `pmm-framework --database psmdb,OL_VERSION=8,GSSAPI=true`. The server reports
`3.9.1-v3-cbf31f02a`, and `PMM-T2268` is already listed in `versionGates.ts` at `3.10.0`:

```
full @rta suite (22 specs):
  ✓  22 tests/qan/storedMetrics/urlState.test.ts:15 › PMM-T2268 … @rta (19.0s)   ← ran; gate never applied

same box, same server, that one spec alone:
  -   1 tests/qan/storedMetrics/urlState.test.ts:15 › PMM-T2268 … @rta
  1 skipped                                                                       ← gate applied
```

Run alone the spec is the first file loaded, so it gets the hook and skips; in the suite the hook landed
elsewhere and it ran against 3.9.1. That is this PR's bug reproduced directly against a real server rather than
a stub, and it is why the auto fixture is the right shape — no change to `versionGates.ts` is needed for
PMM-T2268.

Worth recording separately, since it is what made this particular spec go red on 3.9.1 tonight rather than pass
as it had on previous nights: `PMM-T2268` asserts a **second** pagination page exists after filtering QAN stored
metrics to `service_type=mongodb`, and the QAN page size is 25 (`DEFAULT_PAGE_SIZE` in
`pmm-app/src/pmm-qan/panel/QueryAnalytics.constants.ts`). On the freshly provisioned VM that filter returned
**17** query groups right after setup and **33** about five minutes later. The growth is not test-generated —
every `simulateLongRunningQuery` call collapses into the single fingerprint `db.test.find({"$where":"?"})`. It is
background chatter accumulating distinct fingerprints over time: PBM agent polling (`pbmCmd`, `pbmConfig`,
`pbmAgents`, `pbmBackups`), exporter `$collStats`/`$indexStats`/`dbStats`/`$currentOp`, and oplog reads — with
`.batchSize(1)` variants counting as separate groups and appearing minutes apart. So the spec only has a page 2
once the environment has been up long enough. That is latent and will still be true on 3.10; it is out of scope
here and not worth a change while the gate keeps the spec off 3.9.x.

## Not covered by this PR

Other failures in the same RC run that are **not** version skew, listed so they don't get read as fixed here:

- **PMM-T1899** (`@rbac`) — "Expected 5 Elements without data but found 8" on MySQL Instances Overview (Top MySQL Used Connections / Client Threads Connected / Threads Cached …). Idle server with no MySQL load, the same class as PMM-T1883 in #1194 but a different test; needs load generation, not a skip.
- **PMM-T2237** (`@docker-configuration`) — `Config name should be: default-config but actual value is: … '/etc/clickhouse-server/config.xml'`. Red on `main` + `3-dev-latest` too ([scheduled run 31988194422](https://github.com/percona/pmm-qa/actions/runs/31988194422), job [95266801529](https://github.com/percona/pmm-qa/actions/runs/31988194422/job/95266801529)), so it is not RC-specific and needs its own investigation — the ClickHouse ansible role is byte-identical between `main` and `pmm-3.9.1`.
- **PMM-T2020** (`@docker-configuration`) — Explore rows never appear for the external ClickHouse datasource; also red on `main` in that same run.
- **PMM-T1173/T1174** (`@docker-configuration`) — `publicAddress-text-input` not visible; that job also hit `endpoint with name pmm-server already exists in network pmm-qa` and the test passes on `main`, so it reads as environment contention.