### PR TITLE
Fix PMM-T2020 external ClickHouse Explore assertion

### DIFF
--- a/codeceptjs-e2e/clickhouse/config.d/access-control.xml
+++ b/codeceptjs-e2e/clickhouse/config.d/access-control.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+    <access_control_improvements>
+        <!-- Required by the changeable_in_readonly constraint on the datasource profile in
+             users.d/datasource-user.xml. -->
+        <settings_constraints_replace_previous>true</settings_constraints_replace_previous>
+        <select_from_system_db_requires_grant>true</select_from_system_db_requires_grant>
+    </access_control_improvements>
+</clickhouse>

--- a/codeceptjs-e2e/clickhouse/users.d/datasource-user.xml
+++ b/codeceptjs-e2e/clickhouse/users.d/datasource-user.xml
@@ -1,0 +1,30 @@
+<clickhouse>
+    <profiles>
+        <!-- The Grafana ClickHouse plugin sets max_execution_time on every query, so that one
+             setting has to stay changeable under readonly=1. -->
+        <datasource>
+            <readonly>1</readonly>
+            <constraints>
+                <max_execution_time>
+                    <changeable_in_readonly/>
+                </max_execution_time>
+            </constraints>
+        </datasource>
+    </profiles>
+
+    <users>
+        <!-- Read-only user the PMM Grafana ClickHouse data source connects as, mirroring the one
+             the built-in ClickHouse ships with. Password is the sha256 of 'grafana'. -->
+        <grafana>
+            <password_sha256_hex>cace491b69555e8d0f77747d47ae54e31ce4cc322fe51a7bdcf64402f3676ebf</password_sha256_hex>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <profile>datasource</profile>
+            <quota>default</quota>
+            <grants>
+                <query>GRANT SELECT ON pmm.*</query>
+            </grants>
+        </grafana>
+    </users>
+</clickhouse>

--- a/codeceptjs-e2e/docker-compose-clickhouse.yml
+++ b/codeceptjs-e2e/docker-compose-clickhouse.yml
@@ -23,6 +23,8 @@ services:
       - PMM_ENABLE_TELEMETRY=0
       - PMM_CLICKHOUSE_PASSWORD=pmm_password
       - PMM_CLICKHOUSE_USER=pmm
+      - PMM_CLICKHOUSE_DATASOURCE_USER=grafana
+      - PMM_CLICKHOUSE_DATASOURCE_PASSWORD=grafana
       - PMM_CLICKHOUSE_DATABASE=pmm
       - PMM_CLICKHOUSE_ADDR=external-clickhouse:9000
       - PMM_ENABLE_INTERNAL_PG_QAN=1
@@ -66,6 +68,11 @@ services:
       - CLICKHOUSE_USER=pmm
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
       - CLICKHOUSE_PASSWORD=pmm_password
+    volumes:
+      # Single files, not the directories: the image entrypoint writes its own
+      # users.d/default-user.xml on start and fails if that directory is read-only.
+      - ./clickhouse/config.d/access-control.xml:/etc/clickhouse-server/config.d/access-control.xml:ro
+      - ./clickhouse/users.d/datasource-user.xml:/etc/clickhouse-server/users.d/datasource-user.xml:ro
     healthcheck:
       test: ['CMD-SHELL', 'wget -qO /dev/null http://127.0.0.1:8123/ping || exit 1']
       interval: 5s

--- a/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
+++ b/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
@@ -56,7 +56,8 @@ Scenario('PMM-T2020 - Verify external clickhouse as datasource on explore page @
   I.clearField(explorePage.elements.sqlBuilder);
   I.fillField(explorePage.elements.sqlBuilder, 'SELECT * FROM pmm.metrics LIMIT 10;');
   I.click(explorePage.elements.runQueryButton);
-  I.waitForVisible(explorePage.messages.authError, 10);
+  I.waitForVisible(explorePage.elements.resultRow, 10);
+  I.dontSee(explorePage.messages.authError);
 });
 
 Scenario('PMM-T2018 - Verify internal clickhouse is not running when using external clickhouse @docker-configuration', async ({ I, explorePage }) => {


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4489](https://github.com/Percona-Lab/pmm-submodules/pull/4489) — run [32364190036](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32364190036), check `E2E / Docker configuration tests / e2e tests: @docker-configuration` (job [96410049029](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32364190036/job/96410049029))
- tests:
  - `codeceptjs-e2e/tests/QAN/externalClickhouse_test.js:59` / `@docker-configuration` — PMM-T2020 "Verify external clickhouse as datasource on explore page"

## What failed

That job was `12 passed, 1 failed, 2 skipped`; the one failure is PMM-T2020, and it never reached a real assertion:

```
locator.isVisible: Unexpected token " " while parsing css selector
"Authentication failed: password is incorrect, or there is no user with such name".
Did you mean to CSS.escape it?
Call log:
    - checking visibility of #grafana-iframe >> internal:control=enter-frame >>
      Authentication failed: password is incorrect, or there is no user with such name >> nth=0

✖ I.waitForVisible("Authentication failed: password is incorrect, or there is no user with such name", 10)
    at ./tests/QAN/externalClickhouse_test.js:59:5
```

## Root cause — two things, both on our side

**1. The assertion cannot pass in any environment.** #1197 merged at 11:18 UTC, thirteen minutes before this run started, and replaced

```js
I.waitForVisible(explorePage.elements.resultRow, 10);
I.dontSee(explorePage.messages.authError);
```

with

```js
I.waitForVisible(explorePage.messages.authError, 10);
```

`waitForVisible` takes a **locator**, so `explorePage.messages.authError` — a sentence of prose — is handed to Playwright as a CSS selector and blows up on the first space before the page is ever inspected. It fails identically whether the query succeeds or fails. (`I.dontSee`, which the old line used, does take text — that is why the string worked there.)

It also inverted the scenario's meaning: "Verify external clickhouse as datasource on explore page" now asserted that the datasource is **broken**.

**2. The datasource genuinely cannot authenticate against our external ClickHouse.** [percona/pmm#5747](https://github.com/percona/pmm/pull/5747) (PMM-15309, merged as `ba67206`) stops the Grafana ClickHouse datasource using the privileged QAN user and gives it a dedicated read-only identity. On the FB server this run used, that is already in effect:

```
$ docker exec pmm-server-external-clickhouse grep -i CLICKHOUSE /etc/supervisord.d/grafana.ini
    PMM_CLICKHOUSE_DATASOURCE_USER="grafana",
    PMM_CLICKHOUSE_DATASOURCE_PASSWORD="grafana",
```

while `docker-compose-clickhouse.yml` only ever creates `pmm`:

```
$ docker exec external-clickhouse clickhouse-client --user pmm --password pmm_password --query "SELECT name FROM system.users"
pmm
$ docker exec external-clickhouse clickhouse-client --user grafana --password grafana --query "SELECT 1"
Code: 516. DB::Exception: grafana: Authentication failed: password is incorrect,
or there is no user with such name. (AUTHENTICATION_FAILED)
```

So the auth error #1197 started asserting is a **gap in our setup**, not intended behaviour to lock in. PMM deliberately does not fall back to the privileged account — that fallback is the vulnerability PMM-15309 closes.

## Changes

- `codeceptjs-e2e/tests/QAN/externalClickhouse_test.js` — restore the positive assertion: wait for result rows, then assert the auth error is *not* shown.
- `codeceptjs-e2e/clickhouse/users.d/datasource-user.xml`, `codeceptjs-e2e/clickhouse/config.d/access-control.xml`, `codeceptjs-e2e/docker-compose-clickhouse.yml` — give the external ClickHouse the read-only `grafana` user PMM-15309 requires, and point PMM at it. **These three files are [#1164](https://github.com/percona/pmm-qa/pull/1164) verbatim** — that PR (open since 11 Aug) diagnosed the same setup gap, but it predates #1197, so on its own it no longer makes PMM-T2020 pass: the invalid locator throws before any of it matters. Carrying it here keeps this one PR self-contained; merge either order (the content is identical, so it resolves cleanly) and close #1164 once this lands.

Nothing is loosened: the scenario still has to see real rows come back from external ClickHouse, and a build that breaks the datasource still fails it.

## Verification

Throwaway Linode VM, same pmm-qa SHA as the failing run (`0b7c9ae`), same FB server image (`perconalab/pmm-server-fb:PR-4489-2419bcc`), driven through `runner-e2e-tests-codeceptjs.yml`'s own steps:

| Branch | `codeceptjs run --grep PMM-T2020` |
|--------|-----------------------------------|
| `main` | **1 failed** — `Unexpected token " " while parsing css selector …`, byte-for-byte the CI failure |
| this branch | **1 passed** (14.0s) |

Whole spec file on this branch, same VM: **5 passed** — PMM-T1218, PMM-T2020, PMM-T2018, PMM-T2019, PMM-T2006 (the other four share the compose this PR changes).

The datasource user stays confined to what it needs:

```
SHOW GRANTS FOR CURRENT_USER        -> GRANT SELECT ON pmm.* TO grafana
SELECT count() FROM pmm.metrics     -> ok
SELECT count() FROM system.query_log-> 497 ACCESS_DENIED
CREATE TABLE pmm.x (a Int)          -> 497 ACCESS_DENIED
```

`npx eslint tests/QAN/externalClickhouse_test.js`: clean.

## Other failures in that run (not fixed here — external, not ours)

The run's three other red jobs share one root cause and no code change would help:

- `E2E / MongoDB Exporter tests / @mongodb-exporter` and `E2E / User with changed password UI tests / podman @user-password` — the PSMDB image build failed with `nothing provides percona-telemetry-agent needed by percona-server-mongodb-server-8.0.29-13.el9`. Upstream in the same log, `percona-release enable` had already given up: `Specified repository does not exist: http://repo.percona.com/prel/` at **324s**, `.../telemetry/` at **594s**, `.../pbm/` at **816s** — timeouts, not 404s, so the telemetry repo was never enabled and the dependency could not resolve.
- `CLI / Integration tests / CLI / Integration / Generic` — `percona-release enable ppg-16` failed the same way after 6m33s: `W: Failed to fetch http://repo.percona.com/prel/apt/dists/noble/InRelease Could not connect to repo.percona.com:80 (147.135.54.159), connection timed out`, then `Specified repository does not exist: http://repo.percona.com/ppg-16/`.

Port **443** was fine throughout the same run (`percona-release_latest…deb` downloaded over HTTPS at 312 MB/s); only plain **HTTP on port 80** timed out, which is why some jobs in the matrix survived and others did not. Re-run today on the repro VM, both sequences complete normally:

```
percona-release enable psmdb-80 release   -> real 0m0.404s
percona-release enable telemetry release  -> real 0m0.427s
dnf install percona-server-mongodb-server -> resolves, Install 4 Packages

percona-release enable ppg-16             -> real 0m1.998s, Fetched 151 kB
```

Transient repo.percona.com unavailability during the ~11:35–11:50 UTC window. Nothing to fix in pmm-qa; re-running those three jobs should clear them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuabXavXXg7pgtM1EZzFAQ)_