### PR TITLE
Retry the launchable install in the Prepare launchable step

### DIFF
--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
@@ -136,7 +136,18 @@ jobs:
       - name: Prepare launchable
         working-directory: pmm-qa/codeceptjs-e2e
         run: |
-          pip3 install --user --upgrade launchable~=1.0
+          # A PyPI read timeout here aborts the whole leg before any test runs; retry instead.
+          for attempt in 1 2 3; do
+            if pip3 install --user --upgrade --timeout 60 launchable~=1.0; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "launchable install failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "launchable install attempt ${attempt} failed; retrying"
+            sleep $((attempt * 10))
+          done
           launchable verify || true
 
           docker pull ${{ env.DOCKER_VERSION }} || true

--- a/.github/workflows/runner-e2e-tests-codeceptjs.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs.yml
@@ -164,7 +164,18 @@ jobs:
       - name: Prepare launchable
         working-directory: pmm-qa/codeceptjs-e2e
         run: |
-          pip3 install --user --upgrade launchable~=1.0
+          # A PyPI read timeout here aborts the whole leg before any test runs; retry instead.
+          for attempt in 1 2 3; do
+            if pip3 install --user --upgrade --timeout 60 launchable~=1.0; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "launchable install failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "launchable install attempt ${attempt} failed; retrying"
+            sleep $((attempt * 10))
+          done
           launchable verify || true
           
           docker pull ${{ env.DOCKER_VERSION }} || true

--- a/.github/workflows/runner-e2e-tests-playwright-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-playwright-remote-nightly-tests.yml
@@ -136,7 +136,18 @@ jobs:
       - name: Prepare launchable
         working-directory: pmm-qa/e2e_tests
         run: |
-          pip3 install --user --upgrade launchable~=1.0
+          # A PyPI read timeout here aborts the whole leg before any test runs; retry instead.
+          for attempt in 1 2 3; do
+            if pip3 install --user --upgrade --timeout 60 launchable~=1.0; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "launchable install failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "launchable install attempt ${attempt} failed; retrying"
+            sleep $((attempt * 10))
+          done
           launchable verify || true
 
           docker pull ${{ env.DOCKER_VERSION }} || true

--- a/.github/workflows/runner-e2e-tests-playwright.yml
+++ b/.github/workflows/runner-e2e-tests-playwright.yml
@@ -141,7 +141,18 @@ jobs:
       - name: Prepare launchable
         working-directory: pmm-qa/e2e_tests
         run: |
-          pip3 install --user --upgrade launchable~=1.0
+          # A PyPI read timeout here aborts the whole leg before any test runs; retry instead.
+          for attempt in 1 2 3; do
+            if pip3 install --user --upgrade --timeout 60 launchable~=1.0; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "launchable install failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "launchable install attempt ${attempt} failed; retrying"
+            sleep $((attempt * 10))
+          done
           launchable verify || true
           
           docker pull ${{ env.DOCKER_VERSION }} || true

--- a/.github/workflows/runner-integration-cli-tests.yml
+++ b/.github/workflows/runner-integration-cli-tests.yml
@@ -139,7 +139,18 @@ jobs:
       - name: Prepare launchable
         working-directory: ./pmm-qa/cli
         run: |
-          pip3 install --user --upgrade launchable~=1.0
+          # A PyPI read timeout here aborts the whole leg before any test runs; retry instead.
+          for attempt in 1 2 3; do
+            if pip3 install --user --upgrade --timeout 60 launchable~=1.0; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "launchable install failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "launchable install attempt ${attempt} failed; retrying"
+            sleep $((attempt * 10))
+          done
           launchable verify || true
           
           export DOCKER_IMAGE_ID=$(docker inspect -f '{{index .RepoDigests 0}}' ${{ env.PMM_SERVER_IMAGE }} | cut -d@ -f2) || true


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4540](https://github.com/Percona-Lab/pmm-submodules/pull/4540) — run [32670303080](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32670303080), check `E2E / Docker configuration tests / e2e tests: @docker-configuration` (job [97270034369](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32670303080/job/97270034369))
- tests:
  - none — the leg died in setup, before a single test was selected or run

## What failed

`@docker-configuration` was the only red check out of 48 in that run. That tag has **two** legs with
the same display name — a CodeceptJS one and a Playwright one. The Playwright leg
([97270034411](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32670303080/job/97270034411))
passed. The CodeceptJS one failed at step 8, `Prepare launchable`:

```
Collecting launchable~=1.0
  Downloading launchable-1.124.4-py3-none-any.whl (11.5 MB)
     ━━━╸  1.0/11.5 MB 4.6 MB/s eta 0:00:03
ERROR: Exception:
...
pip._vendor.urllib3.exceptions.ReadTimeoutError:
  HTTPSConnectionPool(host='files.pythonhosted.org', port=443): Read timed out.
##[error]Process completed with exit code 2.
```

The step list shows how much this cost:

| # | Step | Result |
|---|------|--------|
| 8 | `Prepare launchable` | **failure** |
| 9–18 | `Check if launchable subset is empty` … `Setup PMM Server` … `Execute e2e tests` … | **skipped** |

Zero tests ran, no artifacts were produced (`No files were found with the provided path`), and PMM
was never even started. The trigger is transient and entirely runner-side, so there is nothing here
to reproduce on a VM — but the amplifier is ours.

## Root cause — the one unguarded command in the step

```yaml
      - name: Prepare launchable
        run: |
          pip3 install --user --upgrade launchable~=1.0   # <-- unguarded
          launchable verify || true
          docker pull ${{ env.DOCKER_VERSION }} || true
          launchable record session ... || true
          cat test_list.txt | launchable subset ... || true
```

Every other command in that step already ends in `|| true` — the step is written on the premise that
Launchable is best-effort. The `pip3 install` is the exception, and the step runs under
`bash -e`, so its failure takes the whole leg down.

Two things made it fail rather than ride it out:

- **pip's default socket timeout is 15s.** The download started at `22:24:14.33` and raised
  `ReadTimeoutError` at `22:24:29.64` — 15.3s later, exactly the default.
- **pip does not retry a read timeout mid-stream.** The traceback runs through
  `network/download.py → response_chunks → urllib3 stream`, i.e. a partially-downloaded wheel, not a
  failed connection attempt, so the default `--retries 5` never applied.

This is the same single point of failure in **5** workflows — both FB E2E runners, the FB CLI runner,
and both nightly runners — so any PyPI blip can red an arbitrary leg of FB Tests, the nightly matrix,
or the CLI matrix.

## The fix

Raise the timeout to 60s and wrap the install in a bounded 3-attempt retry with backoff:

```bash
for attempt in 1 2 3; do
  if pip3 install --user --upgrade --timeout 60 launchable~=1.0; then
    break
  fi
  if [ "${attempt}" -eq 3 ]; then
    echo "launchable install failed after ${attempt} attempts"
    exit 1
  fi
  echo "launchable install attempt ${attempt} failed; retrying"
  sleep $((attempt * 10))
done
```

### Deliberately not `|| true`

Making the install non-fatal like its neighbours would be the smaller diff and the wrong fix. With no
`launchable` binary, `launchable subset` writes nothing, and the next step reads that as a legitimate
empty subset:

```yaml
      - name: Check if launchable subset is empty
        run: |
          if [ -s "$SUBSET_FILE" ]; then echo "has_subset=true" ...
          else echo "has_subset=false" ...   # setup and tests are then skipped
```

Every `if: steps.check_launchable_subset.outputs.has_subset == 'true'` step is skipped and the job
reports **success having run no tests**. A red leg is noisy; a green leg that silently tested nothing
is worse. Exhausting the retries still fails the step.

## Verification

Honest scope: I did **not** reproduce the original failure. A PyPI read timeout on a GitHub-hosted
runner is not reproducible on demand, and the diagnosis does not depend on PMM behaviour at all — the
log names the exception and the step list proves nothing downstream executed. No Linode VM was
provisioned for this one.

What I did verify:

- **The original failure was purely the install.** I re-ran the failed job
  ([97274472931](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32670303080/job/97274472931),
  same CodeceptJS leg, same FB image) and it passed end to end — `Prepare launchable` succeeded, and
  this time `Execute e2e tests with tags @docker-configuration` actually ran and passed. FB Tests on
  #4540 is now green across all 48 checks. Nothing was wrong with the tests or the product.
- **The real command works.** `pip3 install --user --upgrade --timeout 60 launchable~=1.0` installs
  `launchable-1.124.4` — the very wheel that timed out — and `launchable --version` reports
  `launchable-cli, version 1.124.4`.
- **The loop is correct under `bash -e`**, exercised with a stubbed `pip3` on the exact text committed
  here:

  | Scenario | Attempts | Exit |
  |---|---|---|
  | succeeds first try | 1 | 0 |
  | fails once, then succeeds | 2 | 0 |
  | fails twice, then succeeds | 3 | 0 |
  | fails all three | 3 | **1** |

  The last row is the one that matters: retries exhausted still fails, so the silent-green path above
  stays closed. (An earlier draft used `[ "${attempt}" = 3 ] && exit 1`, which under `set -e` exits
  the shell when the test is *false* — hence the `if`.)
- **All 5 workflows still parse** as YAML with the `Prepare launchable` step intact.

What only real CI can confirm: that a future PyPI blip is actually ridden out rather than reported.