### PR TITLE
Survive transient jobs-API errors in the nightly wait steps

### DIFF
--- a/.github/workflows/nightly-e2e-tests-matrix.yml
+++ b/.github/workflows/nightly-e2e-tests-matrix.yml
@@ -80,7 +80,14 @@ jobs:
   setup:
     name: "setup / ${{ matrix.shard_name }}"
     strategy:
-      fail-fast: true
+      # Each shard hosts its own databases and pmm-agent on its own runner and
+      # holds them alive for the whole test run. Cancelling the siblings when one
+      # shard fails destroys every monitored service mid-run, so the test jobs
+      # then report "no data" across dashboards, QAN and inventory for databases
+      # that were never broken. Let a failed shard fail alone: only its own
+      # databases go missing, and the test jobs' wait step still aborts cleanly if
+      # a shard dies before they start.
+      fail-fast: false
       matrix:
         include:
           - shard_name: external

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -141,6 +141,9 @@ jobs:
       - name: Waiting for tests execution
         uses: actions/github-script@v7
         with:
+          # Octokit retries 5xx/429 on its own; 4xx stays retry-exempt so a real
+          # auth or permission error still fails fast.
+          retries: 3
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -150,6 +153,14 @@ jobs:
             const timeoutMs = Number(process.env.WAIT_TIMEOUT_SECONDS) * 1000;
             const testPrefix = process.env.TEST_JOB_PREFIX;
             const startedAt = Date.now();
+            // A single transient error from the jobs API used to abort this step
+            // outright: the shard failed, and fail-fast on the setup matrix then
+            // cancelled every sibling shard -- tearing down all monitored services
+            // while the test jobs were still running against them. Tolerate a few
+            // consecutive transient failures instead.
+            const maxConsecutiveApiFailures = 3;
+            const apiFailureBackoffMs = 30000;
+            let consecutiveApiFailures = 0;
 
             async function sleep(ms) {
               return new Promise((resolve) => setTimeout(resolve, ms));
@@ -181,10 +192,23 @@ jobs:
             }
 
             while (true) {
-              const jobs = await listJobs();
-              const testJobs = jobs.filter((job) => job.name.startsWith(testPrefix) || job.name.includes(testPrefix));
-              const detailedTestJobs = await Promise.all(testJobs.map(getJob));
-              const executableTestJobs = detailedTestJobs.filter((job) => Array.isArray(job.steps) && job.steps.length > 0);
+              let executableTestJobs;
+              try {
+                const jobs = await listJobs();
+                const testJobs = jobs.filter((job) => job.name.startsWith(testPrefix) || job.name.includes(testPrefix));
+                const detailedTestJobs = await Promise.all(testJobs.map(getJob));
+                executableTestJobs = detailedTestJobs.filter((job) => Array.isArray(job.steps) && job.steps.length > 0);
+              } catch (error) {
+                consecutiveApiFailures += 1;
+                if (consecutiveApiFailures > maxConsecutiveApiFailures) {
+                  throw error;
+                }
+                core.warning(`Jobs API call failed (${consecutiveApiFailures}/${maxConsecutiveApiFailures}), retrying in ${apiFailureBackoffMs / 1000}s: ${error.message}`);
+                await sleep(apiFailureBackoffMs);
+                continue;
+              }
+              consecutiveApiFailures = 0;
+
               const completedTestJobs = executableTestJobs.filter((job) => job.status === 'completed');
 
               core.info(`Test execution jobs: discovered=${executableTestJobs.length}/${expectedTestJobs}, completed=${completedTestJobs.length}/${expectedTestJobs}`);

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
@@ -169,6 +169,9 @@ jobs:
         if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' }}
         uses: actions/github-script@v7
         with:
+          # Octokit retries 5xx/429 on its own; 4xx stays retry-exempt so a real
+          # auth or permission error still fails fast.
+          retries: 3
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -179,6 +182,12 @@ jobs:
             const setupPrefix = process.env.SETUP_JOB_PREFIX;
             const setupWaitStep = process.env.SETUP_WAIT_STEP;
             const startedAt = Date.now();
+            // A single transient error from the jobs API used to abort this step and
+            // with it the whole test job, even though the setup shards were healthy.
+            // Tolerate a few consecutive transient failures instead.
+            const maxConsecutiveApiFailures = 3;
+            const apiFailureBackoffMs = 30000;
+            let consecutiveApiFailures = 0;
 
             async function sleep(ms) {
               return new Promise((resolve) => setTimeout(resolve, ms));
@@ -228,9 +237,22 @@ jobs:
             }
 
             while (true) {
-              const jobs = await listJobs();
-              const setupJobs = jobs.filter((job) => job.name.startsWith(setupPrefix) || job.name.includes(setupPrefix));
-              const detailedSetupJobs = await Promise.all(setupJobs.map(getJob));
+              let detailedSetupJobs;
+              try {
+                const jobs = await listJobs();
+                const setupJobs = jobs.filter((job) => job.name.startsWith(setupPrefix) || job.name.includes(setupPrefix));
+                detailedSetupJobs = await Promise.all(setupJobs.map(getJob));
+              } catch (error) {
+                consecutiveApiFailures += 1;
+                if (consecutiveApiFailures > maxConsecutiveApiFailures) {
+                  throw error;
+                }
+                core.warning(`Jobs API call failed (${consecutiveApiFailures}/${maxConsecutiveApiFailures}), retrying in ${apiFailureBackoffMs / 1000}s: ${error.message}`);
+                await sleep(apiFailureBackoffMs);
+                continue;
+              }
+              consecutiveApiFailures = 0;
+
               const setupJobsWithWaitStep = detailedSetupJobs.filter(findSetupWaitStep);
               const readySetupJobs = setupJobsWithWaitStep.filter(isWaitingForTests);
               const failedSetupJobs = detailedSetupJobs.filter(setupJobFailed);

--- a/.github/workflows/runner-e2e-tests-playwright-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-playwright-remote-nightly-tests.yml
@@ -169,6 +169,9 @@ jobs:
         if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' }}
         uses: actions/github-script@v7
         with:
+          # Octokit retries 5xx/429 on its own; 4xx stays retry-exempt so a real
+          # auth or permission error still fails fast.
+          retries: 3
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -179,6 +182,12 @@ jobs:
             const setupPrefix = process.env.SETUP_JOB_PREFIX;
             const setupWaitStep = process.env.SETUP_WAIT_STEP;
             const startedAt = Date.now();
+            // A single transient error from the jobs API used to abort this step and
+            // with it the whole test job, even though the setup shards were healthy.
+            // Tolerate a few consecutive transient failures instead.
+            const maxConsecutiveApiFailures = 3;
+            const apiFailureBackoffMs = 30000;
+            let consecutiveApiFailures = 0;
 
             async function sleep(ms) {
               return new Promise((resolve) => setTimeout(resolve, ms));
@@ -228,9 +237,22 @@ jobs:
             }
 
             while (true) {
-              const jobs = await listJobs();
-              const setupJobs = jobs.filter((job) => job.name.startsWith(setupPrefix) || job.name.includes(setupPrefix));
-              const detailedSetupJobs = await Promise.all(setupJobs.map(getJob));
+              let detailedSetupJobs;
+              try {
+                const jobs = await listJobs();
+                const setupJobs = jobs.filter((job) => job.name.startsWith(setupPrefix) || job.name.includes(setupPrefix));
+                detailedSetupJobs = await Promise.all(setupJobs.map(getJob));
+              } catch (error) {
+                consecutiveApiFailures += 1;
+                if (consecutiveApiFailures > maxConsecutiveApiFailures) {
+                  throw error;
+                }
+                core.warning(`Jobs API call failed (${consecutiveApiFailures}/${maxConsecutiveApiFailures}), retrying in ${apiFailureBackoffMs / 1000}s: ${error.message}`);
+                await sleep(apiFailureBackoffMs);
+                continue;
+              }
+              consecutiveApiFailures = 0;
+
               const setupJobsWithWaitStep = detailedSetupJobs.filter(findSetupWaitStep);
               const readySetupJobs = setupJobsWithWaitStep.filter(isWaitingForTests);
               const failedSetupJobs = detailedSetupJobs.filter(setupJobFailed);


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Nightly E2E tests Matrix (remote PMM Server) run 32792180461](https://github.com/percona/pmm-qa/actions/runs/32792180461) (`main` @ `e83875b`) — scheduled, dispatched by Jenkins
- tests: all 60 failures in the run's two CodeceptJS test-execution jobs, i.e. the entirety of
  - `test execution / @nightly` — 26 of 71 failed ([job 97635789596](https://github.com/percona/pmm-qa/actions/runs/32792180461/job/97635789596))
  - `test execution / @qan|@valkey-nightly|@permissions-nightly|@pt-summary-nightly|@pbm-nightly` — 34 of 89 failed ([job 97635789644](https://github.com/percona/pmm-qa/actions/runs/32792180461/job/97635789644))
  - `setup / valkey` — the originating job ([job 97635789714](https://github.com/percona/pmm-qa/actions/runs/32792180461/job/97635789714))

  Spanning `@nightly`, `@dashboards`, `@qan`, `@valkey-nightly`, `@pt-summary-nightly`, `@pbm-nightly`, `@inventory`, `@mongodb-exporter` and `@pmm-ps-replica-integration`. Not a product problem — see below.

## What failed

`setup / valkey`'s `Waiting for tests execution` step died at **00:31:02**, 12 minutes into the test run:

```
RequestError [HttpError]: Server Error
  status: 502,
  url: 'https://api.github.com/repos/percona/pmm-qa/actions/runs/32792180461/jobs?filter=latest&per_page=100'
##[error]Unhandled error: HttpError: Server Error
```

Rate limits were not involved (`x-ratelimit-remaining: 4951`). The step had already polled successfully twice, at 00:10:50 and 00:20:51 — this was a one-off 502 from GitHub's own jobs API.

That single error was enough to take the whole nightly down, through two compounding defects:

1. **The poll loops don't tolerate a transient API error.** All three wait steps — the setup shards' `Waiting for tests execution` and both test jobs' `Wait for all setup jobs to be ready` — `await` the jobs API inside a bare `while (true)` with no `try`/`catch`, and leave `actions/github-script`'s own `retries` at its default of `0` (visible as `retries: 0` in the step's input echo). One error anywhere in an 18-poll, 3-hour window fails the step.

2. **`fail-fast: true` on the `setup` matrix turned one shard's failure into all fourteen.** Every sibling shard was cancelled at 00:31:04, two seconds later. Each shard hosts its own databases and pmm-agent *on its own runner* and holds them alive for the whole run, so cancelling them tore down **every monitored service in the run** while both test-execution jobs kept going until 01:29 and 01:31.

This was the only `fail-fast: true` in the repository; every other matrix already uses `false`, and it has been there since the file was added in #1156.

## Evidence that all 60 failures are that teardown, not a product bug

The failure messages are what a vanished client fleet looks like, across every database family at once:

- `Expected 0 Elements without data but found 132` and equivalents on MySQL, PostgreSQL, MongoDB, Valkey, PXC/Galera, ProxySQL, Patroni, VM Agents and Node dashboards
- `PMM-T554` — `Not all pmm agents are connected`
- `PMM-T2146` — services and nodes reporting `"status":"Failed"`
- every QAN row-selector failing (`//div[@role="row" and contains(@class, "tr-1")] still not present`) — the overview table had no rows to select
- `pt-summary` panels never rendering; `PBM` backup artifacts never appearing

The timeline settles it. Reconstructing per-test wall-clock from the JUnit `time` attributes against each job's step start:

| | first failure | failures before the 00:31:04 cancellation |
|---|---|---|
| `@nightly` | ~00:33:24 (`PMM-T2029`) | **0 of 71** |
| `@qan\|…` | ~00:34:08 (`PMM-T13`) | **0 of 89** |

Both suites ran ~14 minutes completely clean, then began failing within ~2–3 minutes of the teardown — the lag being the tests' own 30–150s waits before giving up. The tests that still pass afterwards are the ones that don't need live client data: settings and inventory pages, and QAN/dashboard checks reading history already scraped before 00:31.

## The fix

**Retry transient errors** in all three poll loops: `retries: 3` on the `github-script` steps (octokit retries 5xx/429; 4xx stays retry-exempt, so a genuine auth or permission error still fails fast), plus a bounded tolerance of 3 consecutive failures with a 30s backoff for anything that still escapes. Only the API fetch sits inside the new `catch` — the loops' real errors (a setup shard failing or cancelled, a shard finishing its wait early, the overall timeout) stay outside it and still fail immediately.

**`fail-fast: false`** on the `setup` matrix, so a failed shard fails alone. A genuinely broken shard now costs only its own databases' tests, which fail truthfully; and if a shard dies before the test jobs finish waiting, their wait step still aborts the run cleanly instead of testing against a dead environment.

## Verification, and what it doesn't cover

This is a GitHub Actions orchestration defect, so there was nothing to reproduce on a Linode VM — a VM cannot host an Actions matrix, and the mechanism is witnessed directly in the run's own logs rather than inferred: the 502 stack trace, the two-second gap to the sibling cancellations, and the unprotected loop in the workflow source at the exact SHA that ran.

What I did verify:

- All four workflows parse as YAML; all three patched scripts pass `node --check`.
- Ran each patched loop against a stubbed jobs API. The setup loop: survives 3 transient 502s then completes normally (**the exact failure in this run**); still throws on a persistent outage; resets its counter between separate bursts; unaffected when healthy. The test-side loop: same, and confirmed a cancelled setup shard and an early-finished wait step both still throw with their original messages rather than being swallowed by the new `catch`.

**What only the next real nightly can confirm:** that the 60 tests pass on a run whose environment survives. Their failures are fully consistent with the teardown and none of them failed in the clean first 14 minutes, but this change fixes the orchestration, not any individual test — if a genuine failure was hiding among them it will surface in the next green-environment run and needs its own investigation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKTF5WRabvLdW1EQWcEXwS)_