### PR TITLE
Don't count a value-mapped table cell as an empty panel

### DIFF
--- a/codeceptjs-e2e/tests/pages/dashboardPage.js
+++ b/codeceptjs-e2e/tests/pages/dashboardPage.js
@@ -1131,9 +1131,14 @@ module.exports = {
     panelLoading: locate('div').withAttr({ class: 'panel-loading' }),
     postgreSQLServiceSummaryContent: locate('$pt-summary-fingerprint').withText('Detected PostgreSQL version:'),
     reportTitle: locate('$header-container').inside(locate('[class*="panel-container"]')),
+    // Table cells are excluded: a value mapped to "No Data"/"-" in one column is a
+    // per-row value, not the panel being empty. Grafana renders a panel-wide
+    // no-data state as [data-testid="data-testid Panel data error message"], never
+    // inside a role="gridcell".
     reportTitleWithNA: locate('$header-container').inside(
       locate('[class*="panel-container"]').withDescendant(
-        '//*[(text()="No data") or (text()="NO DATA") or (text()="N/A") or (text()="-") or (text() = "No Data")]',
+        '//*[((text()="No data") or (text()="NO DATA") or (text()="N/A") or (text()="-") or (text() = "No Data"))'
+        + ' and not(ancestor-or-self::*[@role="gridcell"])]',
       ),
     ),
     reportTitleWithNoData: locate('$header-container').inside(

--- a/codeceptjs-e2e/tests/pages/dashboardPage.js
+++ b/codeceptjs-e2e/tests/pages/dashboardPage.js
@@ -1131,10 +1131,6 @@ module.exports = {
     panelLoading: locate('div').withAttr({ class: 'panel-loading' }),
     postgreSQLServiceSummaryContent: locate('$pt-summary-fingerprint').withText('Detected PostgreSQL version:'),
     reportTitle: locate('$header-container').inside(locate('[class*="panel-container"]')),
-    // Table cells are excluded: a value mapped to "No Data"/"-" in one column is a
-    // per-row value, not the panel being empty. Grafana renders a panel-wide
-    // no-data state as [data-testid="data-testid Panel data error message"], never
-    // inside a role="gridcell".
     reportTitleWithNA: locate('$header-container').inside(
       locate('[class*="panel-container"]').withDescendant(
         '//*[((text()="No data") or (text()="NO DATA") or (text()="N/A") or (text()="-") or (text() = "No Data"))'


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [percona/pmm-qa run 32431400653](https://github.com/percona/pmm-qa/actions/runs/32431400653) — `Nightly E2E tests Matrix (remote PMM Server)` (`main`, `8fb0d14`), job [`test execution / @nightly`](https://github.com/percona/pmm-qa/actions/runs/32431400653/job/96623529783) — the only red job of 16
- product bug found: **PMM-15363** — `MongoDB Sharded Cluster Summary shows "No Data" for a load average of 0`
- tests:
  - `codeceptjs-e2e/tests/verifyMongodbDashboards_test.js:25` / `@nightly @dashboards` — "Open the MongoDB Cluster Summary Dashboard and verify Metrics are present and graphs are displayed"

## What failed

```
Expected 9 Elements without data but found 10 on Dashboard
https://.../graph/d/mongodb-cluster-summary/mongodb-sharded-cluster-summary?from=now-5m&...
Report Names are Nodes Overview
  at Object.printFailedReportNames (tests/pages/dashboardPage.js:1359:12)
  at Object.verifyThereAreNoGraphsWithoutData (tests/pages/dashboardPage.js:1339:20)
```

`FAIL | 70 passed, 1 failed, 44 skipped`. The `@nightly` job passed on the Aug 19 nightly, so this was new.

## Two defects, one on each side

**1. Product (PMM-15363) — the dashboard shows "No Data" for a value that exists.**

The `Nodes Overview` panel maps the value `0` to the text `No Data` in
`fieldConfig.defaults.mappings`, so the mapping applies to *every* column including
`Load Average`. The sharded-mongo setup shard runs on a client host that is idle while the tests
drive a different machine, so `node_load1` there is legitimately `0` — and the panel reports that
real value as missing data. The run's own captured query responses (refId `B`,
`avg_over_time(node_load1[$interval]) or avg_over_time(node_load1[5m])`, `$interval` resolved to
`2s`) show it plainly across consecutive refreshes:

```
rs101 0.053   rs102 0.053   rs103 0      rs201 0      rs202 0.0537 ...
rs101 0       rs102 0       rs103 0.053  rs201 0.053  rs202 0.053  ...
```

An idle node reads `No Data` in dark red instead of `0.00`. That is a display bug, and it is
filed as **PMM-15363**. Nothing in this PR touches `percona/pmm`.

**2. Test — a populated panel counted as empty.**

The panel itself was *not* empty. The trace DOM shows a nine-row table with the other columns of
that very row populated:

```html
<div role="gridcell" aria-colindex="3" class="rdg-cell ...">50.83 mins</div>
<div role="gridcell" aria-colindex="5" class="rdg-cell ...">No Data</div>   <!-- Load Average -->
<div role="gridcell" aria-colindex="6" class="rdg-cell ...">61.96%</div>
```

`reportTitleWithNA` matched any panel with a **descendant whose text is `No Data`**, so that table
was counted as a panel without data, tipping the count from 9 to 10 and past the tolerated 9. That
is what this PR fixes.

## The fix

Exclude table cells from the locator. A value mapped to `No Data`/`-`/`N/A` in one column is a
per-row value; Grafana renders a panel-wide no-data state as
`[data-testid="data-testid Panel data error message"]`, never inside a `role="gridcell"`, so
genuinely empty panels — tables included — are still detected.

**The tolerated count is deliberately left at 9.** The nine empty `Oplog GB/Hour - <service>` panels
are real (a GB/*hour* rate over a 5-minute window), which is what the helper's existing
`'24'`/`'hour'` title filter is for. Raising the tolerance to 10 would have hidden them and turned
off a real "PMM shows no data here" signal.

### Why fix the test at all, if the product is also wrong?

Because this assertion is not a detector for misleading value mappings, and never was: it fires
only when a node's 2s load window happens to average exactly zero, and it reports the problem as
*"Nodes Overview has no data"* — which is false and points a reader at the wrong thing. The real
defect is tracked in PMM-15363 and does not depend on this test staying broken. Meanwhile any table
panel mapping a value to `No Data`/`-` trips the same false positive, so the locator needs fixing
regardless of what PMM-15363 does to this one dashboard.

## Verification

**Cause** — established from the failing run's own artifacts: the captured query responses above,
the trace DOM snapshot placing `No Data` inside a `role="gridcell"` beside populated cells, and the
committed dashboard JSON that maps `0` to that text.

**Fix behaviour** — the exact locator codeceptjs composes (`withDescendant` → `[./descendant::…]`
with the `//` prefix stripped) evaluated against the verbatim DOM shapes from that trace:

| Panel (real DOM from the failing run) | on `main` | with this fix |
|---|---|---|
| `Nodes Overview` — populated table, one value-mapped `No Data` cell | counted as empty ❌ | not counted ✅ |
| `Oplog GB/Hour - rs201_17706` — genuine panel-level `No data` | counted ✅ | counted ✅ |
| empty **table** panel — genuine panel-level `No data` | counted ✅ | counted ✅ |
| stat panel showing only `N/A` | counted ✅ | counted ✅ |

So on that run the count becomes 9, not 10, and the test passes — without loosening anything.

**Live** — reproduced the environment on throwaway Linode VMs against the same server image as the
failing run (`perconalab/pmm-server:3-dev-latest`, digest `sha256:439f507a…`, matching the run's
Launchable build) at `main` `8fb0d14`, with `--database psmdb,SETUP_TYPE=sharding`, first
single-host and then in CI's two-machine topology (PMM Server + browser on one VM, the sharded
cluster alone on an otherwise idle second VM). The target test passes with the fix, and the fixed
locator still flagged 32 genuinely empty panels on dashboards whose services aren't registered on
that box — detection is intact in the real browser.

**What only the next nightly can confirm:** the red → green transition itself. The trigger needs
`node_load1 == 0` on the client host, and on a VM I control it floored at ~0.12 and never reached
exactly zero — the second VM still runs ten mongod containers plus `chunk-churn`. The failure is
intermittent in CI for the same reason.