### PR TITLE
PMM-15354 Fix PMM-T2237 ClickHouse config check

### DIFF
--- a/e2e_tests/tests/dockerConfiguration/clickhouseConfig.test.ts
+++ b/e2e_tests/tests/dockerConfiguration/clickhouseConfig.test.ts
@@ -2,24 +2,25 @@ import pmmTest from '@fixtures/pmmTest';
 import { expect } from '@playwright/test';
 
 const dockerVersion = process.env.DOCKER_VERSION || 'perconalab/pmm-server:3-dev-latest';
+const configDir = '/etc/clickhouse-server';
 const configurations = [
   {
     command: `docker run --detach --restart always --network="pmm-qa" -e PMM_CLICKHOUSE_CONFIG=default -e PMM_ENABLE_TELEMETRY=0 --publish 83:8080 --publish 446:8443 --name pmm-server-default-clickhouse-config ${dockerVersion}`,
-    configName: 'default-config',
     containerName: 'pmm-server-default-clickhouse-config',
     port: 446,
+    profile: 'default',
   },
   {
     command: `docker run --detach --restart always --network="pmm-qa" -e PMM_CLICKHOUSE_CONFIG=low-memory -e PMM_ENABLE_TELEMETRY=0 --publish 84:8080 --publish 447:8443 --name pmm-server-low-memory-clickhouse-config ${dockerVersion}`,
-    configName: 'low-memory-config',
     containerName: 'pmm-server-low-memory-clickhouse-config',
     port: 447,
+    profile: 'low-memory',
   },
   {
     command: `docker run --detach --restart always --network="pmm-qa" -e PMM_ENABLE_TELEMETRY=0 --publish 83:8080 --publish 448:8443 --name pmm-server-no-flag-clickhouse-config ${dockerVersion}`,
-    configName: 'default-config',
     containerName: 'pmm-server-no-flag-clickhouse-config',
     port: 448,
+    profile: 'default',
   },
 ];
 
@@ -35,14 +36,28 @@ for (const configuration of configurations) {
         cliHelper.execSilent(configuration.command);
         await api.serverApi.waitForReady();
 
-        const configName = cliHelper.execSilent(
-          `docker exec ${configuration.containerName} cat /srv/logs/clickhouse-server.log | grep "config"`,
-        );
+        // PMM points the fixed config.xml and users.xml names at the files of the selected
+        // configuration, so the configuration in use is read from those links. clickhouse-server is
+        // always handed the fixed names and logs them verbatim, so its log no longer names the
+        // configuration. readlink also exits non-zero when a link has been replaced by a regular
+        // file, which is the state in which PMM_CLICKHOUSE_CONFIG is silently ignored.
+        const configLink = cliHelper
+          .execSilent(`docker exec ${configuration.containerName} readlink ${configDir}/config.xml`)
+          .assertSuccess();
 
         expect(
-          configName.stdout,
-          `Config name should be: ${configuration.configName} but actual value is: ${configName.stdout}`,
-        ).toContain(`${configuration.configName}.xml`);
+          configLink.stdout.trim(),
+          `config.xml should point at the ${configuration.profile} ClickHouse configuration`,
+        ).toEqual(`${configDir}/${configuration.profile}-config.xml`);
+
+        const usersLink = cliHelper
+          .execSilent(`docker exec ${configuration.containerName} readlink ${configDir}/users.xml`)
+          .assertSuccess();
+
+        expect(
+          usersLink.stdout.trim(),
+          `users.xml should point at the ${configuration.profile} ClickHouse configuration`,
+        ).toEqual(`${configDir}/${configuration.profile}-users.xml`);
       },
     );
   });


### PR DESCRIPTION
PMM-15354

PMM-T2237 read the selected ClickHouse configuration out of /srv/logs/clickhouse-server.log. percona/pmm#5747 stopped passing the configuration in the clickhouse-server command line and now points the fixed config.xml and users.xml names at the files of the selected configuration instead. ClickHouse logs the path it is handed, so the log names config.xml for every configuration and all three parameterised cases failed, not just low-memory.

Assert on readlink of config.xml and users.xml instead. Both links are checked because #5747 moves both and they can diverge, and readlink exits non-zero when a link has been replaced by a regular file, which is the state in which PMM_CLICKHOUSE_CONFIG is silently ignored.