### PR TITLE
Resolve PSMDB versions the yum repo actually carries

### DIFF
--- a/qa-integration/pmm_qa/pmm-framework/lib/runners.sh
+++ b/qa-integration/pmm_qa/pmm-framework/lib/runners.sh
@@ -74,30 +74,57 @@ version_is_greater() {
   return 1
 }
 
-# Expand a PSMDB major version into its newest full version.
+# Are a PSMDB version's RPMs actually in the release yum repo?
+#
+# percona.com announces a build as soon as it is released, which can be days
+# before the psmdb-XY yum repo carries its packages. The PSMDB setup
+# Dockerfile installs a pinned '<version>.el<N>' RPM, so an announced-but-not-
+# yet-published version fails the image build with 'Unable to find a match'
+# instead of just installing something slightly older.
+#
+# Fails open: an unreadable listing (proxy, outage, an arch laid out
+# differently) reports 'published', so a probe that cannot answer never blocks
+# a setup that would otherwise have worked.
+#
+# Usage:  psmdb_rpms_published 8.0.28-12 9
+# Returns: 0 when installable (or unknown), 1 when the repo lacks it
+psmdb_rpms_published() {
+  local version=$1 el=$2 repo arch listing
+  repo=psmdb-$(printf '%s' "$version" | awk -F. '{print $1 $2}')
+  arch=$(uname -m)
+  listing=$(curl --fail --silent --max-time 30 \
+    "https://repo.percona.com/$repo/yum/release/$el/RPMS/$arch/") || return 0
+  grep -q 'percona-server-mongodb-server-' <<<"$listing" || return 0
+  grep -q "percona-server-mongodb-server-$version\.el$el\." <<<"$listing"
+}
+
+# Expand a PSMDB major version into its newest installable full version.
 #
 # The PSMDB setup scripts want a complete version such as '8.0.26-11', but
 # specs name the major series ('8.0'). This asks the same admin-ajax.php
 # endpoint the percona.com downloads page itself calls (Percona removed the
 # old products-api.php when the site was rebuilt on WordPress/Breakdance) for
-# every published patch of that series, and picks the highest.
+# every published patch of that series, then walks them newest-first and takes
+# the first one whose RPMs have reached the release repo (see
+# psmdb_rpms_published).
 #
 # 'latest' and '' pass through untouched -- they are meaningful to the setup
-# script as-is. This is the only network call the framework makes, and the only
-# reason `curl` is required (preflight checks for it only when a PSMDB setup is
-# requested).
+# script as-is. `curl` is required for this (preflight checks for it only when
+# a PSMDB setup is requested).
 #
-# Usage:  version=$(latest_psmdb_version 8.0)   # -> 8.0.26-11
+# Usage:  version=$(latest_psmdb_version 8.0 9)   # -> 8.0.28-12
 # Stdout: the resolved version
 # Exits:  via die() when the API call fails or no patch matches
 latest_psmdb_version() {
-  local requested=$1
+  local requested=$1 el=${2:-9}
   if [[ $requested == latest || -z $requested ]]; then
     printf '%s' "$requested"
     return
   fi
+  el=${el:-9}
 
-  local response latest='' latest_patch='' candidate patch
+  local response candidate patch index best best_patch
+  local -a candidates=() patches=() ordered=() taken=()
   response=$(curl --fail --silent --show-error \
     --data-urlencode 'action=percona_downloads' \
     --data-urlencode "product_id=percona-server-mongodb-$requested" \
@@ -112,11 +139,8 @@ latest_psmdb_version() {
   # just another dotted component.
   while IFS= read -r candidate; do
     patch=${candidate#"$requested."}
-    patch=${patch//-/.}
-    if [[ -z $latest ]] || version_is_greater "$patch" "$latest_patch"; then
-      latest=$candidate
-      latest_patch=$patch
-    fi
+    candidates+=("$candidate")
+    patches+=("${patch//-/.}")
   done < <(
     printf '%s' "$response" |
       grep -Eo '"versions"[[:space:]]*:[[:space:]]*\[[^]]*\]' |
@@ -125,9 +149,34 @@ latest_psmdb_version() {
       sed 's/^percona-server-mongodb-//' |
       grep -E "^${requested//./\\.}\.[0-9]+(-[0-9]+)?$"
   )
-  [[ -n $latest ]] ||
+  ((${#candidates[@]})) ||
     die "Could not resolve the latest PSMDB patch for '$requested'."
-  printf '%s' "$latest"
+
+  while ((${#ordered[@]} < ${#candidates[@]})); do
+    best=-1
+    best_patch=''
+    for ((index = 0; index < ${#candidates[@]}; index++)); do
+      [[ -n ${taken[index]:-} ]] && continue
+      if ((best < 0)) || version_is_greater "${patches[index]}" "$best_patch"; then
+        best=$index
+        best_patch=${patches[index]}
+      fi
+    done
+    taken[best]=1
+    ordered+=("${candidates[best]}")
+  done
+
+  for candidate in "${ordered[@]}"; do
+    if psmdb_rpms_published "$candidate" "$el"; then
+      [[ $candidate == "${ordered[0]}" ]] ||
+        log_warn "PSMDB ${ordered[0]} is announced but its el$el RPMs are not in the" \
+          "$requested release repo yet; using $candidate."
+      printf '%s' "$candidate"
+      return
+    fi
+  done
+  die "No PSMDB $requested patch has el$el RPMs in the release repo" \
+    "(newest announced: ${ordered[0]})."
 }
 
 # The PMM Server admin password for this run.

--- a/qa-integration/pmm_qa/pmm-framework/lib/runners.sh
+++ b/qa-integration/pmm_qa/pmm-framework/lib/runners.sh
@@ -74,7 +74,7 @@ version_is_greater() {
   return 1
 }
 
-# Are a PSMDB version's RPMs actually in the release yum repo?
+# Are a PSMDB version's RPMs actually in the yum repo the setup installs from?
 #
 # percona.com announces a build as soon as it is released, which can be days
 # before the psmdb-XY yum repo carries its packages. The PSMDB setup
@@ -86,14 +86,14 @@ version_is_greater() {
 # differently) reports 'published', so a probe that cannot answer never blocks
 # a setup that would otherwise have worked.
 #
-# Usage:  psmdb_rpms_published 8.0.28-12 9
+# Usage:  psmdb_rpms_published 8.0.28-12 9 release
 # Returns: 0 when installable (or unknown), 1 when the repo lacks it
 psmdb_rpms_published() {
-  local version=$1 el=$2 repo arch listing
+  local version=$1 el=$2 channel=$3 repo arch listing
   repo=psmdb-$(printf '%s' "$version" | awk -F. '{print $1 $2}')
   arch=$(uname -m)
   listing=$(curl --fail --silent --max-time 30 \
-    "https://repo.percona.com/$repo/yum/release/$el/RPMS/$arch/") || return 0
+    "https://repo.percona.com/$repo/yum/$channel/$el/RPMS/$arch/") || return 0
   grep -q 'percona-server-mongodb-server-' <<<"$listing" || return 0
   grep -q "percona-server-mongodb-server-$version\.el$el\." <<<"$listing"
 }
@@ -105,23 +105,24 @@ psmdb_rpms_published() {
 # endpoint the percona.com downloads page itself calls (Percona removed the
 # old products-api.php when the site was rebuilt on WordPress/Breakdance) for
 # every published patch of that series, then walks them newest-first and takes
-# the first one whose RPMs have reached the release repo (see
-# psmdb_rpms_published).
+# the first one whose RPMs have reached the yum channel the setup installs
+# from (see psmdb_rpms_published).
 #
 # 'latest' and '' pass through untouched -- they are meaningful to the setup
 # script as-is. `curl` is required for this (preflight checks for it only when
 # a PSMDB setup is requested).
 #
-# Usage:  version=$(latest_psmdb_version 8.0 9)   # -> 8.0.28-12
+# Usage:  version=$(latest_psmdb_version 8.0 9 release)   # -> 8.0.28-12
 # Stdout: the resolved version
 # Exits:  via die() when the API call fails or no patch matches
 latest_psmdb_version() {
-  local requested=$1 el=${2:-9}
+  local requested=$1 el=${2:-9} channel=${3:-release}
   if [[ $requested == latest || -z $requested ]]; then
     printf '%s' "$requested"
     return
   fi
   el=${el:-9}
+  channel=${channel:-release}
 
   local response candidate patch index best best_patch
   local -a candidates=() patches=() ordered=() taken=()
@@ -167,15 +168,15 @@ latest_psmdb_version() {
   done
 
   for candidate in "${ordered[@]}"; do
-    if psmdb_rpms_published "$candidate" "$el"; then
+    if psmdb_rpms_published "$candidate" "$el" "$channel"; then
       [[ $candidate == "${ordered[0]}" ]] ||
         log_warn "PSMDB ${ordered[0]} is announced but its el$el RPMs are not in the" \
-          "$requested release repo yet; using $candidate."
+          "$requested $channel repo yet; using $candidate."
       printf '%s' "$candidate"
       return
     fi
   done
-  die "No PSMDB $requested patch has el$el RPMs in the release repo" \
+  die "No PSMDB $requested patch has el$el RPMs in the $channel repo" \
     "(newest announced: ${ordered[0]})."
 }
 

--- a/qa-integration/pmm_qa/pmm-framework/setups/mongodb.sh
+++ b/qa-integration/pmm_qa/pmm-framework/setups/mongodb.sh
@@ -17,17 +17,18 @@
 # registered default. The middle case is why this helper exists at all: the
 # compose scripts need a full version such as '8.0-12.1', so a spec version is
 # sent through latest_psmdb_version() (a network lookup) rather than used
-# as-is.
+# as-is. The spec's OL_VERSION goes with it, since which patches are
+# installable is per-EL-release.
 #
 # Shared by setup_psmdb and setup_ssl_psmdb.
 #
-# Reads:  PSMDB_VERSION, DB_VERSION, DB_TYPE
+# Reads:  PSMDB_VERSION, DB_VERSION, DB_TYPE, DB_CONFIG
 # Stdout: the resolved version
 psmdb_version() {
   if [[ -n ${PSMDB_VERSION:-} ]]; then
     printf '%s' "$PSMDB_VERSION"
   elif [[ -n $DB_VERSION ]]; then
-    latest_psmdb_version "$DB_VERSION"
+    latest_psmdb_version "$DB_VERSION" "$(resolve_value "$DB_TYPE" OL_VERSION DB_CONFIG)"
   else
     database_default_version "$DB_TYPE"
   fi

--- a/qa-integration/pmm_qa/pmm-framework/setups/mongodb.sh
+++ b/qa-integration/pmm_qa/pmm-framework/setups/mongodb.sh
@@ -17,18 +17,28 @@
 # registered default. The middle case is why this helper exists at all: the
 # compose scripts need a full version such as '8.0-12.1', so a spec version is
 # sent through latest_psmdb_version() (a network lookup) rather than used
-# as-is. The spec's OL_VERSION goes with it, since which patches are
-# installable is per-EL-release.
+# as-is. The spec's OL_VERSION and the yum channel the stack installs from go
+# with it, since a patch is only usable once that channel carries its RPMs --
+# and the two stacks default REPO differently (the diffauth compose uses
+# 'testing', pmm_psmdb-pbm_setup 'release').
 #
 # Shared by setup_psmdb and setup_ssl_psmdb.
 #
-# Reads:  PSMDB_VERSION, DB_VERSION, DB_TYPE, DB_CONFIG
+# Reads:  PSMDB_VERSION, DB_VERSION, DB_TYPE, DB_CONFIG, REPO
 # Stdout: the resolved version
 psmdb_version() {
+  local channel
+  if [[ $DB_TYPE == SSL_PSMDB ]]; then
+    channel=${REPO:-testing}
+  else
+    channel=${REPO:-release}
+  fi
+
   if [[ -n ${PSMDB_VERSION:-} ]]; then
     printf '%s' "$PSMDB_VERSION"
   elif [[ -n $DB_VERSION ]]; then
-    latest_psmdb_version "$DB_VERSION" "$(resolve_value "$DB_TYPE" OL_VERSION DB_CONFIG)"
+    latest_psmdb_version "$DB_VERSION" \
+      "$(resolve_value "$DB_TYPE" OL_VERSION DB_CONFIG)" "$channel"
   else
     database_default_version "$DB_TYPE"
   fi

--- a/qa-integration/pmm_qa/pmm-framework/tests/cli.bats
+++ b/qa-integration/pmm_qa/pmm-framework/tests/cli.bats
@@ -104,6 +104,32 @@ load helpers/test_helper
   [[ $(latest_psmdb_version 8.0) == 8.0.4-2 ]]
 }
 
+@test "skips a PSMDB patch whose RPMs have not reached the release repo" {
+  # percona.com announces a build before the yum repo carries it; the setup
+  # Dockerfile installs a pinned RPM, so the newest announced patch is only
+  # usable once the repo listing shows it.
+  curl() {
+    if [[ $* == *repo.percona.com* ]]; then
+      printf '%s\n' 'percona-server-mongodb-server-8.0.4-1.el9.x86_64.rpm'
+      return
+    fi
+    printf '%s' \
+      '{"success":true,"data":{"versions":["percona-server-mongodb-8.0.4-1","percona-server-mongodb-8.0.5-1"]}}'
+  }
+
+  [[ $(latest_psmdb_version 8.0 9) == 8.0.4-1 ]]
+}
+
+@test "keeps the newest PSMDB patch when the release repo cannot be read" {
+  curl() {
+    [[ $* == *repo.percona.com* ]] && return 22
+    printf '%s' \
+      '{"success":true,"data":{"versions":["percona-server-mongodb-8.0.4-1","percona-server-mongodb-8.0.5-1"]}}'
+  }
+
+  [[ $(latest_psmdb_version 8.0 9) == 8.0.5-1 ]]
+}
+
 @test "selects the existing requests-capable interpreter for Ansible modules" {
   local fake_python=$BATS_TEST_TMPDIR/python
   printf '#!/usr/bin/env bash\nexit 0\n' >"$fake_python"


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4479](https://github.com/Percona-Lab/pmm-submodules/pull/4479) — run [32345563976](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32345563976), check `CLI / Integration tests / CLI / Integration / PSMDB Shard 8.x` (job [96353488321](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32345563976/job/96353488321))
- tests:
  - `cli/tests/mongoDb-psmdb-shard.spec.ts` / `@shard-psmdb` — the job never reached the spec; it died in `Run qa-integration setup` (`--database psmdb=8.0,SETUP_TYPE=sharding`)

## What failed

The job's setup step, not a test:

```
Error: Unable to find a match: percona-server-mongodb-8.0.29-13.el9
  percona-server-mongodb-tools-8.0.29-13.el9
  percona-server-mongodb-server-8.0.29-13.el9
  percona-server-mongodb-mongos-8.0.29-13.el9
target build_member: failed to solve: process "/bin/sh -c set -ex; ..." did not complete successfully: exit code: 1
ERROR: Setup script 'start-sharded.sh' failed.
```

The same job passed in the previous run on this branch ([32238776301](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32238776301), 2026-08-19), and nothing in pmm-qa changed in between.

## Root cause — we pin a PSMDB build the yum repo does not carry yet

The spec asks for the `8.0` series. `latest_psmdb_version()` expands that to a full
patch by asking percona.com's downloads endpoint for every published 8.0 build and
taking the highest — and `pmm_psmdb-pbm_setup/Dockerfile` then installs that patch
**pinned**: `dnf -y install percona-server-mongodb-${PSMDB_VERSION}.el${OL_VERSION}`.

The two sources disagree. percona.com announces a build as soon as it is released;
the `psmdb-80` yum repo gets the RPMs later:

| source | newest 8.0 |
|---|---|
| `admin-ajax.php` downloads endpoint (what we resolve from) | **8.0.29-13** |
| `repo.percona.com/psmdb-80/yum/release/9/RPMS/x86_64/` (what dnf installs from) | **8.0.28-12** |
| `repo.percona.com/psmdb-80/yum/release/8/RPMS/x86_64/` | 8.0.28-12 |
| `repo.percona.com/psmdb-80/yum/testing/9/RPMS/x86_64/` | 8.0.29-13 |

So 8.0.29-13 exists — in `testing`, which the sharded/replica stack does not enable
(`REPO=${REPO:-release}`). `dnf` has nothing to match and the image build dies, which
is why this went red the day 8.0.29-13 was announced and not before.

Not specific to sharding or to this FB. Anything resolving `psmdb=8.0` through the
compose path is affected — `PSMDB Replica 8.x` included; that job stayed green in this
run only because Launchable selected no tests for it, so its setup never ran:

```
No tests were selected for this code change.
Launchable subset is empty. Downstream setup and tests will be skipped.
```

`PSMDB Shard 7.x` passed because 7.0's newest announced patch (7.0.40-22) *is* in the
release repo — the same mechanism seen from the lucky side.

## The fix

`latest_psmdb_version()` now walks the announced patches newest-first and returns the
first one whose RPMs are actually in the repo listing, instead of trusting the
announcement:

```
WARNING: PSMDB 8.0.29-13 is announced but its el9 RPMs are not in the 8.0 release repo yet; using 8.0.28-12.
psmdb=8.0 -> 8.0.28-12
psmdb=7.0 -> 7.0.40-22        # unchanged: newest announced is published
```

Two things go along with the version so the probe asks about the right packages:
`OL_VERSION` from the spec (`el9` vs `el8` are published separately), and the yum
channel the stack installs from — `pmm_psmdb-pbm_setup` defaults `REPO` to `release`,
the diffauth compose to `testing`, and probing the wrong one would either resurrect
this bug or downgrade the diffauth stack for no reason.

Nothing is loosened and no version is hardcoded: the resolution still returns the
newest patch, just the newest *installable* one, and picks 8.0.29-13 by itself once
the repo carries it. A probe that cannot answer (unreadable listing, an arch laid out
differently, network hiccup) **fails open** and keeps today's behaviour, so this can
never block a setup that would otherwise have worked.

## Verification

Throwaway Linode VM, the failing run's own FB server image
`perconalab/pmm-server-fb:PR-4479-62a8d82` — digest `sha256:fd7e7b86…`, the exact
digest Launchable recorded for that session — its FB client tarball, and the job's own
`--database psmdb=8.0,SETUP_TYPE=sharding`:

| | `main` (be81ada) | this branch |
|---|---|---|
| `pmm-framework … --database psmdb=8.0,SETUP_TYPE=sharding` | **failed** — `Unable to find a match: percona-server-mongodb-8.0.29-13.el9`, `Setup script 'start-sharded.sh' failed.` | **OK**, `FRAMEWORK_EXIT=0` |

The red is the CI failure verbatim, down to the resolved version in the build command
(`dnf -y install percona-server-mongodb-8.0.29-13.el9 …`).

On the branch, from scratch (mongo containers removed first, image rebuilt):

```
[1/1] psmdb=8.0,SETUP_TYPE=sharding: OK
FRAMEWORK_EXIT=0
percona-server-mongodb-server-8.0.28-12.el9.x86_64      # installed
db version v8.0.28-12                                   # rs101
```

with all 20 mongodb services registered in PMM (3 shards × 3 + 3 config + mongos, on
both ports), and the job's actual payload then running against it:

```
✓ 1 tests/mongoDb-psmdb-shard.spec.ts:12:7 › @PMM-T1539 Verify that MongoDB exporter shows version for mongos instance @shard-psmdb (999ms)
mongodb_version_info{edition="Community",mongodb="8.0.28-12",vendor="Percona"}
1 skipped, 1 passed
```

Framework checks on the same VM: `bats tests` → **52/52 pass**, including two new
contract tests (skip an unpublished patch; keep the newest when the repo cannot be
read). `shellcheck -x` clean on the changed files (excluding the SC2317 *info* notes
that the existing stubs in `tests/cli.bats` and `lib/execution.sh` already produce).

### What only a real run can confirm

Verified against the 8.0 and 7.0 series as they stand today, plus stubbed listings for
the branch behaviour. The live probe adds one HTTP GET per PSMDB setup (two while a
newer patch is only announced) — measured at well under a second, but the next real
nightly is what confirms it under CI's own egress.

## Other failures in that run (not fixed here)

- **`E2E / Docker configuration tests / @docker-configuration` — PMM-T2020**, external
  ClickHouse on the Explore page. Already tracked by open PR #1164. Confirmed the same
  root cause rather than assumed: the run's own failure screenshot shows
  `[auth] code: 516, message: grafana: Authentication failed: password is incorrect, or
  there is no user with such name`, which is exactly the missing read-only `grafana`
  datasource user percona/pmm#5747 now requires and #1164 adds. Untouched.

- **`CLI / Integration / Generic` — PMM-T2227 "Verify tarball upgrade"**: did **not**
  reproduce, so nothing changed for it. It failed in CI on the *first* `pmm-admin
  status` after the agent is started (`generic.spec.ts:590`), with empty stdout:
  `Expected substring: "Connected" / Received string: ""`. On this VM, with the same FB
  build, the same `--database pdpgsql=16 --database ps,ENCRYPTED_CLIENT_CONFIG=true`
  setup and a host client installed from the same tarball, the test **passes** (26.4s).
  Trying to widen the suspected start-then-status race did not reproduce it either: in
  a fresh `--cpus 0.5` container following the test's own sequence, the immediate
  `pmm-admin status` returned 417 bytes and the agent was `Connected` 172 ms into
  polling; three restart-then-status cycles gave 448–450 bytes and empty stderr. The
  same job passed in the previous run on this branch. Consistent with an environment
  step failing fast (the test discards the exit code of every `docker run` / `docker
  exec` / `wget` step before that assertion, so a failed image pull or download
  surfaces only as this empty-stdout message ~18s in) — worth hardening if it recurs,
  but not something to fix off one unreproduced failure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsRXhtB3AwVUHK6hYnwx2T)_