### PR TITLE
Take pmm-admin version reference from client, not server

### DIFF
--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -17,9 +17,12 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
 
   let PMM_VERSION = `${process.env.CLIENT_VERSION}`;
   if (/^https?:/.test(PMM_VERSION) || /pmm3-rc/.test(PMM_VERSION)) {
-    // Feature-build / RC clients trail v3 VERSION once an RC branches; take the version from the server.
-    PMM_VERSION = JSON.parse(cli.execute('sudo pmm-admin status --json').stdout).pmm_agent_status?.server_version;
-    if (!PMM_VERSION) throw new Error('Could not read server version from "pmm-admin status --json"');
+    // Feature-build / RC clients trail v3 VERSION once an RC branches; take the reference from the
+    // client itself. Server_version drifts from the client on submodules-only FB pushes -- the pmm
+    // submodule pointer doesn't move, so the pmm-managed RPM cache hits and the server keeps
+    // reporting its first-build stamp while the client tarball is rebuilt fresh with the new head.
+    PMM_VERSION = JSON.parse(cli.execute('sudo pmm-admin status --json').stdout).pmm_admin_version;
+    if (!PMM_VERSION) throw new Error('Could not read pmm_admin_version from "pmm-admin status --json"');
   } else if (/latest-tarball|3-dev-latest/.test(PMM_VERSION)) {
     // TODO: refactor to use docker hub API to remove file-update dependency
     // See: https://github.com/Percona-QA/package-testing/blob/master/playbooks/pmm2-client_integration_upgrade_custom_path.yml#L41


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4486](https://github.com/Percona-Lab/pmm-submodules/pull/4486) — run [32742352894](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32742352894), check `CLI / Integration tests / CLI / Integration / Generic` (job [97479577166](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32742352894/job/97479577166); same failure re-observed on the newer [PR-4486-8abaa26 run](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32745251193))
- tests:
  - `cli/tests/generic.spec.ts:109` / `@generic` — `run pmm-admin --version`
  - `cli/tests/generic.spec.ts:136` / `@generic` — `run pmm-admin summary --version`

## What failed

Both tests derive `PMM_VERSION` on the FB / RC path from `pmm-admin status --json` → `pmm_agent_status.server_version` (added in #1175), then assert that string appears verbatim in the client's own `pmm-admin --version` stdout. On PR-4486 the two stamps disagreed:

```
Expected substring: "Version: 3.10.0-fix-switch-branch-slash-names-86ad073d8"
Received string:    "…
Version: 3.10.0-fix-switch-branch-slash-names-1e7d53200
PMMVersion: 3.10.0-fix-switch-branch-slash-names-1e7d53200
Timestamp: 2026-08-24 14:48:42 (UTC)
FullCommit: ccca197e22d3ddbeb7a693e2fc7f8ff47e732d95"
```

## Root cause

FB `perconalab/pmm-server-fb:PR-4486-1e7d532` ships a pmm-managed binary stamped `-86ad073d8` (an earlier pmm-submodules commit), while the fresh client tarball at the same tag stamps `-1e7d53200`. They are the same source snapshot with two different build-time strings, so any equality check between them fails.

Why they drift on a submodules-only PR:

`build/scripts/build-server-rpm`'s `get_rpm_version()` strips the build timestamp (`sed -re 's/\.[0-9]{10}\././'`), leaving the RPM cache key as `pmm-managed-3.10.0-21.<pmm-submodule-short-commit>`. That short commit is `full_commit` from `prepare_specs`, which without a `git_path` arg falls back to the pmm submodule's HEAD. PR-4486 (`Percona-Lab/pmm-submodules#4486`) only touches pmm-submodules's own `ci.py` — the pmm submodule pointer never moves — so every re-push hits the same S3 cache key and pulls the RPM built on the first attempt (Aug 21, HEAD `86ad073d8`). The client tarball is uploaded under a per-push key (`pmm-client-${BRANCH_NAME}-${SHORTENED_COMMIT}.tar.gz`), so it is always rebuilt and stamps the current pmm-submodules HEAD.

Result: same tag, same functional code, two version strings. Server_version is no longer a reliable reference for what the client's stdout will contain.

## Fix

Take `PMM_VERSION` from `pmm_admin_version` in the same `pmm-admin status --json` payload instead of `pmm_agent_status.server_version`. It is the client binary's own compile-time stamp — the exact same string that `pmm-admin --version` prints — so the check remains a strict equality test of client output vs. its own reported version, keeping the #1175 rationale ("track the artifact under test") but pointing at the client artifact these tests actually exercise. No assertion loosening.

## Repro & verification

Provisioned a throwaway Linode VM (`heal-4486`), started `perconalab/pmm-server-fb:PR-4486-8abaa26` (readyz), installed `pmm-client-PR-4486-8abaa26.tar.gz`, provisioned `pdpgsql=16` via `pmm-framework`. The two failing FB tests reproduced identically:

- `pmm_agent_status.server_version` = `3.10.0-fix-switch-branch-slash-names-86ad073d8`
- `pmm_admin_version` = `3.10.0-fix-switch-branch-slash-names-8abaa26f6`
- `pmm-admin --version` prints `-8abaa26f6`

After syncing this branch onto the same VM and re-running `npx playwright test --grep @generic tests/generic.spec.ts`, both `run pmm-admin --version` and `run pmm-admin summary --version` pass. (The remaining local failures — T1219, T2193, T2227 — are unrelated env deps: FB exports `ENCRYPTED_CLIENT_CONFIG=true` in `WIZARD_ARGS`, sets `PMM_CLIENT_VERSION`, and provisions additional services; they pass green in the FB job itself, visible in the run 32742352894 log for the same tests.) The next FB re-push on PR-4486 (or any submodules-only PR) is the real acceptance check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cd1QbwJrHgmUzTMM4abpo7)_