### PR TITLE
Pin the FB client version check to the tarball's own commit

### DIFF
--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import * as cli from '@helpers/cli-helper';
 import { getPmmAdminMinorVersion } from '@helpers/pmm-admin';
+import ExecReturn from '@support/types/exec-return.class';
 import { readZipFile } from '@helpers/zip-helper';
 
 const PGSQL_USER = 'postgres';
@@ -16,8 +17,16 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
   });
 
   let PMM_VERSION = `${process.env.CLIENT_VERSION}`;
-  if (/^https?:/.test(PMM_VERSION) || /pmm3-rc/.test(PMM_VERSION)) {
-    // Feature-build / RC clients trail v3 VERSION once an RC branches; take the version from the server.
+  // A feature-build client tarball is named pmm-client-<branch>-<short commit>.tar.gz and is
+  // rebuilt on every push. The server is not a reference for its version: server RPMs come from
+  // the S3 build cache and keep the version stamp of the last build that actually rebuilt them,
+  // so an FB server legitimately reports an earlier commit of the same PR. The commit in the
+  // tarball name is the only thing that identifies the client build under test.
+  const clientCommit = /^https?:/.test(PMM_VERSION)
+    ? PMM_VERSION.match(/-([0-9a-f]{7,40})\.tar\.gz$/)?.[1]
+    : undefined;
+  if (!clientCommit && (/^https?:/.test(PMM_VERSION) || /pmm3-rc/.test(PMM_VERSION))) {
+    // RC clients trail v3 VERSION once an RC branches; take the version from the server.
     PMM_VERSION = JSON.parse(cli.execute('sudo pmm-admin status --json').stdout).pmm_agent_status?.server_version;
     if (!PMM_VERSION) throw new Error('Could not read server version from "pmm-admin status --json"');
   } else if (/latest-tarball|3-dev-latest/.test(PMM_VERSION)) {
@@ -26,6 +35,17 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     PMM_VERSION = cli.execute('curl -s https://raw.githubusercontent.com/Percona-Lab/pmm-submodules/v3/VERSION')
       .stdout.trim();
   }
+
+  const verifyReportedVersion = async (output: ExecReturn) => {
+    if (clientCommit) {
+      await test.step(`Verify reported version is the client built from ${clientCommit}`, async () => {
+        expect(output.stdout, `Reported version is not the client built from commit ${clientCommit}!`)
+          .toMatch(new RegExp(`^Version: \\d+\\.\\d+\\.\\d+\\S*-${clientCommit}[0-9a-f]*$`, 'm'));
+      });
+    } else {
+      await output.outContains(`Version: ${PMM_VERSION}`);
+    }
+  };
 
   test('Verify pt summary for mysql mongodb and pgsql', async ({}) => {
     await test.step('Verify pt summary returns correct exit code', async () => {
@@ -109,7 +129,7 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
   test('run pmm-admin --version', async ({}) => {
     const output = await cli.exec('sudo pmm-admin --version');
     await output.assertSuccess();
-    await output.outContains(`Version: ${PMM_VERSION}`);
+    await verifyReportedVersion(output);
   });
 
   /**
@@ -136,7 +156,7 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
   test('run pmm-admin summary --version', async ({}) => {
     const output = await cli.exec('sudo pmm-admin summary --version');
     await output.assertSuccess();
-    await output.outContains(`Version: ${PMM_VERSION}`);
+    await verifyReportedVersion(output);
   });
 
   test('PMM-T1219 - verify pmm-admin summary includes targets from vmagent', async ({}) => {


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4486](https://github.com/Percona-Lab/pmm-submodules/pull/4486) — run [32793345517](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32793345517), check `CLI / Integration tests / CLI / Integration / Generic` (job [97639425183](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32793345517/job/97639425183))
- tests:
  - `cli/tests/generic.spec.ts:109` / `@generic` — "run pmm-admin --version"
  - `cli/tests/generic.spec.ts:136` / `@generic` — "run pmm-admin summary --version"

## What failed

`CLI / Integration / Generic` was the only red check in that run. Both failures are the same
assertion — the client's own version does not equal the version the **server** reports:

```
Error: Stdout does not contain Version: 3.10.0-fix-switch-branch-slash-names-86ad073d8, !

Expected substring: "Version: 3.10.0-fix-switch-branch-slash-names-86ad073d8"
Received string:    "ProjectName: pmm-admin
Version: 3.10.0-fix-switch-branch-slash-names-028ef12b8
...
FullCommit: ccca197e22d3ddbeb7a693e2fc7f8ff47e732d95
"
```

`028ef12b8` is the PR's head commit; `86ad073d8` is an **earlier commit on the same PR**
(the `Merge branch 'v3'` from Aug 21). The same job failed identically on the three FB builds
before this one; the last green run on this PR was the `86ad073` build itself.

## Root cause — the server is not a reference for the client's version

Reproduced on a throwaway Linode VM with the exact FB artifacts from the run
(`perconalab/pmm-server-fb:PR-4486-028ef12` + `pmm-client-PR-4486-028ef12.tar.gz`):

```
pmm-admin --version   -> Version: 3.10.0-fix-switch-branch-slash-names-028ef12b8
                         Timestamp: 2026-08-25 00:08:09 (UTC)
pmm-managed --version -> Version: 3.10.0-fix-switch-branch-slash-names-86ad073d8   (inside the
                         Timestamp: 2026-08-21 21:26:54 (UTC)                       PR-4486-028ef12 image)
```

Both carry `FullCommit: ccca197e…` — the same `percona/pmm` source. Only the build stamp differs,
and that is by design of the build cache:

- `build/scripts/vars` sets `full_pmm_version=<VERSION>-<pmm-submodules branch>-<short HEAD>`, so
  the stamp changes on **every** push to the FB branch.
- `build/scripts/build-server-rpm`'s `is_build_needed()` keys the S3 cache on the spec's
  `Version-Release` (base version + the *packaged source* commit), **not** on `full_pmm_version`.
  A push that doesn't change packaged sources therefore reuses the cached RPM, and the server keeps
  the stamp of the last build that actually rebuilt it.
- The client tarball has no such cache — `build-client-binary` runs every time, so the client is
  always stamped with the current commit.

pmm-submodules#4486 only touches `ci.py`, so every build after `86ad073` reused the cached server
RPMs. This will hit **any** FB PR whose later pushes don't change packaged sources.

The expected client version was switched to the server's in #1175 because an FB client trails
`v3`'s `VERSION` — true, but the server isn't a valid stand-in for it either.

## The fix

For an FB client the tarball name (`pmm-client-<branch>-<short commit>.tar.gz`) already identifies
the build under test, so the two tests now assert the reported version carries that commit:

```
Version: 3.10.0-<anything>-028ef12b8
```

The RC path (`pmm3-rc`) and the `latest-tarball` / `3-dev-latest` path are unchanged — release
builds stamp `full_pmm_version` as the plain base version, so those references are stable.

## Verification

On the repro VM, against the exact FB build that failed in CI:

- before the fix — the same 2 tests fail with the same messages as the CI job;
- after the fix (`sync.sh` onto the same VM) — `run pmm-admin --version` and
  `run pmm-admin summary --version` both pass;
- negative check — pointing `CLIENT_VERSION` at `…-86ad073.tar.gz` while the `028ef12` client is
  installed still fails ("Reported version is not the client built from commit 86ad073!"), so the
  assertion has not been loosened into a no-op;
- `npm run lint` (eslint + `tsc --noEmit`) is clean — 0 errors, only the pre-existing
  `no-skipped-test` warnings.

The rest of the `@generic` suite was not re-run on the VM (it needs the `ps` setup and PMM on host
ports 80/443, which the repro box reserves for its exec service); only these two call sites changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjoZJHvaEEgUrDrxVpTGNL)_