### PR TITLE
Wait out the 5m-step panels before the RBAC dashboard assertions

### DIFF
--- a/codeceptjs-e2e/tests/configuration/verifyRoleBasedAccessControl_test.js
+++ b/codeceptjs-e2e/tests/configuration/verifyRoleBasedAccessControl_test.js
@@ -50,8 +50,16 @@ Scenario('PMM-T1584 - Verify assigning Access role to user @rbac', async ({ I, u
 Scenario(
   'PMM-T1899 - Access Role based on Labels and Check Filtering of Metrics on Dashboard @rbac',
   async ({
-    I, dashboardPage, accessRolesPage, rolesApi,
+    I, dashboardPage, accessRolesPage, rolesApi, grafanaAPI,
   }) => {
+    // The MySQL and PostgreSQL dashboards below carry panels that pin `interval: 5m`,
+    // which are read at the last 300s boundary rather than at "now" on a now-5m range.
+    // A service registered after that boundary shows "No data" on them until the next
+    // one passes, so wait the metrics out before asserting on what the panels render.
+    await grafanaAPI.waitForMetricAtDashboardStep('min(mysql_global_status_uptime)');
+    await grafanaAPI.waitForMetricAtDashboardStep('sum(mysql_global_variables_innodb_buffer_pool_size)');
+    await grafanaAPI.waitForMetricAtDashboardStep('avg by (node_name) (node_memory_MemTotal_bytes)');
+
     await rolesApi.createRole(psRole);
     await rolesApi.createRole(pgRole);
 

--- a/codeceptjs-e2e/tests/configuration/verifyRoleBasedAccessControl_test.js
+++ b/codeceptjs-e2e/tests/configuration/verifyRoleBasedAccessControl_test.js
@@ -52,10 +52,11 @@ Scenario(
   async ({
     I, dashboardPage, accessRolesPage, rolesApi, grafanaAPI,
   }) => {
-    // The MySQL and PostgreSQL dashboards below carry panels that pin `interval: 5m`,
-    // which are read at the last 300s boundary rather than at "now" on a now-5m range.
-    // A service registered after that boundary shows "No data" on them until the next
-    // one passes, so wait the metrics out before asserting on what the panels render.
+    // The MySQL and PostgreSQL dashboards below carry panels that pin `interval: 5m`.
+    // On a now-5m range those are evaluated at a single 300s grid point 5-10 minutes
+    // in the past, so a service registered more recently than that renders "No data"
+    // on them no matter how many samples arrived since. Wait the metrics out before
+    // asserting on what the panels render.
     await grafanaAPI.waitForMetricAtDashboardStep('min(mysql_global_status_uptime)');
     await grafanaAPI.waitForMetricAtDashboardStep('sum(mysql_global_variables_innodb_buffer_pool_size)');
     await grafanaAPI.waitForMetricAtDashboardStep('avg by (node_name) (node_memory_MemTotal_bytes)');

--- a/codeceptjs-e2e/tests/configuration/verifyRoleBasedAccessControl_test.js
+++ b/codeceptjs-e2e/tests/configuration/verifyRoleBasedAccessControl_test.js
@@ -52,11 +52,11 @@ Scenario(
   async ({
     I, dashboardPage, accessRolesPage, rolesApi, grafanaAPI,
   }) => {
-    // The MySQL and PostgreSQL dashboards below carry panels that pin `interval: 5m`.
-    // On a now-5m range those are evaluated at a single 300s grid point 5-10 minutes
-    // in the past, so a service registered more recently than that renders "No data"
-    // on them no matter how many samples arrived since. Wait the metrics out before
-    // asserting on what the panels render.
+    // The MySQL and PostgreSQL dashboards below carry panels that pin `interval: 5m`,
+    // so on a now-5m range they are only evaluated at 300s wall-clock boundaries. A
+    // service whose first sample landed after the newest boundary renders "No data"
+    // on them until the next one passes, no matter how many samples arrived since.
+    // Wait the metrics out before asserting on what the panels render.
     await grafanaAPI.waitForMetricAtDashboardStep('min(mysql_global_status_uptime)');
     await grafanaAPI.waitForMetricAtDashboardStep('sum(mysql_global_variables_innodb_buffer_pool_size)');
     await grafanaAPI.waitForMetricAtDashboardStep('avg by (node_name) (node_memory_MemTotal_bytes)');

--- a/codeceptjs-e2e/tests/pages/api/grafanaAPI.js
+++ b/codeceptjs-e2e/tests/pages/api/grafanaAPI.js
@@ -531,17 +531,20 @@ module.exports = {
    * Fluent wait until an expression resolves at the 5-minute grid point that panels
    * pinning `interval: 5m` are read at.
    *
-   * Grafana aligns such a panel's range query down to a multiple of the step, which
-   * on a `now-5m` range leaves a single evaluation point at the 300s boundary at or
-   * before `now - 5m` — so between 5 and 10 minutes in the past. A service that
-   * started being monitored more recently than that has no sample within the
-   * datasource's 5 minute staleness lookback of that point and the panel renders
-   * "No data", however many samples have arrived since. These dashboards do not
-   * auto-refresh either, so re-reading the rendered page cannot recover it.
+   * Grafana aligns such a panel's range query onto the step's own grid, so on a
+   * `now-5m` range it is evaluated only at 300s wall-clock boundaries — the newest
+   * being the last one at or before `now`. A service whose first sample landed after
+   * that boundary has nothing to answer with (the datasource looks back 5 minutes
+   * from the boundary, i.e. to before the service existed) and the panel renders
+   * "No data" until the next boundary passes, however many samples arrived since.
+   * These dashboards do not auto-refresh either, so re-reading the rendered page
+   * cannot recover it — which is why a test can sit in the failure for its whole
+   * poll, and why whether it fails at all depends on where setup happened to fall
+   * against the 5-minute grid.
    *
-   * Waits for that evaluation point to carry as many series as a query at `now`
-   * does, so a node or service that only just started being monitored is waited
-   * for rather than silently tolerated as an empty panel.
+   * Waits for that boundary to carry as many series as a query at `now` does, so a
+   * node or service that only just started being monitored is waited for rather
+   * than silently tolerated as an empty panel.
    *
    * @param   expression          PromQL expression, ex.: min(mysql_global_status_uptime)
    * @param   timeOutInSeconds    time to wait for the evaluation point to catch up
@@ -556,19 +559,18 @@ module.exports = {
       return response.data.data.result.length;
     };
 
-    await I.say(`Wait up to ${timeOutInSeconds} seconds for "${expression}" to resolve where ${stepInSeconds}s-step panels are evaluated`);
+    await I.say(`Wait up to ${timeOutInSeconds} seconds for "${expression}" to resolve at the newest ${stepInSeconds}s boundary`);
 
     await I.asyncWaitFor(async () => {
       const expected = await seriesCount();
 
       if (expected === 0) return false;
 
-      const nowInSeconds = Math.floor(Date.now() / 1000);
-      const evaluatedAt = Math.floor((nowInSeconds - stepInSeconds) / stepInSeconds) * stepInSeconds;
-      const actual = await seriesCount(evaluatedAt);
+      const newestBoundary = Math.floor(Date.now() / 1000 / stepInSeconds) * stepInSeconds;
+      const actual = await seriesCount(newestBoundary);
 
       return actual >= expected;
-    }, timeOutInSeconds, `"${expression}" still resolves to fewer series where ${stepInSeconds}s-step panels are evaluated than at "now"`);
+    }, timeOutInSeconds, `"${expression}" still resolves to fewer series at the newest ${stepInSeconds}s boundary than at "now"`);
   },
 
   async checkMetricAbsent(metricName, refineBy) {

--- a/codeceptjs-e2e/tests/pages/api/grafanaAPI.js
+++ b/codeceptjs-e2e/tests/pages/api/grafanaAPI.js
@@ -527,6 +527,45 @@ module.exports = {
     return response;
   },
 
+  /**
+   * Fluent wait until an expression resolves at the 5-minute grid point that panels
+   * pinning `interval: 5m` are read at.
+   *
+   * Grafana aligns a range query down to a multiple of the step, so on a `now-5m`
+   * dashboard such a panel is evaluated at the last 300s boundary rather than at
+   * "now". A service registered after that boundary renders "No data" on those
+   * panels until the next one passes, however many samples have arrived meanwhile,
+   * and no amount of re-reading the rendered dashboard changes it.
+   *
+   * Waits for the aligned point to carry as many series as an unaligned query does,
+   * so a node or service that only just started monitoring is waited for too.
+   *
+   * @param   expression          PromQL expression, ex.: min(mysql_global_status_uptime)
+   * @param   timeOutInSeconds    time to wait for the grid point to catch up
+   * @param   stepInSeconds       panel step to align to
+   */
+  async waitForMetricAtDashboardStep(expression, timeOutInSeconds = 420, stepInSeconds = 300) {
+    const headers = { Authorization: `Basic ${await I.getAuth()}` };
+    const seriesCount = async (time) => {
+      const path = `prometheus/api/v1/query?query=${encodeURIComponent(expression)}${time ? `&time=${time}` : ''}`;
+      const response = await I.sendGetRequest(path, headers);
+
+      return response.data.data.result.length;
+    };
+
+    await I.say(`Wait up to ${timeOutInSeconds} seconds for "${expression}" to resolve at the ${stepInSeconds}s grid point`);
+
+    await I.asyncWaitFor(async () => {
+      const expected = await seriesCount();
+
+      if (expected === 0) return false;
+
+      const aligned = Math.floor(Date.now() / 1000 / stepInSeconds) * stepInSeconds;
+
+      return await seriesCount(aligned) >= expected;
+    }, timeOutInSeconds, `"${expression}" still resolves to fewer series at the ${stepInSeconds}s grid point than at "now"`);
+  },
+
   async checkMetricAbsent(metricName, refineBy) {
     let response;
 

--- a/codeceptjs-e2e/tests/pages/api/grafanaAPI.js
+++ b/codeceptjs-e2e/tests/pages/api/grafanaAPI.js
@@ -531,20 +531,23 @@ module.exports = {
    * Fluent wait until an expression resolves at the 5-minute grid point that panels
    * pinning `interval: 5m` are read at.
    *
-   * Grafana aligns a range query down to a multiple of the step, so on a `now-5m`
-   * dashboard such a panel is evaluated at the last 300s boundary rather than at
-   * "now". A service registered after that boundary renders "No data" on those
-   * panels until the next one passes, however many samples have arrived meanwhile,
-   * and no amount of re-reading the rendered dashboard changes it.
+   * Grafana aligns such a panel's range query down to a multiple of the step, which
+   * on a `now-5m` range leaves a single evaluation point at the 300s boundary at or
+   * before `now - 5m` — so between 5 and 10 minutes in the past. A service that
+   * started being monitored more recently than that has no sample within the
+   * datasource's 5 minute staleness lookback of that point and the panel renders
+   * "No data", however many samples have arrived since. These dashboards do not
+   * auto-refresh either, so re-reading the rendered page cannot recover it.
    *
-   * Waits for the aligned point to carry as many series as an unaligned query does,
-   * so a node or service that only just started monitoring is waited for too.
+   * Waits for that evaluation point to carry as many series as a query at `now`
+   * does, so a node or service that only just started being monitored is waited
+   * for rather than silently tolerated as an empty panel.
    *
    * @param   expression          PromQL expression, ex.: min(mysql_global_status_uptime)
-   * @param   timeOutInSeconds    time to wait for the grid point to catch up
+   * @param   timeOutInSeconds    time to wait for the evaluation point to catch up
    * @param   stepInSeconds       panel step to align to
    */
-  async waitForMetricAtDashboardStep(expression, timeOutInSeconds = 420, stepInSeconds = 300) {
+  async waitForMetricAtDashboardStep(expression, timeOutInSeconds = 600, stepInSeconds = 300) {
     const headers = { Authorization: `Basic ${await I.getAuth()}` };
     const seriesCount = async (time) => {
       const path = `prometheus/api/v1/query?query=${encodeURIComponent(expression)}${time ? `&time=${time}` : ''}`;
@@ -553,17 +556,19 @@ module.exports = {
       return response.data.data.result.length;
     };
 
-    await I.say(`Wait up to ${timeOutInSeconds} seconds for "${expression}" to resolve at the ${stepInSeconds}s grid point`);
+    await I.say(`Wait up to ${timeOutInSeconds} seconds for "${expression}" to resolve where ${stepInSeconds}s-step panels are evaluated`);
 
     await I.asyncWaitFor(async () => {
       const expected = await seriesCount();
 
       if (expected === 0) return false;
 
-      const aligned = Math.floor(Date.now() / 1000 / stepInSeconds) * stepInSeconds;
+      const nowInSeconds = Math.floor(Date.now() / 1000);
+      const evaluatedAt = Math.floor((nowInSeconds - stepInSeconds) / stepInSeconds) * stepInSeconds;
+      const actual = await seriesCount(evaluatedAt);
 
-      return await seriesCount(aligned) >= expected;
-    }, timeOutInSeconds, `"${expression}" still resolves to fewer series at the ${stepInSeconds}s grid point than at "now"`);
+      return actual >= expected;
+    }, timeOutInSeconds, `"${expression}" still resolves to fewer series where ${stepInSeconds}s-step panels are evaluated than at "now"`);
   },
 
   async checkMetricAbsent(metricName, refineBy) {


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [E2E tests Matrix run 32324742579](https://github.com/percona/pmm-qa/actions/runs/32324742579) (scheduled, `main` @ `6645523`), job `FB E2E tests / PS UI Role based access control / e2e tests: @rbac` ([96293622099](https://github.com/percona/pmm-qa/actions/runs/32324742579/job/96293622099))
- tests:
  - `codeceptjs-e2e/tests/configuration/verifyRoleBasedAccessControl_test.js` / `@rbac` — PMM-T1899 "Access Role based on Labels and Check Filtering of Metrics on Dashboard"

## What failed

```
Expected 5 Elements without data but found 12 on Dashboard
  .../graph/d/mysql-instance-overview/mysql-instances-overview?from=now-5m&to=now...
Report Names are Min MySQL Uptime, Max MySQL Uptime, Total InnoDB Buffer Pool Size,
Top MySQL Used Connections, Top MySQL Used Connections, Top MySQL Client Threads Connected,
Top MySQL Idle Client Threads, Top MySQL Threads Cached, Top MySQL Queries,
Top MySQL Used Query Cache, MySQL Query Cache Size, MySQL Used Query Cache
```

The MySQL service was there and it was producing metrics. The run's own failure
screenshot shows `Services` — which is `count(mysql_global_status_uptime{...})`, the
*same metric* as the two empty Uptime panels — reading **1**, `Total Current QPS`
reading **8.40 ops/s**, and the *Top 5 MySQL Used Connections* graph plotting
`ps_pmm_8_0_1_60747` with its series starting at **02:35:20**. The dashboard was read
at **02:38:42**.

## Root cause — a wall-clock race against the panels' 5-minute step, not missing data

Split the 12 panels:

- **3** are the query-cache panels. `mysql_global_status_qcache_free_memory` does not
  exist on MySQL 8 (verified: the metric is absent), so those are legitimately empty
  and are part of what the tolerance of 5 is for.
- **9** are *exactly* the 9 targets in `MySQL_Instances_Overview.json` that pin
  `interval: 5m`. Not approximately — the sets are identical, and no other panel on
  the dashboard pins it:

  | pinned `interval: 5m` | reported empty |
  |---|---|
  | Min MySQL Uptime | yes |
  | Max MySQL Uptime | yes |
  | Total InnoDB Buffer Pool Size | yes |
  | Top MySQL Used Connections (×2) | yes |
  | Top MySQL Client Threads Connected | yes |
  | Top MySQL Idle Client Threads | yes |
  | Top MySQL Threads Cached | yes |
  | Top MySQL Queries | yes |

  `Services`, `Total Current QPS`, `Top MySQL Questions`, `Top InnoDB I/O Data Reads`
  and the rest use `interval: $interval` and all rendered fine — including panels
  reading the very same metrics.

Replaying such a panel's query through Grafana's own `/graph/api/ds/query` on a
throwaway VM shows why. With `interval: "5m"` / `intervalMs: 300000`, Grafana aligns
the range onto the step's own grid, so on a `now-5m` range the query is answered
**only at 300s wall-clock boundaries** — measured directly:

```
window 04:11:00 -> 04:16:00, intervalMs=300000  ->  1 point, evaluated at 04:15:00
window 04:11:00 -> 04:16:00, intervalMs=15000   -> 15 points, 04:11:15 .. 04:15:45
```

A service whose first sample landed *after* the newest boundary has nothing to answer
with at that boundary — the datasource looks back 5 minutes from it, i.e. to before the
service existed — so the panel reads "No data" until the next boundary passes, however
many samples have arrived since. And `MySQL_Instances_Overview.json` has
`"refresh": false`, so the existing 60s `waitForGraphsToHaveData` poll is re-reading a
DOM that cannot change: the test sits in the failure for the whole minute instead of
recovering, which is exactly what the CI log shows.

That is why this is a race rather than a steady failure. In the failing run the `ps`
service came up at **02:35:20** — 20 seconds past a boundary — so the panels stayed
empty until 02:40:00, covering both the read at 02:38:42 and the full poll. Had setup
finished a few seconds earlier, the 02:35:00 boundary would have answered and the same
test would have passed.

## Reproduction — A/B on one throwaway Linode VM

Same server build as the failing run (`perconalab/pmm-server:3-dev-latest`, digest
`sha256:066a213f…` — the digest Launchable recorded for that session, `3.9.1-v3-0b84a2033`,
managed `bacbbc7`), same pmm-qa SHA, and the `@rbac` job's own setup
(`--database ps --database pdpgsql`) driven through `runner-e2e-tests-codeceptjs.yml`
step for step.

The failure is timing-dependent, and getting it to appear is the interesting part:

| attempt | MySQL service's first sample | `main` |
|---|---|---|
| as provisioned | ~12 min before the read | **passed** |
| re-registered at an arbitrary time (04:13:58) | 04:14:10, *before* the 04:15:00 boundary | **passed** — that boundary answered |
| re-registered 2s after a boundary (04:40:02), mirroring CI's 02:35:20 | 04:40:1x, *after* the 04:40:00 boundary | **failed** |

The third attempt reproduces the CI failure exactly — same count, same 12 panel names:

```
✖ PMM-T1899 ... in 130268ms
Expected 5 Elements without data but found 12 on Dashboard ...
Report Names are Min MySQL Uptime,Max MySQL Uptime,Total InnoDB Buffer Pool Size,
Top MySQL Used Connections,Top MySQL Used Connections,Top MySQL Client Threads Connected,
Top MySQL Idle Client Threads,Top MySQL Threads Cached,Top MySQL Queries,
Top MySQL Used Query Cache,MySQL Query Cache Size,MySQL Used Query Cache
```

with the newest boundary probing empty at the moment of registration:

```
probe newest boundary 04:40:00: {"status":"success","data":{"resultType":"vector","result":[]}}
```

The two passing attempts are not noise — they are the same mechanism seen from the
other side. Whether a given nightly trips this depends on where setup happens to land
against the 5-minute grid, so expect it to come and go rather than fail every night.

## The fix

Wait for the metrics behind those panels to resolve **at the newest 300s boundary**
before asserting on what the dashboard renders. New
`grafanaAPI.waitForMetricAtDashboardStep()` polls the boundary the panels are actually
answered at, and requires it to carry as many series as a query at `now` does — so a
node or service that only just started being monitored is waited for instead of being
absorbed as an empty panel.

Nothing is loosened. The tolerance stays at 5, every panel still has to produce data,
and a build that genuinely stops populating these panels still fails this test — it
just no longer fails because setup happened to land on the wrong side of a wall-clock
boundary. The wait costs nothing in the normal case (the boundary already has data and
it returns on the first poll) and is bounded at 600s, against a worst case of one
boundary interval plus a scrape.

The scenario's PostgreSQL leg has the same exposure and is covered by the same wait:
`PostgreSQL_Instance_Summary.json` pins `interval: 5m` on 4 targets (System Uptime, RAM,
Virtual Memory, Disk Space — all `node_exporter`), and the scenario tolerates 3 empty
panels there, so a node that just started being monitored would fail it the same way.
It did not get that far in this run, because the MySQL assertion failed first.

## Verification

Runs on the same VM, the branch being the only thing that changes within a row:

| MySQL service's first sample | `main` | this branch |
|---|---|---|
| just after a 300s boundary, that boundary probing `result: []` | **failed** — 12 empty panels | **passed** |
| not young (normal case) | passed | passed |

The green run on this branch was set up identically to the red one on `main` — service
re-registered 2 seconds past a boundary (`05:05:02`, boundary `05:05:00` probing
`{"resultType":"vector","result":[]}`), test launched one second later at `05:05:03`.
The wait engaged and held:

```
Wait up to 600 seconds for "min(mysql_global_status_uptime)" to resolve at the newest 300s boundary
Wait up to 600 seconds for "sum(mysql_global_variables_innodb_buffer_pool_size)" to resolve at the newest 300s boundary
Wait up to 600 seconds for "avg by (node_name) (node_memory_MemTotal_bytes)" to resolve at the newest 300s boundary
...
OK  | 1 passed   // 7m
```

It cleared once the `05:10:00` boundary carried the data, and the dashboard assertions
then passed. The scenario took 7 minutes here versus ~3 minutes when the service is not
young — the wait is only paid when it is actually needed.

`eslint` on both changed files: clean (run from the same checkout on the VM).

### What only a real run can confirm

This is verified against the one dashboard pair PMM-T1899 reads. The wait is bounded at
600s; if a nightly ever hits that timeout it will now fail saying the boundary never
caught up, which is a more useful failure than a bare empty-panel count, but I have not
seen it hit.

## Other failures in that run (not fixed here)

Both are already tracked, so they are untouched:

- `Docker configuration tests / @docker-configuration` (Playwright) — PMM-T2237, all
  three ClickHouse configs: already open as **#1203**, same root cause
  (percona/pmm#5747 stopped passing the config on the clickhouse-server command line).
- `Docker configuration tests / @docker-configuration` (CodeceptJS) — PMM-T2020,
  external ClickHouse on the Explore page. The run's own screenshot shows
  `[auth] code: 516, message: grafana: Authentication failed: password is incorrect, or
  there is no user with such name` — verbatim the failure **#1164** fixes by adding the
  read-only `grafana` datasource user percona/pmm#5747 now requires.


---
_Generated by [Claude Code](https://claude.ai/code/session_016jeMYLBZJJ95F1wk4HEnLY)_