### PR TITLE
Fix hook fallback for the multi-repo cloud layout

### DIFF
--- a/.claude/hooks/skill-gardener-review.sh
+++ b/.claude/hooks/skill-gardener-review.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
-# Review completed skills on PostToolUse and reset a skill's retired counter
-# when ConfigChange reports a file change in its skill directory.
+# Review completed skills on PostToolUse.
 # JSON is parsed with node, which this repository already requires.
+# The ConfigChange branch below is dormant: Claude Code has no such hook event,
+# so nothing invokes it -- kept so the counter reset works if one ever ships.
 set -euo pipefail
 
 command -v node >/dev/null 2>&1 || exit 0
 
-here="$(dirname "$0")"
+QA_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 template="The '{skill}' skill just finished (auto-review pass {n} of 3 for this skill before this review retires here). Invoke the skill-gardener skill in Capture mode against the observable tool and command sequence for '{skill}'. Check for repeated reads or searches, avoidable failed retries, unnecessary setup or dependencies, safe parallelization opportunities, and existing helpers or native tools that could replace custom commands. Do not create a raw command log or optimize away required verification. Record a lesson only if something qualifies under skill-gardener's Capture criteria. Follow its auto-apply rules when the primary task is skill testing or review. When done, run: bash .claude/scripts/skill-gardener-counter.sh '{skill}' <found|none> -- pass 'found' if a lesson was added or gained evidence, 'none' if nothing qualified."
 
-action=$(STATE="$here/../skill-gardener-state.json" TEMPLATE="$template" node -e '
+action=$(STATE="$QA_ROOT/.claude/skill-gardener-state.json" TEMPLATE="$template" node -e '
 const fs = require("fs");
 const SKILLS_DIR = "/.claude/skills/";
 
@@ -43,6 +44,6 @@ process.stdout.write("emit " + JSON.stringify({
 ')
 
 case "$action" in
-  "reset "*) bash "$here/../scripts/skill-gardener-counter.sh" "${action#reset }" reset >/dev/null ;;
+  "reset "*) bash "$QA_ROOT/.claude/scripts/skill-gardener-counter.sh" "${action#reset }" reset >/dev/null ;;
   "emit "*) printf '%s\n' "${action#emit }" ;;
 esac

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,7 +31,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'for d in \"$CLAUDE_PROJECT_DIR\" /home/user/pmm-qa; do h=\"$d/.claude/hooks/session-start.sh\"; [ -f \"$h\" ] && exec bash \"$h\"; done; exit 0'"
+            "command": "sh -c 'n=session-start.sh; for d in \"$CLAUDE_PROJECT_DIR\" \"$PWD\" /workspace/pmm-qa; do h=\"$d/.claude/hooks/$n\"; [ -f \"$h\" ] && exec bash \"$h\"; done; echo \"pmm-qa: hook $n not found (CLAUDE_PROJECT_DIR=$CLAUDE_PROJECT_DIR PWD=$PWD)\" >&2; exit 0'"
           }
         ]
       }
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'for d in \"$CLAUDE_PROJECT_DIR\" /home/user/pmm-qa; do h=\"$d/.claude/hooks/block-pmm-submodules-clone.sh\"; [ -f \"$h\" ] && exec bash \"$h\"; done; exit 0'"
+            "command": "sh -c 'n=block-pmm-submodules-clone.sh; for d in \"$CLAUDE_PROJECT_DIR\" \"$PWD\" /workspace/pmm-qa; do h=\"$d/.claude/hooks/$n\"; [ -f \"$h\" ] && exec bash \"$h\"; done; echo \"pmm-qa: hook $n not found (CLAUDE_PROJECT_DIR=$CLAUDE_PROJECT_DIR PWD=$PWD)\" >&2; exit 0'"
           }
         ]
       }
@@ -53,18 +53,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'for d in \"$CLAUDE_PROJECT_DIR\" /home/user/pmm-qa; do h=\"$d/.claude/hooks/skill-gardener-review.sh\"; [ -f \"$h\" ] && exec bash \"$h\"; done; exit 0'"
-          }
-        ]
-      }
-    ],
-    "ConfigChange": [
-      {
-        "matcher": "skills",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sh -c 'for d in \"$CLAUDE_PROJECT_DIR\" /home/user/pmm-qa; do h=\"$d/.claude/hooks/skill-gardener-review.sh\"; [ -f \"$h\" ] && exec bash \"$h\"; done; exit 0'"
+            "command": "sh -c 'n=skill-gardener-review.sh; for d in \"$CLAUDE_PROJECT_DIR\" \"$PWD\" /workspace/pmm-qa; do h=\"$d/.claude/hooks/$n\"; [ -f \"$h\" ] && exec bash \"$h\"; done; echo \"pmm-qa: hook $n not found (CLAUDE_PROJECT_DIR=$CLAUDE_PROJECT_DIR PWD=$PWD)\" >&2; exit 0'"
           }
         ]
       }
@@ -74,7 +63,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'for d in \"$CLAUDE_PROJECT_DIR\" /home/user/pmm-qa; do h=\"$d/.claude/hooks/session-end-cleanup.sh\"; [ -f \"$h\" ] && exec bash \"$h\"; done; exit 0'"
+            "command": "sh -c 'n=session-end-cleanup.sh; for d in \"$CLAUDE_PROJECT_DIR\" \"$PWD\" /workspace/pmm-qa; do h=\"$d/.claude/hooks/$n\"; [ -f \"$h\" ] && exec bash \"$h\"; done; echo \"pmm-qa: hook $n not found (CLAUDE_PROJECT_DIR=$CLAUDE_PROJECT_DIR PWD=$PWD)\" >&2; exit 0'"
           }
         ]
       }


### PR DESCRIPTION
## Problem

No hook from `.claude/settings.json` fires in a cloud session rooted at `/workspace`.

Every one of the five wrappers searched `"$CLAUDE_PROJECT_DIR"` then `/home/user/pmm-qa`. That path no longer exists — the current cloud layout is `/workspace/<repo>` — and `CLAUDE_PROJECT_DIR` does not resolve in the hook process either. The loop therefore fell through to a bare `exit 0`: silent, no log, no signal that anything was wrong.

Confirmed live in a `/workspace` session: an instrumented `PreToolUse` hook never ran, and `/workspace/pmm-qa/.claude/hooks` is the only such directory on disk (`/home/user` does not exist).

## Changes

**1. Fallback chain that resolves in the current layout.** Each wrapper now searches `"$CLAUDE_PROJECT_DIR"`, `"$PWD"`, `/workspace/pmm-qa`. On a miss it prints the hook name and both variables to stderr instead of exiting silently — the silent `exit 0` is why this went unnoticed.

**2. Repo root from `$0`, never from `CLAUDE_PROJECT_DIR`.** `skill-gardener-review.sh` was the only hook still resolving paths relative to the wrapper (`here="$(dirname "$0")"`). It now derives `QA_ROOT` from `BASH_SOURCE`, matching `session-start.sh` and `session-end-cleanup.sh`, so it stays correct if the wrapper changes again and regardless of the hook process's cwd. `block-pmm-submodules-clone.sh` never needs the root.

**3. `ConfigChange` removed — it is not a hook event.** Claude Code 2.1.239 has zero occurrences of `ConfigChange` in `cli.js`; the supported set is `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `Notification`, `UserPromptSubmit`, `SessionStart`, `SessionEnd`, `Stop`, `SubagentStart`, `SubagentStop`, `PreCompact`, `PermissionRequest`, `Setup`, `TeammateIdle`, `TaskCompleted`.

**What is lost:** nothing that currently works, since the entry had never fired. What stays unavailable is the automatic reset of a skill's consecutive-no-finding counter when a file in its skill directory changes. Until an equivalent event ships, reset it by hand:

```
bash .claude/scripts/skill-gardener-counter.sh <skill-name> reset
```

The dormant `ConfigChange` branch is kept in `skill-gardener-review.sh`, with a comment stating that nothing invokes it, so the reset works again if such an event appears.

## Evidence

The earlier verification tested the *script* under a working wrapper and never the *wrapper* under cloud conditions — that is the gap this bug slipped through, so the wrapper is what is tested here.

Old vs. new wrapper strings were read programmatically from `settings.json` (old via `git show HEAD:`, new from the working tree), never retyped, and run against synthetic hook payloads with a marker probe temporarily added to the hook scripts:

| wrapper | cwd | `CLAUDE_PROJECT_DIR` | hook ran |
|---|---|---|---|
| old | `/workspace` | unset | **NO** — exit 0, no output |
| old | `/workspace/pmm-qa` | unset | **NO** — exit 0, no output |
| new | `/workspace` | unset | YES — exit 2, block message |
| new | `/workspace/pmm-qa` | unset | YES |
| new | `/workspace` | `/workspace/pmm-qa` | YES |
| new | `/tmp` | unset | YES |
| new (`PostToolUse`) | `/workspace`, `/tmp` | unset | YES — correct `hookSpecificOutput` |
| new, hook file absent | `/workspace` | unset | no — but now logs to stderr |

Each firing recorded `argv0=/workspace/pmm-qa/.claude/hooks/<script>`, confirming the wrapper resolved the real file. The instrumentation was then removed and both hooks re-verified in their final state; no `TEMP-PROBE` remains and `.claude/skill-gardener-state.json` is unchanged.

### Limitation

Live end-to-end firing was **not** observed. The session used for this work snapshotted the old wrapper at startup and settings hooks are not hot-reloaded, so the fixed wrapper cannot fire in it. Confirming that requires a fresh session on this branch.

## Note for reviewers

`~/.claude/settings.json` in the cloud container holds a byte-identical copy of the broken hook block. That file is outside this repo. If the environment seeds it from the repo at session start this fix propagates on its own; if it is managed as environment config, it needs updating separately for the fix to take effect.

---
_Generated by [Claude Code](https://claude.ai/code/session_014fJTTgbM3re6dp11Tjb4T6)_