### PR TITLE
Upgrade PMM-T2227 from a release older than the build under test

### DIFF
--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -6,6 +6,13 @@ import { readZipFile } from '@helpers/zip-helper';
 const PGSQL_USER = 'postgres';
 const PGSQL_PASSWORD = 'pass+this';
 const ipPort = async () => ((await cli.exec('docker ps')).stdout.includes('pdpgsql_pmm_') ? '127.0.0.1:5432' : '127.0.0.1:5447');
+const compareVersions = (a: string, b: string) => {
+  const left = a.split('.').map(Number);
+  const right = b.split('.').map(Number);
+  const index = left.findIndex((part, i) => part !== right[i]);
+
+  return index === -1 ? 0 : left[index] - right[index];
+};
 
 test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
   test.beforeAll(async ({}) => {
@@ -577,7 +584,26 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     await cli.exec('docker network create pmm-qa || true');
     await cli.exec('docker network connect pmm-server pmm-qa');
     await cli.exec(`docker run --rm -d --name="${containerName}" --network="pmm-qa" --privileged --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /var/lib/containerd antmelekhin/docker-systemd:almalinux-10`);
-    const latestReleasedVersion = (await cli.exec('wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags -O - | jq -r .results[].name | grep -v latest | sort -V | tail -n1')).stdout.trim();
+    const versionLookup = process.env.PMM_CLIENT_VERSION?.includes('http')
+      ? undefined
+      : cli.execute('curl --fail --silent --show-error https://raw.githubusercontent.com/Percona-Lab/pmm-submodules/v3/VERSION');
+    if (versionLookup && (versionLookup.code !== 0 || !versionLookup.stdout.trim())) {
+      throw new Error('Could not read the expected upgrade version from v3 VERSION');
+    }
+    const upgradedVersion = versionLookup?.stdout.trim() ?? '';
+
+    const releasedVersions = (await cli.exec('wget -q "https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags?page_size=100" -O - | jq -r .results[].name'))
+      .getStdOutLines()
+      .map((tag) => tag.trim())
+      .filter((tag) => /^\d+\.\d+\.\d+$/.test(tag))
+      .sort(compareVersions);
+    // The TESTING tarball of the version currently on v3 is the same nightly build as
+    // pmm-client-latest.tar.gz, so upgrading from that tag would install an identical client.
+    const upgradeSources = upgradedVersion
+      ? releasedVersions.filter((tag) => compareVersions(tag, upgradedVersion) < 0)
+      : releasedVersions;
+    const latestReleasedVersion = upgradeSources[upgradeSources.length - 1];
+    expect(latestReleasedVersion, `No released pmm-client version to upgrade from, tags: ${releasedVersions.join(', ')}`).toBeTruthy();
     await cli.exec(`docker cp ../package_tests/scripts/pmm3_client_install_tarball.sh ${containerName}:/`);
     await cli.exec(`docker exec ${containerName} dnf install -y wget`);
     await cli.exec(`docker exec ${containerName} /pmm3_client_install_tarball.sh -v ${latestReleasedVersion}`);
@@ -602,14 +628,6 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     const newPid = await cli.exec(`docker exec ${containerName} ps -C pmm-agent -o pid=`);
     const newAdminStatus = await cli.exec(`docker exec ${containerName} pmm-admin status`);
     const newVersion = await cli.exec(`docker exec ${containerName} pmm-admin version | grep "Version:"`);
-
-    const versionLookup = process.env.PMM_CLIENT_VERSION?.includes('http')
-      ? undefined
-      : cli.execute('curl --fail --silent --show-error https://raw.githubusercontent.com/Percona-Lab/pmm-submodules/v3/VERSION');
-    if (versionLookup && (versionLookup.code !== 0 || !versionLookup.stdout.trim())) {
-      throw new Error('Could not read the expected upgrade version from v3 VERSION');
-    }
-    const upgradedVersion = versionLookup?.stdout.trim() ?? '';
 
     await newPid.outNotContains(oldPid.stdout);
     await newAdminStatus.outContains('Connected');


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [percona/pmm-qa run 32315930087](https://github.com/percona/pmm-qa/actions/runs/32315930087) — `PMM Integration Tests` (scheduled, `main`), job `CLI / Integration / Generic` ([96268001818](https://github.com/percona/pmm-qa/actions/runs/32315930087/job/96268001818))
- tests:
  - `cli/tests/generic.spec.ts:575` / `@generic` — PMM-T2227 - Verify tarball upgrade

## What failed

`CLI / Integration / Generic` was the only red job of the 25 in that run (1 failed, 43 passed, 13 skipped). Its own `Run CLI tests` step ends in `|| true`, so the job went red one step later on `launchable gate` (`Actionable Failures | 1`):

```
Error: expect(received).not.toEqual(expected) // deep equality

Expected: not "Version: 3.9.1-v3-0b84a2033
PMMVersion: 3.9.1-v3-0b84a2033"

  at cli/tests/generic.spec.ts:616:42
```

The old and the new client report the *same* version, so `newVersion != oldVersion` cannot hold.

## Root cause — the test upgraded a build to itself

PMM-T2227 installs "the latest released version" and then upgrades to the build under test:

| step | version asked for | URL `pmm3_client_install_tarball.sh` resolves |
|------|-------------------|---------------------------------------------|
| base install | newest Docker Hub tag of `percona/pmm-client` → `3.9.1` | `downloads.percona.com/downloads/TESTING/pmm/pmm-client-3.9.1.tar.gz` |
| upgrade | `PMM_CLIENT_VERSION=latest-tarball` → dev HEAD | `pmm-build-cache.s3…/PR-BUILDS/pmm-client/pmm-client-latest.tar.gz` |

`downloads.percona.com/.../TESTING/pmm/` does not hold the frozen GA artifact for the version currently on `v3` — it is **rebuilt from the same nightly build** as `pmm-client-latest.tar.gz`. Both files are byte-identical right now (fetched on the repro VM):

```
--- TESTING/pmm/pmm-client-3.9.1.tar.gz
archive sha256:   31fed3bd1496a4ccadd113fc3da9a66e252320304f09b5db943df5e8ef4b0443
pmm-admin sha256: e40098b16d63cd317186484ebbf39df77d9534d0da6fc31b93a9654eefe5cea4
Version: 3.9.1-v3-0b84a2033   Timestamp: 2026-08-19 22:18:59   FullCommit: bacbbc7c9f811cc4b3f097ab70713ddd162906ea

--- PR-BUILDS/pmm-client/pmm-client-latest.tar.gz
archive sha256:   31fed3bd1496a4ccadd113fc3da9a66e252320304f09b5db943df5e8ef4b0443
pmm-admin sha256: e40098b16d63cd317186484ebbf39df77d9534d0da6fc31b93a9654eefe5cea4
Version: 3.9.1-v3-0b84a2033   Timestamp: 2026-08-19 22:18:59   FullCommit: bacbbc7c9f811cc4b3f097ab70713ddd162906ea
```

What changed between the green run on Aug 19 and the red one on Aug 20 is the release, not the code:

- `percona/pmm-client:3.9.1` was pushed to Docker Hub at **2026-08-19 14:49 UTC**, so `latestReleasedVersion` moved `3.9.0` → `3.9.1`.
- `Percona-Lab/pmm-submodules` `v3/VERSION` still reads **3.9.1** (not yet bumped past the release).

With the two equal, the base tarball and the upgrade tarball are the same file. This is deterministic, not flaky — it will fail every night until `v3` moves to the next version. Nothing is wrong with the product or with the tarball upgrade itself; PMM does exactly what it should.

Older versions are unaffected by the rebuild — `TESTING/pmm/pmm-client-3.9.0.tar.gz` has been frozen since 2026-08-04 and reports `3.9.0-v3-83cf42bbe`.

## The fix

Pick the base install as the newest released tag **strictly older** than the version being upgraded to, instead of simply the newest tag. The v3 `VERSION` lookup that the test already performs for the post-upgrade assertion now runs first and feeds that choice, so today the test upgrades `3.9.0` → `3.9.1-v3-0b84a2033`, and it goes back to `3.9.1` → `3.10.0-v3-…` on its own once `v3` is bumped.

Nothing is loosened: both assertions are still there — the version must change, and (for the default dev-latest tarball) the new version must contain the version of the build under test. Tag parsing is restricted to `x.y.z`, so `latest` / `3` / `3.9` moving tags can no longer be picked as a base.

## Verification

Throwaway Linode VM following `.github/workflows/runner-integration-cli-tests.yml`, same server image as the failing run — `perconalab/pmm-server:3-dev-latest`, digest `sha256:066a213f2c9fa3f7cd8abe8553d9672bb99cf6ee35efb8e3095508e7e2044b6e`, the exact digest Launchable recorded for that session — `latest-tarball` client and the job's own `--database pdpgsql=16 --database ps,ENCRYPTED_CLIENT_CONFIG=true` setup.

| spec | `--grep PMM-T2227` |
|------|--------------------|
| `main` (6645523) | **1 failed** — `Expected: not "Version: 3.9.1-v3-0b84a2033 / PMMVersion: 3.9.1-v3-0b84a2033"`, byte-for-byte the CI failure |
| this branch | **1 passed** (24.6s) |

- Base selection on this branch resolves to **3.9.0**, and the container ends on `3.9.1-v3-0b84a2033` — the upgrade now crosses a real version boundary.
- Full `--grep "@generic|@unregister"` run on this branch: **43 passed, 13 skipped, 1 failed** — the same 43/13 as the CI run, with PMM-T2227 among the passes. The one failure is PMM-T1219, which shells out to `unzip`; that binary is absent on the bare Linode image and present on GitHub's `ubuntu-22.04` runner (it passed in CI), so it is a gap in my repro box, not a finding. Installing `unzip` and re-running was inconclusive because the `@unregister` specs unregister the host agent, so a second suite run on the same box fails a dozen state-dependent tests — the numbers above are from the single clean pass.
- `npm run lint` (eslint + `tsc --noEmit`) in `cli/`: **Lint OK**, 0 errors.

The next scheduled `PMM Integration Tests` run is what confirms it end to end on a fresh runner.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdjcpL8QGUDK9BvsNpfvb3)_