### PR TITLE
Make waitForAllGraphsToHaveData actually wait in PMM-T1244

### DIFF
--- a/codeceptjs-e2e/tests/pages/dashboardPage.js
+++ b/codeceptjs-e2e/tests/pages/dashboardPage.js
@@ -1300,8 +1300,21 @@ module.exports = {
   },
 
   async waitForAllGraphsToHaveData(timeout = 60) {
-    await I.waitForInvisible(this.fields.notAvailableMetrics, timeout);
-    await I.waitForInvisible(this.fields.notAvailableDataPoints, timeout);
+    const deadline = Date.now() + timeout * 1000;
+
+    // A dashboard that has not rendered its panels yet contains no "N/A"/"No data"
+    // element at all, so waiting for one to disappear returns straight away. Wait for
+    // the panels first, then poll the same locator verifyThereAreNoGraphsWithoutData
+    // asserts on, so the wait and the assertion agree on what "has data" means.
+    await I.waitForVisible(this.fields.reportTitle, timeout);
+
+    while (Date.now() < deadline) {
+      if ((await this.grabRealFailedReportTitles()).length === 0) return;
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1000);
+      });
+    }
   },
 
   async waitForGraphsToHaveData(acceptableNACount = 0, timeoutInSeconds = 60) {
@@ -1330,9 +1343,7 @@ module.exports = {
 
     I.say(`Number of no data and N/A elements is = ${numberOfNAElements}`);
     if (numberOfNAElements > acceptableNACount) {
-      const titles = await this.grabFailedReportTitles(this.fields.reportTitleWithNA);
-      const realFailures = titles.filter((title) => !title.toLowerCase().includes('24') && !title.toLowerCase().includes('hour'));
-
+      const realFailures = await this.grabRealFailedReportTitles();
       const url = await I.grabCurrentUrl();
 
       if (realFailures.length > 0) {
@@ -1365,6 +1376,12 @@ module.exports = {
 
   async grabFailedReportTitles(selector) {
     return await I.grabTextFromAll(selector);
+  },
+
+  async grabRealFailedReportTitles() {
+    const titles = await this.grabFailedReportTitles(this.fields.reportTitleWithNA);
+
+    return titles.filter((title) => !title.toLowerCase().includes('24') && !title.toLowerCase().includes('hour'));
   },
 
   async expandEachDashboardRow() {


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [`E2E tests Matrix` run 32613108284](https://github.com/percona/pmm-qa/actions/runs/32613108284) (scheduled, `main`) — job `FB E2E tests / Docker configuration tests / e2e tests: @docker-configuration` ([97129189248](https://github.com/percona/pmm-qa/actions/runs/32613108284/job/97129189248))
- tests:
  - `codeceptjs-e2e/tests/dockerConfiguration/verifySrvDataDirectory_test.js` / `@docker-configuration` — PMM-T1244 "Verify PMM Server with empty data container"

## What failed

The job's own `Execute e2e tests with tags @docker-configuration with launchable` step reported
**success** (it runs under `set +e` and only records an output variable); the job went red one step
later on `launchable gate`. The real result was `FAIL | 13 passed, 1 failed, 2 skipped`:

```
Expected 0 Elements without data but found 11 on Dashboard
http://127.0.0.1:8083/pmm-ui/graph/d/node-instance-summary/node-summary?orgId=1&refresh=5s...&var-node_name=pmm-server
Report Names are System Uptime,Virtual CPUs,Load Average,Disk Space,Min Space Available,
Time before run out of space,RAM,Memory Available,Virtual Memory,CPU Usage,CPU Saturation and Max Core Usage
    at Object.printFailedReportNames (tests/pages/dashboardPage.js:1359:12)
    at Object.verifyThereAreNoGraphsWithoutData (tests/pages/dashboardPage.js:1339:20)
```

The telling detail is the duration: **133.7s**. The scenario opens with a fixed `I.wait(120)`, so
everything after it — authorize, QAN, and a `waitForAllGraphsToHaveData(300)` — took about 13
seconds. A 300-second wait that returns in seconds did not wait.

## Root cause — the wait is a no-op while the dashboard is still loading

```js
async waitForAllGraphsToHaveData(timeout = 60) {
  await I.waitForInvisible(this.fields.notAvailableMetrics, timeout);   // //span[contains(text(), "N/A")]
  await I.waitForInvisible(this.fields.notAvailableDataPoints, timeout); // //div[contains(text(),"No data")]
}
```

`waitForInvisible` is satisfied when the locator matches **nothing**, and that is exactly the state
of a Grafana dashboard that has not rendered its panels yet. So both calls return almost
immediately, and `verifyThereAreNoGraphsWithoutData()` — which counts panels via a *different*
locator, `reportTitleWithNA` — then runs against a dashboard that is still filling in.

Two further things make the window wide rather than theoretical: the scenario points at a PMM
Server container created ~2 minutes earlier, and Node Summary's default range is `now-12h`, which
Grafana renders at **5m resolution** (visible in the captured screenshot's "Data for pmm-server with
5m resolution" banner). At that step size a 2-minute-old server genuinely has nothing to plot yet —
the 300s budget exists precisely to absorb that, and was being thrown away.

## The fix

Wait for the panels to exist first, then poll the same locator the assertion uses, so the wait and
the assertion agree on what "has data" means. `grabRealFailedReportTitles` factors out the
`24`/`hour` title filter that `verifyThereAreNoGraphsWithoutData` already applied, so the wait
tolerates exactly the panels the assertion tolerates and cannot spin out its whole budget on one.

The helper still only *waits* — it never throws — so `verifyThereAreNoGraphsWithoutData` remains the
thing that fails, with the same message and the same `acceptableNACount`. **No assertion was
loosened:** the tolerated-empty-panel count for PMM-T1244 stays `0`.

`waitForAllGraphsToHaveData` has exactly two call sites, both in the failing spec, so the blast
radius is this test.

## Verification

Reproduced and verified on a throwaway Linode VM built from this run's own commit (`b8d037c`),
following `runner-e2e-tests-codeceptjs.yml`: same PMM Server image
(`perconalab/pmm-server:3-dev-latest`), same client (`latest-tarball`), same Chromium build as CI
(151.0.7922.34).

The failure is load-sensitive — it needs the runner slow enough that the dashboard is still
rendering when the wait is called. Idle, the test passes even unfixed; under `stress-ng --cpu 6
--io 4 --vm 2 --vm-bytes 1G` it fails deterministically:

| | idle | under load |
|---|---|---|
| `main` (b8d037c) | PASS 285s, PASS 232s | **FAIL 168s**, **FAIL 167s** |
| this branch | — | PASS 399s, PASS 295s |

Both loaded failures are the CI failure: same assertion, same dashboard, same panel list (`found 5`
and `found 1` — the count varies with how far the scrape got, which is what a race looks like).
Both loaded runs on this branch pass, taking 295–399s where the broken wait bailed at ~168s.

Notes on what this does and does not prove:

- PMM-T1244 creates a **fresh** PMM Server container and volume on every run, so the usual
  "long-lived repro VM has accumulated history a CI run won't have" caveat does not apply here — the
  data being waited for is generated inside a brand-new container each time. The two loaded runs
  above each started from `docker volume rm srvFolder`.
- The added patience costs wall-clock in the worst case: if the dashboard never fills, the scenario
  now spends its `300s` + `180s` budgets before failing instead of failing at once. The
  `@docker-configuration` job took 15m of its 90m `timeout-minutes`, so there is ample room.
- `eslint` is clean on the changed file (repo config, run on the VM's `node_modules`).
- Only the next real scheduled run can confirm the failure is gone on GitHub's own runners; what is
  proven here is that the mechanism reproduces and that this change survives it.

## Not covered by this PR

The same run had a second red job, `MySQL SSL tests / e2e tests: @ssl-mysql`
([97129189036](https://github.com/percona/pmm-qa/actions/runs/32613108284/job/97129189036)) —
`verifyTLSMySQLRemoteInstance_test.js`, PMM-T1403 + PMM-T1404 + PMM-T1426 + PMM-T1431 with
`maxQueryLength: ""`, timing out on the QAN Examples tab:

```
element (//*[@data-testid="highlight-code" or contains(@class, "pretty-json-container")])
still not visible after 30 sec.
  at QueryAnalyticsQueryDetails.checkExamplesTab (./tests/pages/components/queryAnalytics/queryAnalyticsQueryDetails.js:94:7)
```

**It did not reproduce.** On the same VM: the full `@ssl-mysql` tag passed that variant (169s), and
a `PMM-T1403`-only run under the same `stress-ng` load passed all three data variants (`10`, `-1`,
`""` — 323s/341s/329s). The scheduled run of the **previous day at this identical commit**
(`b8d037c`, [32546268416](https://github.com/percona/pmm-qa/actions/runs/32546268416)) was also
green. Treating it as a flake for now rather than guessing at a fix — no change made for it here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YJudpovQykqeun6S8v9eS6)_