### PR TITLE
Retry PMM-T2202 sidebar clicks against auto-collapse

### DIFF
--- a/e2e_tests/pages/navigation.page.ts
+++ b/e2e_tests/pages/navigation.page.ts
@@ -198,6 +198,7 @@ export default class LeftNavigation extends BasePage {
     await pmmTest.step(`Select menu item: ${path}`, async () => {
       const parts = path.split('.');
       let node = this.buttons as NestedLocators;
+      let reExpandParent: (() => Promise<void>) | undefined;
 
       for (const [index, part] of parts.entries()) {
         const item = node[part];
@@ -205,25 +206,37 @@ export default class LeftNavigation extends BasePage {
         if (!item) throw new Error(`Menu item not found: ${part} in path: ${path}`);
         if (index < parts.length - 1 && !this.isLocator(item) && part !== 'ha' && part !== 'org') {
           const childLocator = this.getLocator((item as NestedLocators)[parts[index + 1]] as NestedLocator);
+          const expandButton = this.getLocator(item as NestedLocator)
+            ?.locator('xpath=..')
+            .getByRole('button')
+            .first();
 
-          if (childLocator && !(await childLocator.isVisible())) {
-            await this.getLocator(item as NestedLocator)
-              ?.locator('xpath=..')
-              .getByRole('button')
-              .first()
-              .click({ timeout: Timeouts.TEN_SECONDS });
-            await childLocator.waitFor({ state: 'visible', timeout: Timeouts.TEN_SECONDS });
+          if (childLocator && expandButton) {
+            const expand = async (): Promise<void> => {
+              if (!(await childLocator.isVisible())) {
+                await expandButton.click({ timeout: Timeouts.TEN_SECONDS });
+                await childLocator.waitFor({ state: 'visible', timeout: Timeouts.TEN_SECONDS });
+              }
+            };
+
+            await expand();
+            reExpandParent = expand;
           }
         }
         if (part === 'ha' || part === 'org') {
           const expandKey = part === 'ha' ? 'highAvailability' : 'orgManagement';
           const expandLocator = this.getLocator(node[expandKey] as NestedLocator);
-
-          await expandLocator?.click({ timeout: Timeouts.TEN_SECONDS });
-
           const expandedItem = this.getLocator(item as NestedLocator);
 
-          await expandedItem?.waitFor({ state: 'visible', timeout: Timeouts.TEN_SECONDS });
+          const expand = async (): Promise<void> => {
+            if (!(await expandedItem?.isVisible())) {
+              await expandLocator?.click({ timeout: Timeouts.TEN_SECONDS });
+              await expandedItem?.waitFor({ state: 'visible', timeout: Timeouts.TEN_SECONDS });
+            }
+          };
+
+          await expand();
+          reExpandParent = expand;
         }
 
         node = item as NestedLocators;
@@ -233,11 +246,16 @@ export default class LeftNavigation extends BasePage {
 
       if (!locator) throw new Error(`No locator found for path: ${path}`);
 
-      await locator.waitFor({ state: 'visible', timeout: Timeouts.TEN_SECONDS });
-
       const currentUrl = this.page.url();
 
-      await locator.click({ timeout: Timeouts.TEN_SECONDS });
+      // The left-nav auto-collapses an expanded submenu shortly after a route
+      // change, so a nested item can flip from visible back to hidden between the
+      // visibility wait and the click landing (the PMM-T2202 traversal flake).
+      // Re-expand the parent and retry the click together until it registers.
+      await expect(async () => {
+        await reExpandParent?.();
+        await locator.click({ timeout: Timeouts.TEN_SECONDS });
+      }).toPass({ timeout: Timeouts.THIRTY_SECONDS });
       await this.page
         .waitForFunction((url) => window.location.href !== url, currentUrl, { timeout: Timeouts.TEN_SECONDS })
         .catch(Boolean);

--- a/e2e_tests/pages/navigation.page.ts
+++ b/e2e_tests/pages/navigation.page.ts
@@ -198,7 +198,7 @@ export default class LeftNavigation extends BasePage {
     await pmmTest.step(`Select menu item: ${path}`, async () => {
       const parts = path.split('.');
       let node = this.buttons as NestedLocators;
-      let reExpandParent: (() => Promise<void>) | undefined;
+      let expandButton: Locator | undefined;
 
       for (const [index, part] of parts.entries()) {
         const item = node[part];
@@ -206,37 +206,26 @@ export default class LeftNavigation extends BasePage {
         if (!item) throw new Error(`Menu item not found: ${part} in path: ${path}`);
         if (index < parts.length - 1 && !this.isLocator(item) && part !== 'ha' && part !== 'org') {
           const childLocator = this.getLocator((item as NestedLocators)[parts[index + 1]] as NestedLocator);
-          const expandButton = this.getLocator(item as NestedLocator)
+
+          expandButton = this.getLocator(item as NestedLocator)
             ?.locator('xpath=..')
             .getByRole('button')
             .first();
 
-          if (childLocator && expandButton) {
-            const expand = async (): Promise<void> => {
-              if (!(await childLocator.isVisible())) {
-                await expandButton.click({ timeout: Timeouts.TEN_SECONDS });
-                await childLocator.waitFor({ state: 'visible', timeout: Timeouts.TEN_SECONDS });
-              }
-            };
-
-            await expand();
-            reExpandParent = expand;
+          if (childLocator && !(await childLocator.isVisible())) {
+            await expandButton?.click({ timeout: Timeouts.TEN_SECONDS });
+            await childLocator.waitFor({ state: 'visible', timeout: Timeouts.TEN_SECONDS });
           }
         }
         if (part === 'ha' || part === 'org') {
           const expandKey = part === 'ha' ? 'highAvailability' : 'orgManagement';
           const expandLocator = this.getLocator(node[expandKey] as NestedLocator);
+
+          await expandLocator?.click({ timeout: Timeouts.TEN_SECONDS });
+
           const expandedItem = this.getLocator(item as NestedLocator);
 
-          const expand = async (): Promise<void> => {
-            if (!(await expandedItem?.isVisible())) {
-              await expandLocator?.click({ timeout: Timeouts.TEN_SECONDS });
-              await expandedItem?.waitFor({ state: 'visible', timeout: Timeouts.TEN_SECONDS });
-            }
-          };
-
-          await expand();
-          reExpandParent = expand;
+          await expandedItem?.waitFor({ state: 'visible', timeout: Timeouts.TEN_SECONDS });
         }
 
         node = item as NestedLocators;
@@ -248,12 +237,11 @@ export default class LeftNavigation extends BasePage {
 
       const currentUrl = this.page.url();
 
-      // The left-nav auto-collapses an expanded submenu shortly after a route
-      // change, so a nested item can flip from visible back to hidden between the
-      // visibility wait and the click landing (the PMM-T2202 traversal flake).
-      // Re-expand the parent and retry the click together until it registers.
+      // The left-nav auto-collapses a submenu after a route change, hiding a
+      // just-verified nested item before the click lands (PMM-T2202 flake).
       await expect(async () => {
-        await reExpandParent?.();
+        if (!(await locator.isVisible())) await expandButton?.click({ timeout: Timeouts.TEN_SECONDS });
+
         await locator.click({ timeout: Timeouts.TEN_SECONDS });
       }).toPass({ timeout: Timeouts.THIRTY_SECONDS });
       await this.page


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [`E2E tests Matrix` run 32683387599](https://github.com/percona/pmm-qa/actions/runs/32683387599) (scheduled, `main`) — job `New Navigation UI tests / e2e tests: @new-navigation|@menu` ([97303903356](https://github.com/percona/pmm-qa/actions/runs/32683387599/job/97303903356))
- tests:
  - `e2e_tests/tests/navigation.test.ts:148` / `@new-navigation` — PMM-T2202 "Traverse all the menu items in left menu sidebar"

## What failed

`New Navigation UI tests` was the only red job in that run (23 passed, 1 failed, 0 quarantined). Its `Run UI tests` step ends in `|| true`, so the job went red one step later on `launchable gate` (`Actionable Failures | 1`):

```
TimeoutError: locator.click: Timeout 10000ms exceeded.
Call log:
  - waiting for getByTestId('navitem-inventory-nodes')
    - locator resolved to <a ... data-testid="navitem-inventory-nodes" ...>
  - attempting click action
    2 × waiting for element to be visible, enabled and stable
      - element is not visible
    - retrying click action
    ...
    19 × waiting for element to be visible, enabled and stable
       - element is not visible
```

The signature is identical on all three attempts: `navitem-inventory-nodes` resolves in the DOM, then flips to "not visible" through the whole 10s retry window. The Playwright aria snapshot in the run's `error-context.md` shows the Inventory subtree collapsed at failure time — only the top-level "Inventory" link is present, no nested `nodes`/`services`/`addServices`.

## Root cause — a race between the left-nav's auto-collapse and the click

`LeftNavigation.selectMenuItem` (`e2e_tests/pages/navigation.page.ts`) expands the parent, waits for the child to be visible, then clicks — but between the visibility wait and the click landing, the left-nav auto-collapses the previously expanded submenu once the route change from the last item's navigation settles. The child locator is still attached to a DOM node, but that node's ancestor was hidden by the collapse animation, so Playwright's "visible/enabled/stable" precheck keeps refusing to click. This is a pmm-qa test-code timing bug, not a product regression: the item is reachable — the same test passed on Aug 21/22/23 at the same head SHA (`b8d037c`), and reproducing on a fresh VM shows the test as `flaky` (fails attempt 1, passes retry) with the same interception cause.

## Fix

Wrap the final visibility-wait + click in `expect(...).toPass({ timeout: 30s })`, and re-expand the parent submenu before each attempt. If the submenu collapsed between attempts, the next iteration re-opens it and clicks; if the click lands, the retry is a no-op. Left the surrounding code and the intra-loop expands as-is — only the leaf click now retries against collapse.

## Fix verification

Reproduced against `perconalab/pmm-server:3-dev-latest` (sha256:`fbfe80b7...fca08e7b` — the same image Launchable recorded in the failing CI run) on a throwaway Linode VM with the CI job's env matched (`CI=1 WORKERS=1`, `--database ps=8.4 --database psmdb --database valkey`):

- Pre-fix (main @ `b8d037c`): PMM-T2202 flaked once — attempt 1 failed at `inventory.nodes` with the identical timeout signature, retry passed (`1 flaky`, matches CI's failure mode).
- Post-fix (this branch): three consecutive clean single-attempt passes in the same job on the same VM, 2.3–2.6 min each (the failed CI run took 8.6 min across three retry attempts).

This is a smoke-test-strength fix verification for a flake whose base rate we don't know — the next scheduled `E2E tests Matrix` on `main` is what will confirm stability at full CI cadence.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MQrHqt9hrQo1C6EYE2nYma)_