### PR TITLE
Restore the PMM-T2020 success assertion on the Explore page

### DIFF
--- a/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
+++ b/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
@@ -56,7 +56,8 @@ Scenario('PMM-T2020 - Verify external clickhouse as datasource on explore page @
   I.clearField(explorePage.elements.sqlBuilder);
   I.fillField(explorePage.elements.sqlBuilder, 'SELECT * FROM pmm.metrics LIMIT 10;');
   I.click(explorePage.elements.runQueryButton);
-  I.waitForVisible(explorePage.messages.authError, 10);
+  I.waitForVisible(explorePage.elements.resultRow, 10);
+  I.dontSee(explorePage.messages.authError);
 });
 
 Scenario('PMM-T2018 - Verify internal clickhouse is not running when using external clickhouse @docker-configuration', async ({ I, explorePage }) => {


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4479](https://github.com/Percona-Lab/pmm-submodules/pull/4479) — run [32365019561](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32365019561), check `@docker-configuration UI tests` (job [96412562137](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32365019561/job/96412562137))
- blocked-on: [percona/pmm-qa#1164](https://github.com/percona/pmm-qa/pull/1164) — **DO NOT MERGE** until that PR lands; this test expects the Explore query to succeed, which needs the read-only `grafana` datasource user #1164 adds to the external ClickHouse.
- tests:
  - `codeceptjs-e2e/tests/QAN/externalClickhouse_test.js:59` / `@docker-configuration` — PMM-T2020 "Verify external clickhouse as datasource on explore page"

## What failed

```
locator.isVisible: Unexpected token " " while parsing css selector
"Authentication failed: password is incorrect, or there is no user with such name".
Did you mean to CSS.escape it?
Call log:
    - checking visibility of #grafana-iframe >> internal:control=enter-frame
      >> Authentication failed: password is incorrect, or there is no user with such name >> nth=0
    at Playwright.waitForVisible (node_modules/codeceptjs/lib/helper/Playwright.js:2842:80)
```

## Root cause — the assertion, not the build

[#1197](https://github.com/percona/pmm-qa/pull/1197) (merged at 11:18 UTC, 23 minutes before this FB run started) replaced the scenario's last two lines:

```diff
-  I.waitForVisible(explorePage.elements.resultRow, 10);
-  I.dontSee(explorePage.messages.authError);
+  I.waitForVisible(explorePage.messages.authError, 10);
```

`explorePage.messages.authError` is a plain sentence, not a locator. `waitForVisible` hands it to Playwright as a selector, CodeceptJS classifies it as CSS (no `//` prefix), and Playwright rejects it at parse time — before it ever looks at the page. **This throws on every build, with or without a working data source**, so `@docker-configuration` is red on `main` from that merge onward. `fb-e2e-suite.yml` is the only workflow that runs this suite, so every FB Tests run carries the failure.

The change also inverted what the scenario asserts. Expecting the auth error would certify a broken external-ClickHouse deployment as correct: `PMM_CLICKHOUSE_DATASOURCE_USER` / `PMM_CLICKHOUSE_DATASOURCE_PASSWORD` (default `grafana`) landed in PMM 3.9.1 and are on `percona/pmm` `main` (`managed/services/supervisord/supervisord.go:47`, `build/ansible/roles/grafana/files/datasources.yml`) — the Grafana ClickHouse data source is *meant* to connect as its own read-only user, and an external ClickHouse is expected to provide one. That user is what #1164 adds to `docker-compose-clickhouse.yml`; PMM deliberately does not fall back to the privileged QAN account.

So this PR restores the original success assertion rather than making the broken locator valid.

## Verification

Throwaway Linode VM, external-ClickHouse compose driven as `runner-e2e-tests-codeceptjs.yml` does, with the failing run's own FB image (`PMM_SERVER_IMAGE=perconalab/pmm-server-fb:PR-4479-041e7cd`):

| pmm-qa ref | PMM-T2020 |
|---|---|
| `main` (`0b7c9ae`) | **failed**, twice — the CI error verbatim, same call log, 12.9s each |
| `claude/brave-dijkstra-1qd6jw` (#1164 head `9316242`) | **passed** in 14.1s |

#1164's branch predates #1197, so its copy of `externalClickhouse_test.js` is byte-identical to what this PR restores. That row is therefore this PR's change plus #1164's compose change, run together — the state this PR is asking for, proven green against the FB build.

`eslint` on the changed file: clean (run from the VM's own `node_modules`).

### What this does and does not prove

The green row needed #1164's read-only user. On current `main`'s compose the query still fails to authenticate, so **this PR alone will not turn the check green** — it will fail on the auth error instead of the parse error. Both PRs have to land; #1164 is safe to merge first and on its own (its body covers that). Hence draft.

## Other failures in that run (not fixed here)

Both are environmental, and neither is caused by PR-4479:

- `CLI / Integration / Generic` — PMM-T2227 "Verify tarball upgrade" hit its 120s test timeout after running **5.1 minutes**. The same test took **33.4s** in the previous night's scheduled run ([32199838689](https://github.com/percona/pmm-qa/actions/runs/32199838689)) and **24.8s / 22.2s / 22.1s** across three runs on the repro VM against this same FB client tarball, so it did not reproduce. The test spends nearly all of its budget on network: an AlmaLinux image pull, `dnf install wget`, and two ~186 MB client-tarball downloads.
- `E2E / Percona Server for MySQL UI integration tests / @pmm-ps-integration` — never reached the tests; `percona-server-setup.yml` failed installing `percona-release` inside the container: `Connecting to repo.percona.com|147.135.54.159|:443... failed: Connection timed out` and `|2604:2dc0:200:69f::2|:443... failed: Network is unreachable`, after 2m16s.

Those two point at the same window of Percona-hosted download endpoints being unreachable from the runner. From the repro VM `repo.percona.com` and `downloads.percona.com` both answer in ~0.25s, and the 186 MB released tarball downloads in ~3s. Worth noting for PR-4479 specifically: `@pmm-ps-integration` is the suite most relevant to a MySQL change, and it never ran.

One latent nit spotted while reading PMM-T2227, deliberately left alone: line 577 is `docker network connect pmm-server pmm-qa`, with the network and container the wrong way round — it fails with `No such container: pmm-qa` on every run, and is harmless only because `pmm-framework` has already attached `pmm-server` to `pmm-qa`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLT7SigCUsTNHNxsAbzAbp)_