### PR TITLE
Untag PS and PDPGSQL QAN details tests from the GSSAPI nightly

### DIFF
--- a/codeceptjs-e2e/tests/QAN/details_explain_test.js
+++ b/codeceptjs-e2e/tests/QAN/details_explain_test.js
@@ -58,7 +58,7 @@ async function verifySupportedDBTabs({
 }
 
 Scenario(
-  'PMM-T13 - Check Example, Explain, Plan and Table tabs for PS @qan @gssapi-nightly',
+  'PMM-T13 - Check Example, Explain, Plan and Table tabs for PS @qan',
   async ({ I, queryAnalyticsPage, inventoryAPI }) => {
     await verifySupportedDBTabs({
       I,
@@ -72,7 +72,7 @@ Scenario(
 );
 
 Scenario(
-  'PMM-T13 - Check Example, Explain, Plan and Table tabs for PDPGSQL @qan @gssapi-nightly',
+  'PMM-T13 - Check Example, Explain, Plan and Table tabs for PDPGSQL @qan',
   async ({ I, queryAnalyticsPage, inventoryAPI }) => {
     await verifySupportedDBTabs({
       I,

--- a/codeceptjs-e2e/tests/pages/api/inventoryAPI.js
+++ b/codeceptjs-e2e/tests/pages/api/inventoryAPI.js
@@ -111,10 +111,16 @@ module.exports = {
 
     const regex = new RegExp(regexPattern);
 
-    return service
+    const foundService = service
       .data
       .services
       .find((service) => regex.test(service.service_name));
+
+    if (!foundService) {
+      throw new Error(`Service matching "${regexPattern}" not found.`);
+    }
+
+    return foundService;
   },
 
   async getServiceDetailsByPartialDetails(details) {


### PR DESCRIPTION
## Failures fixed (investigator)

- source: Jenkins [pmm3-ui-tests-nightly-gssapi #436](https://pmm.cd.percona.com/job/pmm3-ui-tests-nightly-gssapi/436/) (also #437 and every build back to #351)
- tests:
  - `codeceptjs-e2e/tests/QAN/details_explain_test.js:61` / `@gssapi-nightly` — PMM-T13 "Check Example, Explain, Plan and Table tabs for PS"
  - `codeceptjs-e2e/tests/QAN/details_explain_test.js:75` / `@gssapi-nightly` — PMM-T13 "Check Example, Explain, Plan and Table tabs for PDPGSQL"

## What failed

36 passed, 2 failed in the `Run UI Tests` stage:

```
Service with details "{"cluster":"ps-single-dev-cluster","service_name":"ps_"}" not found.
Cannot read properties of undefined (reading 'service_name')
```

Both fail at the inventory lookup, before touching any product behaviour.

## Root cause — the tag, not the product

`pmm3-ui-tests-nightly-gssapi.groovy` provisions exactly one client and then runs
`npx codeceptjs run ... --grep '@gssapi-nightly'`:

```groovy
runStagingClient(..., '--database psmdb,SETUP_TYPE=pss,GSSAPI=true', ...)
```

There is no MySQL and no PostgreSQL in that environment, so no `ps_` or `pdpgsql_` service can
ever exist — yet both PMM-T13 scenarios carried `@gssapi-nightly` and were selected by the grep.

## This never passed — it is not a regression

Worth stating explicitly, since carrying the tag suggests it once worked:

- **No revision of the pipeline ever provisioned PS or PDPGSQL.** All 9 revisions of
  `pmm/v3/pmm3-ui-tests-nightly-gssapi.groovy`, from the job's creation (`53769c48`, 2025-08-25)
  through today, pass only `--database psmdb,SETUP_TYPE=pss,GSSAPI=true`. The
  `Check Agent Status on ps single and mongo pss` stage name is a leftover from the non-GSSAPI
  nightly this pipeline was cloned from — the stage only ever checks the mongo node.
- **The tag arrived on 2026-06-02**, in `a3dc07de` ("PMM-15033 add gh related scripts for nightly
  tests", #956), which reworked tags across the suite (`@nightly-generic` disappears around the
  same commit).
- **The failure starts with the very next build.** Build
  [#349](https://pmm.cd.percona.com/job/pmm3-ui-tests-nightly-gssapi/349/) (2026-06-01, pre-tag):
  37 tests, 3 failures, neither PMM-T13 scenario among them — and since neither can pass without a
  `ps_`/`pdpgsql_` service, not failing means they did not run. Build
  [#351](https://pmm.cd.percona.com/job/pmm3-ui-tests-nightly-gssapi/351/) (2026-06-03, first build
  after the tag): 38 tests, 2 failures — exactly these two, with byte-identical error strings to
  #436/#437 today.
- The job has not gone green once in its last 120 builds (#338–#437, since 2026-05-25).

## The fix

Drop `@gssapi-nightly` from the PS and PDPGSQL scenarios. They keep `@qan`, so their coverage is
unchanged in `pmm3-ui-tests-nightly`, which *does* provision both
(`--database ps,QUERY_SOURCE=slowlog,MY_ROCKS=true` and `--database pdpgsql --database pgsql ...`).
The PSMDB scenario in the same file keeps the tag and already resolves `rs101_gssapi` via
`isJenkinsGssapiJob`.

This matches how the suite already gates non-MongoDB services out of this job — `query_test.js:10`
and `verifyAnnotations_test.js:6` both wrap their non-mongo data-table rows in `if (!isJenkinsGssapiJob)`.

Also makes `getServiceDetailsByRegex` throw a named "not found" error instead of returning
`undefined`, so a missing service reports like `getServiceDetailsByPartialDetails` does rather than
as an opaque `Cannot read properties of undefined`. All 7 call sites already dereference the result
immediately, so nothing relied on the `undefined` return.

## Verification

`codeceptjs dry-run` against `pr.codecept.js`, which is what decides selection:

| | `--grep '@gssapi-nightly'` (with `JOB_NAME=...gssapi`) | `--grep '@qan'` |
|---|---|---|
| before | 40 tests — includes PMM-T13 PS + PDPGSQL | PS, PDPGSQL, PSMDB |
| after | **38 tests** — PS + PDPGSQL gone, PSMDB kept | PS, PDPGSQL, PSMDB (unchanged) |

Exactly the two failing tests are dropped, and nothing else changes. `npx eslint` clean on both
changed files.

Not verified end-to-end on a live GSSAPI staging environment — the change is selection-only, and
the next scheduled nightly is what confirms the job goes green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XbfQ9WtrXGzr39d3yH2XnE)_