### PR TITLE
Use a smaller QAN page size in PMM-T2268

### DIFF
--- a/e2e_tests/pages/qan/storedMetrics/storedMetrics.page.ts
+++ b/e2e_tests/pages/qan/storedMetrics/storedMetrics.page.ts
@@ -34,6 +34,16 @@ export default class StoredMetricsPage extends BasePage {
   };
   messages = {};
 
+  getTotalQueryCount = async () => {
+    const countString = await this.elements.totalCount.first().textContent({ timeout: Timeouts.ONE_MINUTE });
+
+    if (!countString) throw new Error('Count of queries is not displayed!');
+
+    const match = countString.match(/of (\d+) items/);
+
+    return match ? parseInt(match[1], 10) : null;
+  };
+
   verifyOnlyServiceTypeVisible = async (expected: AccessServiceType) => {
     await expect(this.elements.pageTitle).toBeVisible({
       timeout: Timeouts.THIRTY_SECONDS,
@@ -60,14 +70,7 @@ export default class StoredMetricsPage extends BasePage {
   };
 
   verifyTotalQueryCount = async (expectedQueryCount: number) => {
-    const countString = await this.elements.totalCount.first().textContent({ timeout: Timeouts.ONE_MINUTE });
-
-    if (!countString) throw new Error('Count of queries is not displayed!');
-
-    const match = countString.match(/of (\d+) items/);
-    const queryCount = match ? parseInt(match[1], 10) : null;
-
-    expect(queryCount).toEqual(expectedQueryCount);
+    expect(await this.getTotalQueryCount()).toEqual(expectedQueryCount);
   };
 
   waitForQanStoredMetricsToHaveData = async (timeout: Timeouts = Timeouts.THIRTY_SECONDS) => {

--- a/e2e_tests/tests/qan/storedMetrics/urlState.test.ts
+++ b/e2e_tests/tests/qan/storedMetrics/urlState.test.ts
@@ -3,9 +3,13 @@ import { Timeouts } from '@helpers/timeouts';
 import StoredMetricsPage from '@pages/qan/storedMetrics/storedMetrics.page';
 import { expect } from '@playwright/test';
 
+// Below QAN's own default of 25, so a second page exists for the amount of query
+// digests a freshly provisioned environment has actually collected by test time.
+const PAGE_SIZE = 10;
+
 pmmTest.beforeEach(async ({ grafanaHelper, page, queryAnalytics }) => {
   await grafanaHelper.authorize();
-  await page.goto(queryAnalytics.url);
+  await page.goto(`${queryAnalytics.url}?page_size=${PAGE_SIZE}`);
   await queryAnalytics.storedMetrics.elements.iframe.waitFor({
     state: 'visible',
     timeout: Timeouts.THIRTY_SECONDS,
@@ -24,6 +28,13 @@ pmmTest(
     });
 
     await pmmTest.step('Change pagination', async () => {
+      await expect
+        .poll(async () => storedMetrics.getTotalQueryCount(), {
+          message: `QAN needs more than one page of ${PAGE_SIZE} mongodb queries to exercise pagination`,
+          timeout: Timeouts.THIRTY_SECONDS,
+        })
+        .toBeGreaterThan(PAGE_SIZE);
+
       const secondPaginationItem = storedMetrics.builders.paginationItem('2');
 
       await expect(secondPaginationItem).toBeVisible({ timeout: Timeouts.THIRTY_SECONDS });
@@ -54,6 +65,7 @@ pmmTest(
     await pmmTest.step('Verify state in the URL', async () => {
       await expect.poll(() => new URL(page.url()).searchParams.has('dimensionSearchText')).toBeFalsy();
       await expect.poll(() => new URL(page.url()).searchParams.get('page_number')).toBe('2');
+      await expect.poll(() => new URL(page.url()).searchParams.get('page_size')).toBe(String(PAGE_SIZE));
       await expect
         .poll(() => new URL(page.url()).searchParams.getAll('var-service_type'))
         .toContain('mongodb');


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [`PSMDB GSSAPI E2E Tests Matrix` run 32546010826](https://github.com/percona/pmm-qa/actions/runs/32546010826) (scheduled, `main`) — job `OL8 PSMDB E2E tests / e2e tests: @rta` ([96964424579](https://github.com/percona/pmm-qa/actions/runs/32546010826/job/96964424579))
- tests:
  - `e2e_tests/tests/qan/storedMetrics/urlState.test.ts:15` / `@rta` — PMM-T2268 "Verify QAN shared URL restores filters and pagination"

## What failed

The job's own `Run UI tests: @rta with launchable` step reported **success** (it ends in `|| true`); the job went red one step later on `launchable gate`:

```
| Status   |   Quarantined (Ignored) |   Actionable Failures |
| FAILED   |                       0 |                     1 |
```

One test, failing all three attempts (~34s each — the 30s `toBeVisible` timeout):

```
Error: expect(locator).toBeVisible() failed

Locator: locator('//*[@id="grafana-iframe"]').contentFrame()
           .getByRole('listitem', { name: '2', exact: true })
Expected: visible
Timeout: 30000ms
Error: element(s) not found

> 29 |       await expect(secondPaginationItem).toBeVisible({ timeout: Timeouts.THIRTY_SECONDS });
  at e2e_tests/tests/qan/storedMetrics/urlState.test.ts:29:42
```

Not a one-off: the same test, same assertion, also failed the OL8 `@rta` leg on **2026-08-19** ([run 32208328543](https://github.com/percona/pmm-qa/actions/runs/32208328543)). In both runs the **OL9** leg of the same matrix passed.

## Root cause — the test needs more query digests than the environment reliably has

The test filters QAN stored metrics to `service_type=mongodb` and then requires a **page 2** to exist. QAN's default page size is 25 (`DEFAULT_PAGE_SIZE = +PageSizes.low`, `dashboards/pmm-app/src/pmm-qan/panel/QueryAnalytics.constants.ts`), so a second page only exists once **more than 25** distinct MongoDB query digests have been collected.

A freshly provisioned psmdb environment sits right on that boundary. Reproduced on a throwaway Linode VM with the job's exact setup (`perconalab/pmm-server:3-dev-latest`, `--database psmdb,OL_VERSION=8,GSSAPI=true`, ol8 client tarball — 3 mongodb services registered), measured straight off `/v1/qan/metrics:getReport`:

| window | mongodb query rows | pages at size 25 |
|---|---|---|
| 2 min | 22 | 1 |
| 3 min | 23 → 25 | 1 |
| 4 min | 26 | 2 |
| 12 h | 29 → 32 | 2 |

20–29 rows against a threshold of 25 — a margin of a few rows either way, which is why one OS leg passes and the other fails on the same commit.

Confirmed in the UI with the test's own locator and page object:

```
range=now-3m    total="1-25 of 25 items"   paginationItem('2') count=0   <- element(s) not found, as in CI
range=now-12h   total="1-25 of 29 items"   paginationItem('2') count=1   <- passes
```

PMM is behaving correctly here — QAN renders a single page when there are ≤25 rows. The bug is that the test's precondition is an ambient property of the environment rather than something it establishes.

## The fix

`page_size` is a first-class QAN URL parameter (`pageSize: query.get('page_size') || DEFAULT_PAGE_SIZE`, `provider.tools.ts:137`). Navigate with `page_size=10`, so a second page exists for the amount of data such an environment has actually collected by test time, and assert `page_size` survives in the shared URL alongside `page_number`.

**No assertion is loosened.** The test still clicks through to page 2, still asserts `page_number=2` persists, and still asserts the shared URL restores the active page — the required row count drops from >25 to >10, giving a 2–3× margin instead of 0.8–1.2×.

The pagination step is also guarded on the observed row count, so an environment that genuinely collected almost nothing still fails, and says so:

```
Error: QAN needs more than one page of 25 mongodb queries to exercise pagination
expect(received).toBeGreaterThan(expected)
Expected: > 25
Received:   23
```

instead of a bare "element(s) not found". `getTotalQueryCount` is factored out of the existing `verifyTotalQueryCount` for this; that helper's behaviour is unchanged.

## Verification

On the reproduced VM, driving the real spec through Playwright:

| case | data | result |
|---|---|---|
| Fixed test, default window (as CI runs it) | 29–32 rows | ✅ passes (16–20s) |
| **Pre-fix** page size 25, narrow window | 22–23 rows | ❌ **fails at 36.9s** — reproduces the CI failure |
| **Post-fix** page size 10, same window and data | 22–23 rows | ✅ passes (15.8s) |

Before/after on identical data is the load-bearing evidence: the only variable is the page size.

Full `@rta` suite on the same box: **17 passed, 4 failed**. The 4 are `qan/rta/details.test.ts` (T2192, T2230) and `qan/rta/overview.test.ts` (T2173/T2174, T2184) — the tests that seed live queries through `mongoDbHelper` against `127.0.0.1:27027`, which is unreachable because I drove Playwright from outside the box rather than on it as CI does. **Verified pre-existing:** the same 4 fail identically with this change stashed. They passed in the CI run under investigation, and this change touches neither the RTA page object nor those specs.

`npx eslint` clean and `tsc --noEmit` clean on both changed files.

What only the next real run can confirm: that the OL8/OL9 `@rta` legs of the nightly PSMDB GSSAPI matrix both go green on a CI-provisioned host, with the live-query RTA tests exercised in place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJ7YeUhsa3EF3X4hKpgdMq)_