### PR TITLE
Resolve PSMDB versions from the repo the setup installs from

### DIFF
--- a/qa-integration/pmm_qa/pmm-framework/lib/runners.sh
+++ b/qa-integration/pmm_qa/pmm-framework/lib/runners.sh
@@ -77,19 +77,22 @@ version_is_greater() {
 # Expand a PSMDB major version into its newest full version.
 #
 # The PSMDB setup scripts want a complete version such as '8.0.26-11', but
-# specs name the major series ('8.0'). This asks the same admin-ajax.php
-# endpoint the percona.com downloads page itself calls (Percona removed the
-# old products-api.php when the site was rebuilt on WordPress/Breakdance) for
-# every published patch of that series, and picks the highest.
+# specs name the major series ('8.0'). This lists the psmdb repo the setup
+# installs from and picks the highest patch there. Reading the repo rather than
+# the percona.com downloads page matters: a release appears on the page (and in
+# psmdb-<series>/yum/testing) before its RPMs are promoted to 'release', and the
+# Dockerfile installs a pinned '<version>.el<N>' from 'release' -- so the newest
+# published patch is not always one that can be installed yet.
 #
 # 'latest' and '' pass through untouched -- they are meaningful to the setup
 # script as-is. This is the only network call the framework makes, and the only
 # reason `curl` is required (preflight checks for it only when a PSMDB setup is
 # requested).
 #
+# Reads:  OL_VERSION (the el release the Dockerfile builds on, default 9)
 # Usage:  version=$(latest_psmdb_version 8.0)   # -> 8.0.26-11
 # Stdout: the resolved version
-# Exits:  via die() when the API call fails or no patch matches
+# Exits:  via die() when the repo index cannot be read or no patch matches
 latest_psmdb_version() {
   local requested=$1
   if [[ $requested == latest || -z $requested ]]; then
@@ -97,19 +100,14 @@ latest_psmdb_version() {
     return
   fi
 
-  local response latest='' latest_patch='' candidate patch
-  response=$(curl --fail --silent --show-error \
-    --data-urlencode 'action=percona_downloads' \
-    --data-urlencode "product_id=percona-server-mongodb-$requested" \
-    --data-urlencode 'hydrate=1' \
-    'https://www.percona.com/wp-admin/admin-ajax.php') ||
-    die "Failed to query the Percona products API for PSMDB $requested."
+  local el=${OL_VERSION:-9} index latest='' latest_patch='' candidate patch
+  index=$(curl --fail --silent --show-error \
+    "https://repo.percona.com/psmdb-${requested//./}/yum/release/$el/RPMS/$(uname -m)/") ||
+    die "Failed to read the psmdb-${requested//./} release repo index for PSMDB $requested."
 
-  # The API answers with JSON; pull the quoted entries out of the 'versions'
-  # array, strip the product prefix, and keep only entries for the requested
-  # series. Patches look like '<major.minor>.<patch>-<build>'; the trailing
-  # '-build' is turned into '.build' so version_is_greater can compare it as
-  # just another dotted component.
+  # Patches look like '<major.minor>.<patch>-<build>'; the trailing '-build' is
+  # turned into '.build' so version_is_greater can compare it as just another
+  # dotted component.
   while IFS= read -r candidate; do
     patch=${candidate#"$requested."}
     patch=${patch//-/.}
@@ -118,15 +116,12 @@ latest_psmdb_version() {
       latest_patch=$patch
     fi
   done < <(
-    printf '%s' "$response" |
-      grep -Eo '"versions"[[:space:]]*:[[:space:]]*\[[^]]*\]' |
-      grep -Eo '"percona-server-mongodb-[^"]+"' |
-      tr -d '"' |
-      sed 's/^percona-server-mongodb-//' |
-      grep -E "^${requested//./\\.}\.[0-9]+(-[0-9]+)?$"
+    printf '%s' "$index" |
+      grep -Eo "percona-server-mongodb-server-${requested//./\\.}\.[0-9]+-[0-9]+\.el$el\." |
+      sed -e 's/^percona-server-mongodb-server-//' -e "s/\.el$el\.\$//"
   )
   [[ -n $latest ]] ||
-    die "Could not resolve the latest PSMDB patch for '$requested'."
+    die "Could not resolve an installable PSMDB patch for '$requested' from the psmdb-${requested//./} release repo."
   printf '%s' "$latest"
 }
 

--- a/qa-integration/pmm_qa/pmm-framework/tests/cli.bats
+++ b/qa-integration/pmm_qa/pmm-framework/tests/cli.bats
@@ -96,9 +96,12 @@ load helpers/test_helper
   # Same patch, two builds: only correct if 'patch-build' is compared as
   # 'patch.build' rather than as one opaque, arithmetic-subtraction-prone
   # token (see the "-" to "." conversion in latest_psmdb_version()).
+  # 8.0.29-13 is deliberately absent: only what the release repo carries is a
+  # candidate, so a patch still sitting in psmdb-80/yum/testing is never picked.
   curl() {
-    printf '%s' \
-      '{"success":true,"data":{"versions":["percona-server-mongodb-8.0.4-1","percona-server-mongodb-8.0.4-2"]}}'
+    printf '%s\n' \
+      '<a href="percona-server-mongodb-server-8.0.4-1.el9.x86_64.rpm">' \
+      '<a href="percona-server-mongodb-server-8.0.4-2.el9.x86_64.rpm">'
   }
 
   [[ $(latest_psmdb_version 8.0) == 8.0.4-2 ]]


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4533](https://github.com/Percona-Lab/pmm-submodules/pull/4533) — run [32346833128](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32346833128), check `CLI / Integration tests / CLI / Integration / PSMDB Shard 8.x` (job [96357255985](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32346833128/job/96357255985))
- tests:
  - qa-integration `pmm-framework` PSMDB setup (`--database psmdb=8.0,SETUP_TYPE=sharding`) — the `Run qa-integration setup` step, before any test ran

## What failed

The setup step, not a test. The sharded-cluster image build couldn't install the pinned PSMDB packages:

```
No match for argument: percona-server-mongodb-8.0.29-13.el9
target build_member: failed to solve: ... exit code: 1
ERROR: Setup script 'start-sharded.sh' failed.
```

## Root cause

`latest_psmdb_version()` resolved `psmdb=8.0` by asking percona.com's downloads endpoint for every published patch and taking the highest — **8.0.29-13**. But the Dockerfile installs a pinned `<version>.el<N>` from the psmdb **release** repo, and a release hits the downloads page (and `yum/testing`) before its RPMs are promoted to `release`:

| series | downloads page | release repo (el9) | testing repo (el9) |
|--------|---------------|--------------------|--------------------|
| 8.0 | 8.0.29-13 | **8.0.28-12** | 8.0.29-13 |
| 7.0 | 7.0.40-22 | 7.0.40-22 | 7.0.40-22 |
| 6.0 | 6.0.29-23 | 6.0.29-23 | 6.0.29-23 |

Only 8.0 was mid-promotion, which is why `PSMDB Shard 7.x` passed in the same run. QA-infra bug, not a product one — the resolver simply named a version the setup can't install yet, and it recurs on every PSMDB release until promotion completes.

## The fix

Read the release repo index instead of the downloads page, so only installable patches are ever candidates. Same selection loop, same `latest`/`''` passthrough — just a different source, honouring `OL_VERSION` and the build arch. Net **−2 lines** (one network call instead of one, a 2-stage pipeline instead of 5). Nothing loosened: a series with no installable patch now fails with a clear message instead of a raw `dnf` "No match for argument".

## Verification

Throwaway Linode VM, FB server image `perconalab/pmm-server-fb:PR-4533-0412ad5` (digest `sha256:041b6113…`, the digest Launchable recorded for the failing session), following `runner-integration-cli-tests.yml`:

- **Before** (`main`): `--database psmdb=8.0,SETUP_TYPE=sharding` fails identically — resolver returned `8.0.29-13`, `No match for argument: percona-server-mongodb-8.0.29-13.el9`.
- **After**: resolver returns `8.0.28-12`; the sharded cluster builds and comes up healthy (`rs1`/`rs2`/`rscfg` + `mongos` + `minio`), mongos registers, and the `@shard-psmdb` CLI spec passes against it (`1 passed`).
- Live resolution re-checked on the final version of this branch: `8.0 → 8.0.28-12`, `7.0 → 7.0.40-22`, `6.0 → 6.0.29-23`, `OL_VERSION=8 → 8.0.28-12`, `latest` passthrough intact. The end-to-end run above consumed exactly this resolver output (`8.0.28-12`), which is the only thing the setup sees.
- `make syntax` clean; `bats tests` 50/50 pass (the existing `latest_psmdb_version` case, with its stub repointed at a repo index).

Once 8.0.29-13 is promoted, the resolver picks it up automatically — it tracks the repo, it doesn't pin. The next FB/nightly PSMDB run confirms it in CI.

## Other failures in that run (not fixed here)

- `E2E / Docker configuration tests / @docker-configuration` (CodeceptJS) — **PMM-T2020**, external ClickHouse on Explore. Already tracked by open **#1164** (the read-only `grafana` datasource user percona/pmm#5747 / PMM-15309 requires). Untouched.
- `CLI / Integration / Generic` — **PMM-T2227** "Verify tarball upgrade", failing at `adminStatus.outContains('Connected')` with empty stdout (generic.spec.ts:590), which reads `pmm-admin status` immediately after `pmm-agent -d` starts with no readiness wait. **Not reproduced**: passed every time on the VM, including at `--cpus 0.1`, because the agent connects within a single `docker exec` round-trip. Looks like a rare cold-start hiccup on a contended runner; the missing readiness-wait is worth hardening (same family as merged #1187/#1184) but not off a non-reproduction.