### PR TITLE
Tolerate differing git-SHA suffix in @generic version checks

### DIFF
--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -18,8 +18,12 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
   let PMM_VERSION = `${process.env.CLIENT_VERSION}`;
   if (/^https?:/.test(PMM_VERSION) || /pmm3-rc/.test(PMM_VERSION)) {
     // Feature-build / RC clients trail v3 VERSION once an RC branches; take the version from the server.
+    // The server image and client tarball can be built from different commits (e.g. a superproject-only
+    // change reuses a cached server image), so their trailing git-SHA suffixes may differ even though the
+    // X.Y.Z-branch part matches. Drop that suffix so the check compares the meaningful version, not the SHA.
     PMM_VERSION = JSON.parse(cli.execute('sudo pmm-admin status --json').stdout).pmm_agent_status?.server_version;
     if (!PMM_VERSION) throw new Error('Could not read server version from "pmm-admin status --json"');
+    PMM_VERSION = PMM_VERSION.replace(/-[0-9a-f]{7,}$/, '');
   } else if (/latest-tarball|3-dev-latest/.test(PMM_VERSION)) {
     // TODO: refactor to use docker hub API to remove file-update dependency
     // See: https://github.com/Percona-QA/package-testing/blob/master/playbooks/pmm2-client_integration_upgrade_custom_path.yml#L41


### PR DESCRIPTION
## Failures fixed (investigator)

- source: Percona-Lab/pmm-submodules PR #4486 — run https://github.com/Percona-Lab/pmm-submodules/actions/runs/32745251193, check `CLI / Integration tests / CLI / Integration / Generic` (job [97489136095](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32745251193/job/97489136095))
- tests:
  - `cli/tests/generic.spec.ts` / `@generic` — "run pmm-admin --version"
  - `cli/tests/generic.spec.ts` / `@generic` — "run pmm-admin summary --version"

## What

Both version tests resolve the expected version from the server
(`pmm-admin status --json` → `pmm_agent_status.server_version`) in the
feature-build / RC path, then assert the client's `pmm-admin --version`
output contains it. This PR strips a trailing git-SHA suffix
(`-[0-9a-f]{7,}`) from that server-derived reference so the comparison
checks the meaningful `X.Y.Z-branch` version rather than the exact build
commit.

## Why

The `Generic` CLI job was the only red check on FB PR #4486. Both version
tests failed with:

```
Expected substring: "Version: 3.10.0-fix-switch-branch-slash-names-86ad073d8"
Received string:    "Version: 3.10.0-fix-switch-branch-slash-names-8abaa26f6"
```

The server image and the client tarball were built from **different
commits**: the server reports `86ad073d8` (the Aug‑21 "Merge branch v3"
commit) and the client reports `8abaa26f6` (the current PR build). PR #4486
only changes `ci.py` in the pmm-submodules superproject, so across those
commits the pmm source is unchanged — the FB reused a cached server image
while the client tarball was rebuilt, leaving the two artifacts with the
same `3.10.0-fix-switch-branch-slash-names` version but a different trailing
git SHA. The binaries are functionally identical; only the SHA stamp
differs, so the strict equality assertion failed cosmetically.

This is a general property of long-lived, superproject-only FB PRs, not a
PMM/Grafana product bug and not specific to #4486. The assumption that the
server version is an exact stand-in for the client version (introduced when
the reference moved to the server) does not hold when the two artifacts are
built from different commits.

The relaxed check still catches genuine regressions — a wrong `X.Y.Z`, a
wrong branch, or an empty/garbage version — because only a trailing hex git
SHA is dropped.

## Verification

Reproduced and verified on a throwaway VM using the **exact FB artifacts**
from the failing run (`perconalab/pmm-server-fb:PR-4486-8abaa26`, server
image digest `ac34e68…` matching the CI build, and client tarball
`pmm-client-PR-4486-8abaa26.tar.gz`), with the same setup
(`--database pdpgsql=16 --database ps,ENCRYPTED_CLIENT_CONFIG=true`):

- Server reported `server_version: 3.10.0-fix-switch-branch-slash-names-86ad073d8`; client reported `3.10.0-fix-switch-branch-slash-names-8abaa26f6` — the real divergence, unchanged.
- Before: both version tests **fail** (identical to CI).
- After: both version tests **pass**.

The full `@generic|@unregister` run on the repro VM showed 3 other
`@generic` failures (PMM-T1219 summary/vmagent-targets, the summary
`--server-insecure-tls` 47-file count, and PMM-T2227 tarball upgrade). These
are **not** caused by this change: all three passed in the FB CI run, they
do not use the version-resolution logic touched here, and they fail
identically on `main` (without this patch) on the same VM — i.e.
pre-existing environmental differences on the long-lived repro box (fresh-VM
scrape timing, a hard-coded zip file count, and an in-container tarball
reinstall step), which only the next real FB/CI run can confirm green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4VagTYaJAahVvcN69Xa7F)_