### PR TITLE
Match the FB client version against its own tarball, not the server

### DIFF
--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import * as cli from '@helpers/cli-helper';
 import { getPmmAdminMinorVersion } from '@helpers/pmm-admin';
 import { readZipFile } from '@helpers/zip-helper';
+import ExecReturn from '@support/types/exec-return.class';
 
 const PGSQL_USER = 'postgres';
 const PGSQL_PASSWORD = 'pass+this';
@@ -16,8 +17,15 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
   });
 
   let PMM_VERSION = `${process.env.CLIENT_VERSION}`;
-  if (/^https?:/.test(PMM_VERSION) || /pmm3-rc/.test(PMM_VERSION)) {
-    // Feature-build / RC clients trail v3 VERSION once an RC branches; take the version from the server.
+  // A feature build names its client tarball after the pmm-submodules commit it was built from,
+  // and stamps that commit into the client version. The server image sharing the same FB tag can
+  // report an earlier commit, because the server side is only rebuilt when its own sources change,
+  // so the client is matched against its own artifact rather than against the server.
+  const fbCommit = /pmm-client-PR-\d+-([0-9a-f]{7,40})\.tar\.gz$/.exec(PMM_VERSION)?.[1];
+  if (fbCommit) {
+    PMM_VERSION = '';
+  } else if (/^https?:/.test(PMM_VERSION) || /pmm3-rc/.test(PMM_VERSION)) {
+    // RC clients trail v3 VERSION once an RC branches; take the version from the server.
     PMM_VERSION = JSON.parse(cli.execute('sudo pmm-admin status --json').stdout).pmm_agent_status?.server_version;
     if (!PMM_VERSION) throw new Error('Could not read server version from "pmm-admin status --json"');
   } else if (/latest-tarball|3-dev-latest/.test(PMM_VERSION)) {
@@ -26,6 +34,16 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     PMM_VERSION = cli.execute('curl -s https://raw.githubusercontent.com/Percona-Lab/pmm-submodules/v3/VERSION')
       .stdout.trim();
   }
+
+  const expectedVersion = fbCommit
+    ? new RegExp(`Version: \\d+\\.\\d+\\.\\d+\\S*-${fbCommit}[0-9a-f]*\\s`)
+    : `Version: ${PMM_VERSION}`;
+
+  const verifyReportedVersion = async (output: ExecReturn) => {
+    await test.step(`Verify command output reports ${expectedVersion}`, async () => {
+      expect(output.stdout.replace(/ +(?= )/g, ''), `Stdout does not report ${expectedVersion}!`).toMatch(expectedVersion);
+    });
+  };
 
   test('Verify pt summary for mysql mongodb and pgsql', async ({}) => {
     await test.step('Verify pt summary returns correct exit code', async () => {
@@ -109,7 +127,7 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
   test('run pmm-admin --version', async ({}) => {
     const output = await cli.exec('sudo pmm-admin --version');
     await output.assertSuccess();
-    await output.outContains(`Version: ${PMM_VERSION}`);
+    await verifyReportedVersion(output);
   });
 
   /**
@@ -136,7 +154,7 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
   test('run pmm-admin summary --version', async ({}) => {
     const output = await cli.exec('sudo pmm-admin summary --version');
     await output.assertSuccess();
-    await output.outContains(`Version: ${PMM_VERSION}`);
+    await verifyReportedVersion(output);
   });
 
   test('PMM-T1219 - verify pmm-admin summary includes targets from vmagent', async ({}) => {


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4483](https://github.com/Percona-Lab/pmm-submodules/pull/4483) — run [32794472638](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32794472638), check `CLI / Integration tests / CLI / Integration / Generic` (job [97642787657](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32794472638/job/97642787657))
- tests:
  - `cli/tests/generic.spec.ts:109` / `@generic` — "run pmm-admin --version"
  - `cli/tests/generic.spec.ts:136` / `@generic` — "run pmm-admin summary --version"

## What failed

`CLI / Integration / Generic` was the only red check in that run. Both tests failed on the
same assertion, deterministically:

```
Expected substring: "Version: 3.10.0-cursor-mongodb-unused-indexes-dashboard-0faa-2a005bcdd"
Received string:    "ProjectName: pmm-admin
Version: 3.10.0-cursor-mongodb-unused-indexes-dashboard-0faa-7b146773c
PMMVersion: 3.10.0-cursor-mongodb-unused-indexes-dashboard-0faa-7b146773c
Timestamp: 2026-08-25 00:22:35 (UTC)
FullCommit: 698aed175d63fdf74a688a3a65f4fd27c4be8bf4
"
```

The client reports the PR's head commit `7b146773c`; the expectation carries `2a005bcdd`,
an earlier commit on the same PR. This is not specific to #4483 — the run before it
(`db686e3`) failed the same way with the same `2a005bcdd` expectation, and
[#4486](https://github.com/Percona-Lab/pmm-submodules/pull/4486)'s latest run
([32793345517](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32793345517))
has `CLI / Integration / Generic` as its single red check, expecting `86ad073d8` from a
client built at `028ef12`.

## Root cause — our expectation reads the wrong artifact

For a tarball `CLIENT_VERSION`, the suite resolved the expected **client** version from the
**server**:

```ts
PMM_VERSION = JSON.parse(cli.execute('sudo pmm-admin status --json').stdout).pmm_agent_status?.server_version;
```

That assumes the server image and the client tarball sharing an FB tag were built from the
same commit. They need not be: the server side is only rebuilt when its own sources change,
so an image tagged with commit X can carry binaries stamped with an earlier commit Y, while
the client tarball is always stamped with X.

Verified directly against the published artifacts on a throwaway Linode VM — the exact image
digest the failing job recorded with Launchable
(`sha256:8a2d4c25fbeea539be8d9afc8c256bd2082e2c12fb71ab0583949a3dfa229cb3`):

```
$ docker exec pmm-server /usr/sbin/pmm-managed --version      # image tag PR-4483-7b14677
Version:    3.10.0-cursor-mongodb-unused-indexes-dashboard-0faa-2a005bcdd
Timestamp:  2026-08-24 23:52:49 (UTC)
FullCommit: 698aed175d63fdf74a688a3a65f4fd27c4be8bf4

$ pmm-admin --version                                          # tarball pmm-client-PR-4483-7b14677
Version:    3.10.0-cursor-mongodb-unused-indexes-dashboard-0faa-7b146773c
Timestamp:  2026-08-25 00:22:35 (UTC)
FullCommit: 698aed175d63fdf74a688a3a65f4fd27c4be8bf4
```

Same `FullCommit` — the PMM sources are identical between the two commits; only the
pmm-submodules pointer moved (`ci.py` / `ci.yml` edits), so the server artifacts were reused
and only their pmm-submodules stamp is stale. The binaries are the right ones, so there is
no product defect here to report; what is wrong is the test taking the server as an oracle
for the client.

## The fix

Take the expected version from the artifact actually under test. A feature build names its
client tarball after the pmm-submodules commit it was built from, so the reported version is
matched against that commit; RC and dev-latest clients keep resolving exactly as before.

This re-points the assertion rather than loosening it — it still pins the exact build the
client was installed from, and the two permanently-skipped strict-match tests are untouched.

## Verification

Reproduced and fixed on a throwaway Linode VM, following
`.github/workflows/runner-integration-cli-tests.yml`: FB server image
`perconalab/pmm-server-fb:PR-4483-7b14677`, client tarball
`pmm-client-PR-4483-7b14677.tar.gz`, `pmm-framework --database pdpgsql=16 --database ps,ENCRYPTED_CLIENT_CONFIG=true`,
pmm-qa at `main` (e83875b — the commit the failing run used).

| | before | after |
|---|---|---|
| `run pmm-admin --version` | ✗ expected `…-2a005bcdd` | ✓ |
| `run pmm-admin summary --version` | ✗ expected `…-2a005bcdd` | ✓ |

Negative control: re-running with `CLIENT_VERSION=…/pmm-client-PR-4483-deadbee.tar.gz`
fails both tests, so the new assertion is not vacuous.

Full `@generic|@unregister` suite on the same box: `41 passed, 13 skipped, 3 failed`. The
three are pre-existing — they fail identically on unmodified `main` on the same box, and
none was red in the CI run:
`PMM-T1219` and `PMM-T2227` — environment-specific to this repro box (not investigated
further; neither was red in the CI run) — and `run pmm-admin summary --server-url
--server-insecure-tls with https`, which is the 47-vs-48 zip file count already tracked
in #1166.

The assertion is a deterministic string match with no time or data-accumulation component,
so nothing here depends on how long the repro VM had been alive. `npm run lint` (eslint +
`tsc --noEmit`) is clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N3Yy97wvExwtS2bRyUGP2r)_