### PR TITLE
Fix the three FB CLI failures on pmm-submodules#4515

### DIFF
--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -16,10 +16,19 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
   });
 
   let PMM_VERSION = `${process.env.CLIENT_VERSION}`;
+  let CLIENT_VERSION_LABEL = '';
   if (/^https?:/.test(PMM_VERSION) || /pmm3-rc/.test(PMM_VERSION)) {
     // Feature-build / RC clients trail v3 VERSION once an RC branches; take the version from the server.
-    PMM_VERSION = JSON.parse(cli.execute('sudo pmm-admin status --json').stdout).pmm_agent_status?.server_version;
-    if (!PMM_VERSION) throw new Error('Could not read server version from "pmm-admin status --json"');
+    const status = JSON.parse(cli.execute('sudo pmm-admin status --json').stdout).pmm_agent_status;
+    const serverVersion = status?.server_version;
+    if (!serverVersion) throw new Error('Could not read server version from "pmm-admin status --json"');
+    // Only the release part is comparable between the server image and the client tarball: the
+    // '-<branch>-<commit>' suffix names the pmm-submodules commit an artifact was built from, and a
+    // feature build reuses an unchanged server image, so its label can name an older commit than the
+    // client tarball published in the same build.
+    PMM_VERSION = serverVersion.match(/^\d+\.\d+\.\d+/)?.[0] || serverVersion;
+    // The client's own label is still asserted in full - pmm-agent and pmm-admin ship together.
+    CLIENT_VERSION_LABEL = status?.agent_version || '';
   } else if (/latest-tarball|3-dev-latest/.test(PMM_VERSION)) {
     // TODO: refactor to use docker hub API to remove file-update dependency
     // See: https://github.com/Percona-QA/package-testing/blob/master/playbooks/pmm2-client_integration_upgrade_custom_path.yml#L41
@@ -110,6 +119,9 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     const output = await cli.exec('sudo pmm-admin --version');
     await output.assertSuccess();
     await output.outContains(`Version: ${PMM_VERSION}`);
+    if (CLIENT_VERSION_LABEL) {
+      await output.outContains(`Version: ${CLIENT_VERSION_LABEL}`);
+    }
   });
 
   /**
@@ -137,6 +149,9 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     const output = await cli.exec('sudo pmm-admin summary --version');
     await output.assertSuccess();
     await output.outContains(`Version: ${PMM_VERSION}`);
+    if (CLIENT_VERSION_LABEL) {
+      await output.outContains(`Version: ${CLIENT_VERSION_LABEL}`);
+    }
   });
 
   test('PMM-T1219 - verify pmm-admin summary includes targets from vmagent', async ({}) => {
@@ -587,6 +602,7 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     const oldVersion = await cli.exec(`docker exec ${containerName} pmm-admin version | grep "Version:"`);
     const oldPid = await cli.exec(`docker exec ${containerName} ps -C pmm-agent -o pid=`);
 
+    await adminStatus.assertSuccess();
     await adminStatus.outContains('Connected');
     await oldVersion.outContains(latestReleasedVersion);
     const tarballURL = process.env.PMM_CLIENT_VERSION!.includes('http') ? process.env.PMM_CLIENT_VERSION : 'https://pmm-build-cache.s3.us-east-2.amazonaws.com/PR-BUILDS/pmm-client/pmm-client-latest.tar.gz';

--- a/package_tests/scripts/pmm3_client_install_tarball.sh
+++ b/package_tests/scripts/pmm3_client_install_tarball.sh
@@ -94,7 +94,15 @@ if [[ "$architecture" == "arm64" ]]; then
     # tarballs live on the downloads site with an -aarch64 suffix.
     tarball_url=https://downloads.percona.com/downloads/pmm3/${version}/binary/tarball/pmm-client-${version}-aarch64.tar.gz
 elif [[ "$architecture" == "amd64" ]]; then
-    tarball_url=https://downloads.percona.com/downloads/TESTING/pmm/${client_tar}
+    # Released amd64 tarballs are arch-suffixed on the downloads site too.
+    # TESTING/pmm/pmm-client-<version>.tar.gz is unversioned staging and gets
+    # overwritten: on 2026-08-20 it started serving an aarch64 build for 3.9.1,
+    # which installs without error and then dies with "exec format error". Keep
+    # it only as a fallback for versions the downloads site does not carry yet.
+    tarball_url=https://downloads.percona.com/downloads/pmm3/${version}/binary/tarball/pmm-client-${version}-x86_64.tar.gz
+    if [ -z "${fb}" ] && ! wget --spider -q "${tarball_url}"; then
+      tarball_url=https://downloads.percona.com/downloads/TESTING/pmm/${client_tar}
+    fi
 fi
 
 if [ -n "${fb}" ]; then

--- a/qa-integration/pmm_qa/pmm-framework/lib/runners.sh
+++ b/qa-integration/pmm_qa/pmm-framework/lib/runners.sh
@@ -74,30 +74,55 @@ version_is_greater() {
   return 1
 }
 
-# Expand a PSMDB major version into its newest full version.
+# Whether a full PSMDB version's RPMs are published in the 'release' yum
+# repository the setup images install from.
+#
+# The downloads API lists a release as soon as its packages are built, which
+# can be well before they are promoted from 'testing' to 'release'. The member
+# image enables the release repo only, so picking such a version fails the
+# image build with 'No match for argument:
+# percona-server-mongodb-<version>.el<ol>' -- PSMDB 8.0.29-13 did exactly that.
+#
+# A missing RPM answers 404. Anything else, including a request that never
+# completes, counts as published, so a network hiccup degrades to picking the
+# newest version rather than failing the run.
+#
+# Usage:  psmdb_rpms_published 8.0.28-12 9
+psmdb_rpms_published() {
+  local version=$1 ol_version=$2 series code
+  series=$(printf '%s' "$version" | awk -F. '{print $1 $2}')
+  code=$(curl --silent --head --output /dev/null --write-out '%{http_code}' \
+    "https://repo.percona.com/psmdb-${series}/yum/release/${ol_version}/RPMS/x86_64/percona-server-mongodb-server-${version}.el${ol_version}.x86_64.rpm") ||
+    return 0
+  [[ $code != 404 ]]
+}
+
+# Expand a PSMDB major version into its newest installable full version.
 #
 # The PSMDB setup scripts want a complete version such as '8.0.26-11', but
 # specs name the major series ('8.0'). This asks the same admin-ajax.php
 # endpoint the percona.com downloads page itself calls (Percona removed the
 # old products-api.php when the site was rebuilt on WordPress/Breakdance) for
-# every published patch of that series, and picks the highest.
+# every published patch of that series, and picks the highest one whose RPMs
+# the image build can actually install (see psmdb_rpms_published).
 #
 # 'latest' and '' pass through untouched -- they are meaningful to the setup
-# script as-is. This is the only network call the framework makes, and the only
-# reason `curl` is required (preflight checks for it only when a PSMDB setup is
-# requested).
+# script as-is. These are the only network calls the framework makes, and the
+# only reason `curl` is required (preflight checks for it only when a PSMDB
+# setup is requested).
 #
-# Usage:  version=$(latest_psmdb_version 8.0)   # -> 8.0.26-11
+# Usage:  version=$(latest_psmdb_version 8.0 9)   # -> 8.0.28-12
 # Stdout: the resolved version
-# Exits:  via die() when the API call fails or no patch matches
+# Exits:  via die() when the API call fails or no patch is installable
 latest_psmdb_version() {
-  local requested=$1
+  local requested=$1 ol_version=${2:-9}
   if [[ $requested == latest || -z $requested ]]; then
     printf '%s' "$requested"
     return
   fi
 
-  local response latest='' latest_patch='' candidate patch
+  local response candidate patch best best_patch best_index index
+  local -a candidates=()
   response=$(curl --fail --silent --show-error \
     --data-urlencode 'action=percona_downloads' \
     --data-urlencode "product_id=percona-server-mongodb-$requested" \
@@ -107,16 +132,9 @@ latest_psmdb_version() {
 
   # The API answers with JSON; pull the quoted entries out of the 'versions'
   # array, strip the product prefix, and keep only entries for the requested
-  # series. Patches look like '<major.minor>.<patch>-<build>'; the trailing
-  # '-build' is turned into '.build' so version_is_greater can compare it as
-  # just another dotted component.
+  # series.
   while IFS= read -r candidate; do
-    patch=${candidate#"$requested."}
-    patch=${patch//-/.}
-    if [[ -z $latest ]] || version_is_greater "$patch" "$latest_patch"; then
-      latest=$candidate
-      latest_patch=$patch
-    fi
+    candidates+=("$candidate")
   done < <(
     printf '%s' "$response" |
       grep -Eo '"versions"[[:space:]]*:[[:space:]]*\[[^]]*\]' |
@@ -125,9 +143,32 @@ latest_psmdb_version() {
       sed 's/^percona-server-mongodb-//' |
       grep -E "^${requested//./\\.}\.[0-9]+(-[0-9]+)?$"
   )
-  [[ -n $latest ]] ||
+  ((${#candidates[@]})) ||
     die "Could not resolve the latest PSMDB patch for '$requested'."
-  printf '%s' "$latest"
+
+  # Newest first, returning the first one that is installable. Patches look
+  # like '<major.minor>.<patch>-<build>'; the trailing '-build' is turned into
+  # '.build' so version_is_greater can compare it as just another dotted
+  # component.
+  while ((${#candidates[@]})); do
+    best='' best_patch='' best_index=-1
+    for index in "${!candidates[@]}"; do
+      patch=${candidates[index]#"$requested."}
+      patch=${patch//-/.}
+      if [[ -z $best ]] || version_is_greater "$patch" "$best_patch"; then
+        best=${candidates[index]}
+        best_patch=$patch
+        best_index=$index
+      fi
+    done
+    if psmdb_rpms_published "$best" "$ol_version"; then
+      printf '%s' "$best"
+      return
+    fi
+    unset "candidates[best_index]"
+    candidates=("${candidates[@]}")
+  done
+  die "No PSMDB '$requested' patch is published in the release repository for el$ol_version."
 }
 
 # The PMM Server admin password for this run.

--- a/qa-integration/pmm_qa/pmm-framework/setups/mongodb.sh
+++ b/qa-integration/pmm_qa/pmm-framework/setups/mongodb.sh
@@ -17,17 +17,19 @@
 # registered default. The middle case is why this helper exists at all: the
 # compose scripts need a full version such as '8.0-12.1', so a spec version is
 # sent through latest_psmdb_version() (a network lookup) rather than used
-# as-is.
+# as-is. The Oracle Linux release the member image is built on decides which
+# RPMs that lookup has to find, so it is passed along.
 #
 # Shared by setup_psmdb and setup_ssl_psmdb.
 #
 # Reads:  PSMDB_VERSION, DB_VERSION, DB_TYPE
 # Stdout: the resolved version
 psmdb_version() {
+  local ol_version=${1:-9}
   if [[ -n ${PSMDB_VERSION:-} ]]; then
     printf '%s' "$PSMDB_VERSION"
   elif [[ -n $DB_VERSION ]]; then
-    latest_psmdb_version "$DB_VERSION"
+    latest_psmdb_version "$DB_VERSION" "$ol_version"
   else
     database_default_version "$DB_TYPE"
   fi
@@ -43,8 +45,9 @@ psmdb_version() {
 #
 # SETUP_TYPE picks the script; 'shards' and 'sharding' are aliases.
 setup_psmdb() {
-  local version client setup_type script
-  version=$(psmdb_version)
+  local version client setup_type script ol_version
+  ol_version=$(resolve_value PSMDB OL_VERSION DB_CONFIG)
+  version=$(psmdb_version "$ol_version")
   client=$(resolved_client_version PSMDB DB_CONFIG)
   setup_type=$(resolve_value PSMDB SETUP_TYPE DB_CONFIG)
   setup_type=${setup_type,,}
@@ -58,7 +61,7 @@ setup_psmdb() {
     [COMPOSE_PROFILES]="$(resolve_value PSMDB COMPOSE_PROFILES DB_CONFIG)"
     [MONGO_SETUP_TYPE]="$setup_type"
     [MONGO_STORAGE_ENGINE]="$(resolve_value PSMDB STORAGE_ENGINE DB_CONFIG)"
-    [OL_VERSION]="$(resolve_value PSMDB OL_VERSION DB_CONFIG)"
+    [OL_VERSION]="$ol_version"
     [GSSAPI]="$(resolve_value PSMDB GSSAPI DB_CONFIG)"
     [TESTS]=no
     [CLEANUP]=no

--- a/qa-integration/pmm_qa/pmm-framework/tests/cli.bats
+++ b/qa-integration/pmm_qa/pmm-framework/tests/cli.bats
@@ -104,6 +104,35 @@ load helpers/test_helper
   [[ $(latest_psmdb_version 8.0) == 8.0.4-2 ]]
 }
 
+@test "skips PSMDB patches whose RPMs are not in the release repository yet" {
+  # The downloads API lists a release before its RPMs leave 'testing', which is
+  # how 8.0.29-13 broke the member image build.
+  curl() {
+    printf '%s' \
+      '{"success":true,"data":{"versions":["percona-server-mongodb-8.0.4-2","percona-server-mongodb-8.0.29-13"]}}'
+  }
+  psmdb_rpms_published() {
+    [[ $1 != 8.0.29-13 ]]
+  }
+
+  [[ $(latest_psmdb_version 8.0) == 8.0.4-2 ]]
+}
+
+@test "reports a missing RPM as unpublished and anything else as published" {
+  curl() {
+    case " $* " in
+      *8.0.29-13*) printf '404' ;;
+      *) printf '200' ;;
+    esac
+  }
+
+  run psmdb_rpms_published 8.0.29-13 9
+  [[ $status -ne 0 ]]
+
+  run psmdb_rpms_published 8.0.28-12 9
+  [[ $status -eq 0 ]]
+}
+
 @test "selects the existing requests-capable interpreter for Ansible modules" {
   local fake_python=$BATS_TEST_TMPDIR/python
   printf '#!/usr/bin/env bash\nexit 0\n' >"$fake_python"


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4515](https://github.com/Percona-Lab/pmm-submodules/pull/4515) — run [32344767049](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32344767049) (FB build `PR-4515-7f81e94`)
- tests:
  - `cli/tests/generic.spec.ts:109` / `@generic` — "run pmm-admin --version" ([job 96351079158](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32344767049/job/96351079158))
  - `cli/tests/generic.spec.ts:136` / `@generic` — "run pmm-admin summary --version" (same job)
  - `cli/tests/generic.spec.ts:575` / `@generic` — PMM-T2227 "Verify tarball upgrade" (same job)
  - `qa-integration/pmm_qa/pmm-framework` setup for `@shard-psmdb` — `CLI / Integration / PSMDB Shard 8.x` ([job 96351079099](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32344767049/job/96351079099)), where the setup failed before any test ran

Three red checks in that run, four distinct causes; the fourth (`@docker-configuration`) is already covered elsewhere — see the last section.

## 1. `PSMDB Shard 8.x` — the framework picked a version the release repo does not carry

The job never reached its tests: `start-sharded.sh` failed while building the member image.

```
+ dnf -y install percona-server-mongodb-8.0.29-13.el9 percona-server-mongodb-tools-8.0.29-13.el9 ...
No match for argument: percona-server-mongodb-8.0.29-13.el9
Error: Unable to find a match: percona-server-mongodb-8.0.29-13.el9 ...
ERROR: Setup script 'start-sharded.sh' failed.
```

`latest_psmdb_version 8.0` expands the spec version by asking the percona.com downloads API for every published patch and taking the highest — which today is **8.0.29-13**. The member image enables the **release** yum repo (`percona-release enable psmdb-80 release`), and 8.0.29-13 has not been promoted there yet:

| repo | el9 | el8 |
|---|---|---|
| `psmdb-80/yum/release` | newest is **8.0.28-12** | newest is 8.0.28-12 |
| `psmdb-80/yum/testing` | 8.0.29-13 present | 8.0.29-13 present |

So the two sources disagree, and the framework trusted the one it does not install from. This is not specific to 8.0: any series will break the same way for however long a new release sits in `testing`. `PSMDB Shard 7.x` passed in the same run only because 7.0's newest API entry (7.0.40-22) *is* in the release repo, and `PSMDB Replica 8.x` passed because Launchable selected no tests for it, so its setup never ran.

**Fix** — `latest_psmdb_version` now walks the API's patches newest-first and returns the first one whose `percona-server-mongodb-server-<version>.el<ol>.x86_64.rpm` actually answers in the release repo. Nothing is loosened: it still picks the newest version, just the newest *installable* one, and it still fails loudly if none of them is published. A probe that cannot complete counts as published, so a network hiccup degrades to the old behaviour instead of failing the run. The Oracle Linux release is threaded in from `setup_psmdb` (`OL_VERSION`, default 9), since that decides which RPM has to exist.

## 2 & 3. `pmm-admin --version` / `summary --version` — comparing two artifacts' build labels

```
Expected substring: "Version: 3.9.1-PMM-15302-ha-remove-ssh-settings-68ce53410"
Received string:    "Version: 3.9.1-PMM-15302-ha-remove-ssh-settings-7f81e9497"
```

`CLIENT_VERSION` is a URL for a feature build, so the spec takes the expected version from `pmm-admin status --json`'s `server_version` and asserts the client prints it verbatim. In this build the two labels name different commits, and both are correct:

| artifact | version label | `FullCommit` | built |
|---|---|---|---|
| server image `PR-4515-7f81e94` (digest `sha256:48b2f7cb…`, the digest Launchable recorded for the failing session) | `…-68ce53410` | `49f3f640892…` | 2026-08-19 08:29:46 |
| client tarball `pmm-client-PR-4515-7f81e94.tar.gz` | `…-7f81e9497` | `49f3f640892…` | 2026-08-20 07:22:05 |

`68ce53410` and `7f81e9497` are the previous and current commits of **pmm-submodules PR #4515** — both plain `Merge branch 'v3'` merges — while `FullCommit` is identical on both sides: `49f3f640892`, the head of `percona/pmm`'s `PMM-15302-ha-remove-ssh-settings`. The `pmm` sources did not move between the two feature builds, so the server image was reused and re-tagged, keeping the label of the build that produced it, while the client tarball was rebuilt and labelled with today's commit. Same code, different label — nothing for this test to catch.

**Fix** — for feature-build / RC clients, compare only the release part (`3.9.1`) of the server's version, which is the part that is meaningfully shared between the two artifacts. The client's *own* full label is now asserted exactly as well, against `agent_version` from `pmm-admin status --json`: pmm-agent and pmm-admin ship in the same tarball, so that comparison is legitimately strict, and a client that is a different release from the server still fails the test.

## 4. PMM-T2227 — the released amd64 client tarball turned into an arm64 build

```
Expected substring: "Connected"
Received string:    ""
```

The empty output is the symptom; the cause only shows with the exec log on:

```
exec: "docker exec tarball_client pmm-admin status"
exec /usr/bin/pmm-admin: exec format error
```

`pmm3_client_install_tarball.sh` installs the newest *released* client (3.9.1) into the tarball container, and for amd64 it took it from `downloads.percona.com/downloads/TESTING/pmm/pmm-client-<version>.tar.gz` — an unversioned staging path. That file was overwritten at **2026-08-20 06:56 UTC**, ~40 minutes before this run, with an **aarch64** build. Measured on the box, both directly and through the extracted binary:

```
TESTING/pmm/pmm-client-3.9.1.tar.gz               -> ELF e_machine 0x00b7 (AArch64)
pmm3/3.9.1/binary/tarball/pmm-client-3.9.1-x86_64 -> ELF e_machine 0x003e (x86-64)
```

It untars and installs without complaint, so the test only noticed three commands later, as an empty `pmm-admin status`.

**Fix** — take released amd64 tarballs from the same arch-suffixed downloads path the arm64 branch already uses (`pmm3/<version>/binary/tarball/pmm-client-<version>-x86_64.tar.gz`), which exists for every released version back to 3.0.0, and keep `TESTING/pmm` only as a fallback for versions the downloads site does not carry yet (pre-GA RCs, which the package tests do install). The test also asserts `pmm-admin status` exited 0 before matching `Connected`, so an unusable client names itself instead of surfacing as an empty string.

## Reproduction and verification

One throwaway Linode VM, following `runner-integration-cli-tests.yml` step for step with the failing run's own artifacts — server image `perconalab/pmm-server-fb:PR-4515-7f81e94` (digest `sha256:48b2f7cb…`, the same digest Launchable recorded), the matching client tarball, and each job's own `WIZARD_ARGS`.

| | `main` (`be81ada`) | this branch |
|---|---|---|
| `pmm-framework --database psmdb=8.0,SETUP_TYPE=sharding` | **failed** — `No match for argument: percona-server-mongodb-8.0.29-13.el9`, identical to CI | **OK** — cluster up on `db version v8.0.28-12` (mongos + 3 shards + 3 config members); `@shard-psmdb` then passes (1 passed, 1 `test.skip`) |
| `--grep "run pmm-admin (summary )?--version"` | **2 failed** — same expected/received strings as CI | **passed** |
| `--grep PMM-T2227` | **failed** — `exec /usr/bin/pmm-admin: exec format error` | **passed** (22.1s) |

The install script's own behaviour, checked directly in an `almalinux-10` container:

```
-v 3.9.1     -> Downloading .../pmm3/3.9.1/binary/tarball/pmm-client-3.9.1-x86_64.tar.gz
                ELF 0x003e (x86-64); pmm-admin --version -> "Version: 3.9.1"
-v 3.99.0    -> Downloading .../TESTING/pmm/pmm-client-3.99.0.tar.gz      (fallback intact)
-v <FB url>  -> Downloading .../PR-BUILDS/pmm-client/pmm-client-PR-4515-7f81e94.tar.gz
```

Linters, run from the same checkout:

- `cli`: `npm run lint` (eslint + `tsc --noEmit`) — **Lint OK**, 0 errors (80 pre-existing `.skip()` warnings, none in the changed test).
- `pmm-framework`: `make syntax` clean, `make test` **52/52 ok** (including two new bats cases for the unpublished-patch skip). `make lint` exits non-zero, but it does so on `main` too with shellcheck 0.9.0 — the same `SC2317 (info)` on stubbed functions in `tests/cli.bats` and on `lib/execution.sh`, which this branch does not touch. It is not a CI gate (CI only runs bats for the helm charts).

None of this is timing- or data-dependent, so the VM's age does not flatter it: the PSMDB change is version resolution, and the other two are deterministic given these artifacts. What only a real run can confirm is the rest of each job's matrix — the FB build re-run is the check.

## Other failure in that run (not fixed here)

- `E2E / Docker configuration tests / e2e tests: @docker-configuration` (CodeceptJS) — PMM-T2020, external ClickHouse on the Explore page: `waitForVisible(//div[@role="row"])` after `Run Query`. Already covered by the open **#1164**, which adds the read-only `grafana` datasource user that percona/pmm#5747 requires on an external ClickHouse. Untouched here. (The Playwright `@docker-configuration` job with the same name passed — 6 passed — so only the CodeceptJS one is red.)

Two things noticed while in here and deliberately left alone, since neither caused a failure in this run: PMM-T2227's `docker network connect pmm-server pmm-qa` has its arguments the wrong way round (it only works because the framework already attaches `pmm-server` to `pmm-qa`), and the aarch64 build now sitting at `TESTING/pmm/pmm-client-3.9.1.tar.gz` is worth someone on the release side looking at — this PR just stops depending on that mutable path.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CGiuN3Fs6Q5nVPpUbZ6etJ)_