### PR TITLE
Make PMM-T2227 assert the upgrade instead of racing it

### DIFF
--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -591,7 +591,9 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     await oldVersion.outContains(latestReleasedVersion);
     const tarballURL = process.env.PMM_CLIENT_VERSION!.includes('http') ? process.env.PMM_CLIENT_VERSION : 'https://pmm-build-cache.s3.us-east-2.amazonaws.com/PR-BUILDS/pmm-client/pmm-client-latest.tar.gz';
 
-    await cli.exec(`docker exec ${containerName} /pmm3_client_install_tarball.sh -v ${tarballURL} -u`);
+    const upgrade = await cli.exec(`docker exec ${containerName} /pmm3_client_install_tarball.sh -v ${tarballURL} -u`);
+
+    await upgrade.assertSuccess();
     await cli.exec(`docker exec ${containerName} pkill -f pmm-agent`);
     await expect(async () => {
       const pids = await cli.exec(`docker exec ${containerName} ps -C pmm-agent -o pid=`);
@@ -613,7 +615,11 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
 
     await newPid.outNotContains(oldPid.stdout);
     await newAdminStatus.outContains('Connected');
-    expect(newVersion.stdout.trim()).not.toEqual(oldVersion.stdout.trim());
+    // The dev-latest tarball tracks the v3 line, so right after a release is cut it is the same
+    // build as the latest released tarball and the reported version legitimately cannot change.
+    if (!upgradedVersion || !oldVersion.stdout.includes(upgradedVersion)) {
+      expect(newVersion.stdout.trim()).not.toEqual(oldVersion.stdout.trim());
+    }
     if (upgradedVersion) {
       await newVersion.outContains(upgradedVersion);
     }

--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -620,22 +620,14 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     const newPid = await cli.exec(`docker exec ${containerName} ps -C pmm-agent -o pid=`);
     const newVersion = await cli.exec(`docker exec ${containerName} pmm-admin version | grep "Version:"`);
 
-    const versionLookup = process.env.PMM_CLIENT_VERSION?.includes('http')
-      ? undefined
-      : cli.execute('curl --fail --silent --show-error https://raw.githubusercontent.com/Percona-Lab/pmm-submodules/v3/VERSION');
-    if (versionLookup && (versionLookup.code !== 0 || !versionLookup.stdout.trim())) {
-      throw new Error('Could not read the expected upgrade version from v3 VERSION');
-    }
-    const upgradedVersion = versionLookup?.stdout.trim() ?? '';
+    // pmm3-client-setup.sh installed the host client from this same PMM_CLIENT_VERSION, so the
+    // host's own version is the exact reference for what the upgrade must report. v3 VERSION is
+    // not: it is bumped when a release branches, ahead of the builds that carry the new number.
+    const upgradedVersion = (await cli.exec('sudo pmm-admin version | grep -m1 "^Version:"'))
+      .stdout.replace('Version:', '').trim();
 
+    expect(upgradedVersion, 'Could not read the expected upgrade version from the host client!').not.toEqual('');
     await newPid.outNotContains(oldPid.stdout);
-    // The dev-latest tarball tracks the v3 line, so right after a release is cut it is the same
-    // build as the latest released tarball and the reported version legitimately cannot change.
-    if (!upgradedVersion || upgradedVersion !== latestReleasedVersion) {
-      expect(newVersion.stdout.trim()).not.toEqual(oldVersion.stdout.trim());
-    }
-    if (upgradedVersion) {
-      await newVersion.outContains(upgradedVersion);
-    }
+    await newVersion.outContains(upgradedVersion);
   });
 });

--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -7,16 +7,6 @@ const PGSQL_USER = 'postgres';
 const PGSQL_PASSWORD = 'pass+this';
 const ipPort = async () => ((await cli.exec('docker ps')).stdout.includes('pdpgsql_pmm_') ? '127.0.0.1:5432' : '127.0.0.1:5447');
 
-// `docker exec -d pmm-agent` returns before the agent has bound its local API on
-// 127.0.0.1:7777, so reading the status once races it - on a loaded runner the agent can
-// need ~1s while the next docker exec arrives in ~60ms.
-const waitForAgentConnected = async (container: string, after: string) => {
-  await expect(async () => {
-    const status = await cli.exec(`docker exec ${container} pmm-admin status`);
-    expect(status.stdout, `pmm-agent in ${container} never reported Connected after ${after}!`).toContain('Connected');
-  }).toPass({ intervals: [1_000], timeout: 30_000 });
-};
-
 test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
   test.beforeAll(async ({}) => {
     const result = await cli.exec('docker ps | grep pdpgsql_pmm | awk \'{print $NF}\'');
@@ -597,7 +587,10 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
 
     await setup.assertSuccess();
     await cli.exec(`docker exec -d ${containerName} pmm-agent --debug --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml`);
-    await waitForAgentConnected(containerName, 'install');
+    await expect(async () => {
+      const status = await cli.exec(`docker exec ${containerName} pmm-admin status`);
+      expect(status.stdout, 'pmm-agent did not report Connected after install!').toContain('Connected');
+    }).toPass({ intervals: [1_000], timeout: 30_000 });
 
     const oldVersion = await cli.exec(`docker exec ${containerName} pmm-admin version | grep "Version:"`);
     const oldPid = await cli.exec(`docker exec ${containerName} ps -C pmm-agent -o pid=`);
@@ -615,14 +608,14 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     }).toPass({ intervals: [500], timeout: 30_000 });
     await cli.exec(`docker exec -d ${containerName} pmm-agent --debug --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml`);
 
-    await waitForAgentConnected(containerName, 'upgrade');
+    await expect(async () => {
+      const status = await cli.exec(`docker exec ${containerName} pmm-admin status`);
+      expect(status.stdout, 'pmm-agent did not report Connected after upgrade!').toContain('Connected');
+    }).toPass({ intervals: [1_000], timeout: 30_000 });
 
     const newPid = await cli.exec(`docker exec ${containerName} ps -C pmm-agent -o pid=`);
     const newVersion = await cli.exec(`docker exec ${containerName} pmm-admin version | grep "Version:"`);
 
-    // pmm3-client-setup.sh installed the host client from this same PMM_CLIENT_VERSION, so the
-    // host's own version is the exact reference for what the upgrade must report. v3 VERSION is
-    // not: it is bumped when a release branches, ahead of the builds that carry the new number.
     const upgradedVersion = (await cli.exec('sudo pmm-admin version | grep -m1 "^Version:"'))
       .stdout.replace('Version:', '').trim();
 

--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -7,6 +7,16 @@ const PGSQL_USER = 'postgres';
 const PGSQL_PASSWORD = 'pass+this';
 const ipPort = async () => ((await cli.exec('docker ps')).stdout.includes('pdpgsql_pmm_') ? '127.0.0.1:5432' : '127.0.0.1:5447');
 
+// `docker exec -d pmm-agent` returns before the agent has bound its local API on
+// 127.0.0.1:7777, so reading the status once races it - on a loaded runner the agent can
+// need ~1s while the next docker exec arrives in ~60ms.
+const waitForAgentConnected = async (container: string, after: string) => {
+  await expect(async () => {
+    const status = await cli.exec(`docker exec ${container} pmm-admin status`);
+    expect(status.stdout, `pmm-agent in ${container} never reported Connected after ${after}!`).toContain('Connected');
+  }).toPass({ intervals: [1_000], timeout: 30_000 });
+};
+
 test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
   test.beforeAll(async ({}) => {
     const result = await cli.exec('docker ps | grep pdpgsql_pmm | awk \'{print $NF}\'');
@@ -580,14 +590,18 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     const latestReleasedVersion = (await cli.exec('wget -q https://registry.hub.docker.com/v2/repositories/percona/pmm-client/tags -O - | jq -r .results[].name | grep -v latest | sort -V | tail -n1')).stdout.trim();
     await cli.exec(`docker cp ../package_tests/scripts/pmm3_client_install_tarball.sh ${containerName}:/`);
     await cli.exec(`docker exec ${containerName} dnf install -y wget`);
-    await cli.exec(`docker exec ${containerName} /pmm3_client_install_tarball.sh -v ${latestReleasedVersion}`);
-    await cli.exec(`docker exec ${containerName} pmm-agent setup --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml --force --server-insecure-tls --server-address=pmm-server:8443 --server-username=admin --server-password=admin 127.0.0.1 generic tarball_node`);
+    const install = await cli.exec(`docker exec ${containerName} /pmm3_client_install_tarball.sh -v ${latestReleasedVersion}`);
+
+    await install.assertSuccess();
+    const setup = await cli.exec(`docker exec ${containerName} pmm-agent setup --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml --force --server-insecure-tls --server-address=pmm-server:8443 --server-username=admin --server-password=admin 127.0.0.1 generic tarball_node`);
+
+    await setup.assertSuccess();
     await cli.exec(`docker exec -d ${containerName} pmm-agent --debug --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml`);
-    const adminStatus = await cli.exec(`docker exec ${containerName} pmm-admin status`);
+    await waitForAgentConnected(containerName, 'install');
+
     const oldVersion = await cli.exec(`docker exec ${containerName} pmm-admin version | grep "Version:"`);
     const oldPid = await cli.exec(`docker exec ${containerName} ps -C pmm-agent -o pid=`);
 
-    await adminStatus.outContains('Connected');
     await oldVersion.outContains(latestReleasedVersion);
     const tarballURL = process.env.PMM_CLIENT_VERSION!.includes('http') ? process.env.PMM_CLIENT_VERSION : 'https://pmm-build-cache.s3.us-east-2.amazonaws.com/PR-BUILDS/pmm-client/pmm-client-latest.tar.gz';
 
@@ -601,8 +615,9 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     }).toPass({ intervals: [500], timeout: 30_000 });
     await cli.exec(`docker exec -d ${containerName} pmm-agent --debug --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml`);
 
+    await waitForAgentConnected(containerName, 'upgrade');
+
     const newPid = await cli.exec(`docker exec ${containerName} ps -C pmm-agent -o pid=`);
-    const newAdminStatus = await cli.exec(`docker exec ${containerName} pmm-admin status`);
     const newVersion = await cli.exec(`docker exec ${containerName} pmm-admin version | grep "Version:"`);
 
     const versionLookup = process.env.PMM_CLIENT_VERSION?.includes('http')
@@ -614,7 +629,6 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     const upgradedVersion = versionLookup?.stdout.trim() ?? '';
 
     await newPid.outNotContains(oldPid.stdout);
-    await newAdminStatus.outContains('Connected');
     // The dev-latest tarball tracks the v3 line, so right after a release is cut it is the same
     // build as the latest released tarball and the reported version legitimately cannot change.
     if (!upgradedVersion || upgradedVersion !== latestReleasedVersion) {

--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -617,7 +617,7 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     await newAdminStatus.outContains('Connected');
     // The dev-latest tarball tracks the v3 line, so right after a release is cut it is the same
     // build as the latest released tarball and the reported version legitimately cannot change.
-    if (!upgradedVersion || !oldVersion.stdout.includes(upgradedVersion)) {
+    if (!upgradedVersion || upgradedVersion !== latestReleasedVersion) {
       expect(newVersion.stdout.trim()).not.toEqual(oldVersion.stdout.trim());
     }
     if (upgradedVersion) {


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [percona/pmm-qa run 32431332272](https://github.com/percona/pmm-qa/actions/runs/32431332272) — `PMM Integration Tests` (scheduled, `main`), job [`CLI / Integration / Generic`](https://github.com/percona/pmm-qa/actions/runs/32431332272/job/96623322197), the only red job of 25
- source: [Percona-Lab/pmm-submodules#4535](https://github.com/Percona-Lab/pmm-submodules/pull/4535) — [run 32468661499](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32468661499), check `CLI / Integration / Generic` (job [96730625653](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32468661499/job/96730625653))
- tests:
  - `cli/tests/generic.spec.ts` / `@generic` — PMM-T2227 "Verify tarball upgrade"

One test, three separate defects — it failed differently in each run, and neither failure was a product bug.

## 1. It races pmm-agent's startup (the FB failure)

```
at cli/tests/generic.spec.ts:590:5     # the PRE-upgrade status check
Error: Stdout does not contain Connected, !
Received: "failed to get PMM Agent status from local pmm-agent:
  Post \"http://127.0.0.1:7777/local/Status\": dial tcp 127.0.0.1:7777: connect: connection refused"
```

`docker exec -d … pmm-agent` returns as soon as the exec is created, well before the agent
has bound its local API — and the test read the status on the very next line, with no retry.

`pmm-managed.log` from that job's own artifact shows the agent was healthy, just late:

| time (UTC) | event |
|---|---|
| 09:43:32.120 | `RegisterNode` done — the `pmm-agent setup` on line 584 |
| *(between)* | agent launched, status read → **connection refused** |
| **09:43:32.840** | `Connected pmm-agent: {Version:3.9.1-v3-8afda6a9a}` |

That `3.9.1-v3-8afda6a9a` is the `tarball_client` agent (the host client in that run is
`3.10.0-bump-up-release-version-to-3.10.1-d4188a238`), so the agent did start and did
register — it needed ~700 ms and got none.

The runner was contended at that moment: the same `RegisterNode` took **485 ms** against
**38 / 40 / 135 ms** for its three siblings in the run, and `pmm-managed` logged
`sendSetStateRequest` at **1.1–3.1 s**. Measured margin on a quiet VM: the agent binds in
**30–38 ms** while one `docker exec` round-trip costs **~56–68 ms** — it normally wins by
~25 ms, which is the test's entire safety budget.

Both status checks now poll, reusing the `toPass` block already sitting between them, on the
same 30 s budget as the neighbouring wait for the old process to exit.

## 2. It discards the exit code of every setup command

Lines 583–585 fired the released-tarball install, `pmm-agent setup`, and the agent start
with no assertion, as did the upgrade install. That is why a broken step surfaced as an
opaque "connection refused" instead of naming itself. The install and setup are now
asserted — both do real work and can genuinely fail (`pmm-agent setup` against a bad
server address exits `1`; the install script against a missing tarball exits `1` on
`ERROR 404`). The `docker exec -d` start stays unasserted on purpose: exiting 0 says
nothing about the agent, and the new wait is what actually establishes it came up.

## 3. It took the expected version from a file that leads the builds (the nightly failure)

The nightly run failed instead on `expect(newVersion).not.toEqual(oldVersion)` — the test
used "the version changed" as a proxy for "the upgrade happened". That proxy is invalid
whenever the released and dev-latest tarballs are the **same build**, which happens every
time a release is cut. Both times I looked, they were byte-identical:

| when | released tarball | dev-latest tarball | reported |
|---|---|---|---|
| 2026-08-20 | sha256 `2125344e…a15a048` | sha256 `2125344e…a15a048` | `3.9.1-v3-8afda6a9a` |
| 2026-08-21 09:58 | commit `ccca197e` | commit `ccca197e` | `3.9.1-v3-570a46445` |

The upgrade itself was always fine: it exits `0` and does replace the binaries
(`bin/pmm-agent` mtime `00:30:54` → `00:31:32`).

My first attempt guarded that proxy with `v3 VERSION`, and verification showed the guard
is unsound too: **`v3 VERSION` is bumped when a release branches, ahead of the builds that
carry the number.** At the time of writing it says **3.10.0** while every client tarball
reports **3.9.1-v3-570a46445** — so the guard would enforce a change that cannot happen, and
the exact-version check would demand `3.10.0` from a client correctly saying `3.9.1`.

`pmm3-client-setup.sh` installs the host client from `PMM_CLIENT_VERSION`, mapping
`latest-tarball` to the very same `pmm-client-latest.tar.gz` this test upgrades to
([`pmm3-client-setup.sh:95`](https://github.com/percona/pmm-qa/blob/main/qa-integration/pmm_qa/pmm3-client-setup.sh#L95)),
and to the same feature-build URL on the FB legs. So the host client is the **identical
artifact**, and its version is an exact reference with no cross-pipeline drift. #1184 fixed
the RC leg the same way — resolve from the artifact under test, not the moving `v3` line.

### On dropping `not.toEqual`

That single exact assertion subsumes it: proving the container reports the target build
proves the upgrade landed it, in every state — two identical tarballs, a moved dev line, or
a feature build. `not.toEqual` could not distinguish those states at all, which is what
started this PR. "The upgrade ran" is now carried by the install's exit code and by the
agent coming back up on the new binary. This is a net strengthening, not a loosened
assertion.

A side effect: the post-upgrade pid check stops passing vacuously — it used
`not.toContain` against possibly-empty output, and now runs only once an agent is known up.

## Verification

Throwaway Linode VMs following `runner-integration-cli-tests.yml`, both code paths, with
the host client installed from each path's own `PMM_CLIENT_VERSION` as CI does:

| path | host client (the oracle) | PMM-T2227 |
|---|---|---|
| `main`, nightly path | — | **failed** — CI's error verbatim, same version string |
| nightly (`latest-tarball`) | `3.9.1-v3-570a46445` | **passed** 22.8s |
| FB (`…/pmm-client-PR-4535-d4188a2.tar.gz`) | `3.10.0-bump-up-release-version-to-3.10.1-d4188a238` | **passed** 24.4s |

The FB row is what shows the version check is non-vacuous: the expected string is wholly
different from the `3.9.1` release the container starts on, and it matched exactly.

Also reproduced the FB run's whole environment (`pmm-server-fb:PR-4535-d4188a2` + its
client tarball) on `main`: **passed**, confirming that failure was timing, not the build.

The new waits are not on the critical path: the agent reports Connected in **~110 ms**, so
each wait costs about that against its 30 s ceiling, and the test still finishes in ~23 s.
(A first run on a fresh VM measures ~1.4 m, but that is the cold `antmelekhin/docker-systemd`
pull and `dnf install wget`, not the waits — a second run on the same box is 23.3 s.)

`eslint tests/generic.spec.ts`: **0 errors**, and **19 warnings against `main`'s 23** — the
four fewer are the `no-conditional-in-test` / `no-conditional-expect` branches this change
removes.

### What this does and does not prove

I could **not** reproduce the "connection refused" itself. 45+ replays of lines 585–586
across an idle box, a CPU-saturated host, and a container throttled to 0.08 CPU never
refused once — throttling the container slows `pmm-admin` alongside `pmm-agent`, since they
share a cgroup, so the margin never inverts. The mechanism is established from the failing
run's own `pmm-managed` log (the 720 ms gap above) plus the measured 30 ms vs 60 ms margin,
not from a local red-then-green. The retry is sized against that measurement, not a
reproduction.

The version fix is on firmer ground: both paths were run red-then-green with the real
artifacts.

## Not fixed here — worth a separate look

The same "`v3 VERSION` leads the builds" trap sits in this file's describe-level
`PMM_VERSION` (`generic.spec.ts:18-27`), on the `latest-tarball` / `3-dev-latest` branch that
reads that file. The FB legs are immune — they take the `http`/`pmm3-rc` branch and resolve
from `server_version`, which is what #1184 fixed — so only the scheduled runs use the
affected path.

It opens a **transient skew window**: between a VERSION bump landing on `v3` and the next
dev build picking the number up, that file names a version no artifact reports yet.

| event | UTC |
|---|---|
| dev-latest tarball built — still `pmm-client-3.9.1` | 10:00:32 |
| [#4535](https://github.com/Percona-Lab/pmm-submodules/pull/4535) bumps `v3` VERSION to 3.10.0 | 10:15:52 |

Inside that window a full `@generic` run on the `latest-tarball` path goes red on two tests
— observed on a repro VM at ~11:40 with `v3 VERSION` at `3.10.0` and the client at
`3.9.1-v3-570a46445`:

```
✘  run pmm-admin --version @generic
✘  run pmm-admin summary --version @generic
   (35 passed, 12 skipped — PMM-T2227 among the passes)
```

Both assert `outContains(`Version: ${PMM_VERSION}`)`. I did not read their failure messages,
so the attribution is from the code path and the value mismatch rather than from the error
text — treat it as strongly inferred, not confirmed.

This is a latent fragility, not a scheduled failure: the next dev build closes the window on
its own, and the run that was green through it ([FB 32468661499](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32468661499),
where both version tests passed) simply took the `server_version` branch. Worth fixing so a
run that lands mid-window does not go red, but it needs its own change and verification —
the `pmm3-rc` side of that resolution is what #1184 deliberately shaped.