### PR TITLE
Retry panel lookups in the dashboard metric walk

### DIFF
--- a/codeceptjs-e2e/tests/pages/dashboardPage.js
+++ b/codeceptjs-e2e/tests/pages/dashboardPage.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-useless-path-segments */
 const { I, adminPage } = inject();
 const assert = require('assert');
+const { retryTo } = require('codeceptjs/effects');
 const { DashboardPanelMenu } = require('./dashboards/components/DashboardPanelMenu');
 const PmmHealthDashboard = require('./dashboards/experimental/pmmHealthDashboard');
 const HomeDashboard = require('./dashboards/homeDashboard');
@@ -1198,8 +1199,7 @@ module.exports = {
     for (const i in metrics) {
       I.pressKey('PageDown');
       await this.expandEachDashboardRow();
-      I.waitForElement(this.graphsLocator(metrics[i]), 5);
-      I.scrollTo(this.graphsLocator(metrics[i]));
+      await this.scrollToPanel(this.graphsLocator(metrics[i]));
     }
   },
 
@@ -1207,9 +1207,19 @@ module.exports = {
     for (const i in metrics) {
       I.pressKey('PageDown');
       await this.expandEachDashboardRow();
-      I.waitForElement(this.graphsLocatorPartialMatch(metrics[i]), 5);
-      I.scrollTo(this.graphsLocatorPartialMatch(metrics[i]));
+      await this.scrollToPanel(this.graphsLocatorPartialMatch(metrics[i]));
     }
+  },
+
+  // Grafana renders a panel only once it scrolls into view, and a fully expanded
+  // dashboard blocks the browser's main thread for tens of seconds at a time, which
+  // stalls every element lookup - including ones for panels already on screen. Retry
+  // the lookup rather than betting the whole test on a single wait budget.
+  async scrollToPanel(locator) {
+    await retryTo(() => {
+      I.waitForElement(locator, 10);
+      I.scrollTo(locator);
+    }, 3);
   },
 
   openGraphDropdownMenu(metric) {


### PR DESCRIPTION
## Failures fixed (investigator)

- source: nightly CI run [32241365624](https://github.com/percona/pmm-qa/actions/runs/32241365624) — job `test execution / @nightly` ([96032443396](https://github.com/percona/pmm-qa/actions/runs/32241365624/job/96032443396))
- tests:
  - `codeceptjs-e2e/tests/dashboards/verifyPostgresqlDashboards_test.js:84` / `@nightly @dashboards` — PMM-T2048 "Verify PostgreSQL Instances Overview Extended metrics"

## What failed

One test out of 71 in that job (`70 passed, 1 failed`). The `Execute e2e tests` step went red
and `launchable gate` then reported `Actionable Failures | 1`, taking the job — and the run —
with it:

```
element ([data-testid*="data-testid Panel header"][data-testid*="Top 5 Conflicts"])
still not present on page after 5 sec
locator.waitFor: Timeout 5000ms exceeded.
  at async Object.verifyMetricsExistencePartialMatch (tests/pages/dashboardPage.js:1209:7)
  at async Test.<anonymous> (tests/dashboards/verifyPostgresqlDashboards_test.js:92:5)
```

The panel is not missing. `Top 5 Conflicts` exists in `PostgreSQL_Overview_Extended.json`
(row *Conflicts & Locks Details*), and the job's own failure screenshot — taken 12.8 s after
the timeout — **shows the panel rendered, on screen, with data**. PMM-T2048 passed on the
previous nightly ([32200025112](https://github.com/percona/pmm-qa/actions/runs/32200025112),
206 s) against the same build.

## Root cause — a fixed wait against a page that stalls

`verifyMetricsExistence` / `verifyMetricsExistencePartialMatch` walk every panel of a
dashboard: `PageDown`, expand any collapsed rows, `waitForElement(panel, 5)`, `scrollTo(panel)`.
Grafana renders a panel only once it scrolls into view, so the walk depends on the page
keeping up.

This dashboard has **86 panels**, and the walk forces all 11 collapsed rows open before it
starts. Reading the failing run's own Playwright trace, per-panel element lookups tell the
story:

| # | t | panel | lookup |
|---|---|-------|--------|
| 3–35 | 35–107 s | Services … Max Size of Temp Files | **0.01–0.03 s** each |
| 36 | 109.9 s | Top 5 Commit Transactions | **13.28 s** (scroll; passed) |
| 48–57 | 139–158 s | Total Locks … Deadlocks | 0.01–0.03 s each |
| 58 | 161.0 s | **Top 5 Conflicts** | **5.03 s → timeout** |

Every panel the walk reached was already attached when it looked — 0.02 s, not 4 s. The
budget is not being consumed by rendering; it is consumed by the page's main thread going
away. The 13.28 s entry at #36 is the same stall landing on a lookup for an element that was
already there, and it only passed because that call had a 20 s budget rather than 5 s.
`expandEachDashboardRow`'s own `grabNumberOfVisibleElements` degrades in step with it
(0.32 s → 1.17 s across the walk).

So: whichever panel the walk happens to be on when a >5 s stall hits, fails. That is why the
panel varies rather than being a stable one.

## Reproduction

Throwaway Linode VM, `perconalab/pmm-server:3.9.1-rc` — digest `sha256:003f9c25f842…`, the
same digest Launchable recorded for the failing session — plus `pmm-framework --database
pdpgsql` and client `pmm3-rc`, matching the run's `setup / pdpgsql` job.

| condition | PMM-T2048 |
|-----------|-----------|
| VM as provisioned (6 cores, server on the same box) | passed, 264.8 s |
| pinned to 2 cores (GitHub runner shape) | passed, 331.4 s |
| 2 cores **+ 50 ms loopback latency** | **failed** |

That third row is the one that matters. The nightly is
`runner-e2e-tests-codeceptjs-remote-nightly-tests.yml` — the browser drives a PMM Server on
*another host*, so every panel query is a network round trip. Putting that back is what
reproduces the red.

## The fix

Retry the wait-and-scroll pair per panel instead of betting the test on one budget, via
`retryTo` from `codeceptjs/effects` (the module the config's `tryTo` plugin already points at).

Both walkers get it — they carry the identical race, and between them back 61 dashboard
assertions across the MySQL, MongoDB, PostgreSQL, Valkey, OS and Insight suites.

**Nothing is loosened.** `retryTo` re-throws the last error once `maxTries` is exhausted
(`codeceptjs/lib/effects.js`, `handleRetryException` → `recorder.throw`), so the assertion is
still "this panel exists": a dashboard that really stops shipping `Top 5 Conflicts` fails
PMM-T2048 exactly as before, after the retries rather than at an arbitrary 5 s mark. No
tolerance widened, no check deleted, no expected count adjusted.

## Verification

Same VM, same widened conditions, three runs each, branch switched with `sync.sh`:

| spec | result |
|------|--------|
| `main` (1ea29d1) | **3 / 3 failed** |
| this branch | **3 / 3 passed** (392 s, 274 s, 373 s) |

The three failures on `main` landed on three different panels with three different messages —
which is the point, and why chasing "the Top 5 Conflicts panel" would have been the wrong
investigation:

```
run 1: locator.boundingBox: Timeout 20000ms exceeded
         … [data-testid*="Top 5 Canceled Queries"]

run 2: element ([data-testid*="data-testid Panel header"][data-testid*="Top 5 Active Connections"])
         still not present on page after 5 sec
       locator.waitFor: Timeout 5000ms exceeded.          <- the CI failure, verbatim shape

run 3: locator.scrollIntoViewIfNeeded: Timeout 19509ms exceeded
         - attempting scroll into view action
           - waiting for element to be stable
```

`npx eslint tests/pages/dashboardPage.js` clean.

### What this does and does not prove

The retry removes the failure mode, under conditions harsher than CI's (3/3 red → 3/3 green).
It does not make the dashboard faster: the browser still stalls for 10–20 s at a time once all
86 panels are expanded, which is the test's own doing rather than something a user would
trigger, so no product bug is filed for it — but it does mean PMM-T2048 stays a ~4–7 minute
test. Only the next real nightly confirms it end to end.

The sibling suites now covered by the same retry (MySQL, Valkey, MongoDB, OS, Insight) were
not individually re-run here; they exercise the same two helpers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi4cngKnSAegYDZMGodnkb)_