### PR TITLE
Take the feature-build client version from the client, not the server

### DIFF
--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -17,9 +17,17 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
 
   let PMM_VERSION = `${process.env.CLIENT_VERSION}`;
   if (/^https?:/.test(PMM_VERSION) || /pmm3-rc/.test(PMM_VERSION)) {
-    // Feature-build / RC clients trail v3 VERSION once an RC branches; take the version from the server.
-    PMM_VERSION = JSON.parse(cli.execute('sudo pmm-admin status --json').stdout).pmm_agent_status?.server_version;
-    if (!PMM_VERSION) throw new Error('Could not read server version from "pmm-admin status --json"');
+    // Feature-build / RC clients trail v3 VERSION once an RC branches, so read the version off the
+    // running client, not off the server: a feature build re-stamps the client tarball on every
+    // pmm-submodules commit but reuses cached server packages while the source is unchanged, so
+    // server_version legitimately names an older commit than the client under test.
+    const status = JSON.parse(cli.execute('sudo pmm-admin status --json').stdout);
+    PMM_VERSION = status.pmm_agent_status?.agent_version;
+    if (!PMM_VERSION) throw new Error('Could not read agent version from "pmm-admin status --json"');
+    const buildCommit = /pmm-client-(?:PR-\d+-)?([0-9a-f]{7,40})\.tar\.gz/.exec(`${process.env.CLIENT_VERSION}`)?.[1];
+    if (buildCommit && !PMM_VERSION.includes(buildCommit)) {
+      throw new Error(`pmm-agent reports ${PMM_VERSION}, which is not the client build under test (${buildCommit})`);
+    }
   } else if (/latest-tarball|3-dev-latest/.test(PMM_VERSION)) {
     // TODO: refactor to use docker hub API to remove file-update dependency
     // See: https://github.com/Percona-QA/package-testing/blob/master/playbooks/pmm2-client_integration_upgrade_custom_path.yml#L41


### PR DESCRIPTION
## Failures fixed (investigator)

- source: Percona-Lab/pmm-submodules PR #4483 — run [32794075374](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32794075374), check `CLI / Integration tests / CLI / Integration / Generic` (job [97641619666](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32794075374/job/97641619666)). Deterministic, not a flake: it failed identically on the next build of the same PR, run [32794472638](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32794472638) (job [97642787657](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32794472638/job/97642787657)).
- tests:
  - `cli/tests/generic.spec.ts:109` / `@generic` — "run pmm-admin --version"
  - `cli/tests/generic.spec.ts:136` / `@generic` — "run pmm-admin summary --version"

## What failed

`CLI / Integration / Generic` was the only red check in that run. Both failures are the same
assertion — the client printing a version that is not the one the test expected:

```
Expected substring: "Version: 3.10.0-cursor-mongodb-unused-indexes-dashboard-0faa-2a005bcdd"
Received string:    "ProjectName: pmm-admin
Version: 3.10.0-cursor-mongodb-unused-indexes-dashboard-0faa-7b146773c
PMMVersion: 3.10.0-cursor-mongodb-unused-indexes-dashboard-0faa-7b146773c
FullCommit: 698aed175d63fdf74a688a3a65f4fd27c4be8bf4
"
  at cli/tests/generic.spec.ts:112:5   (and :139:5)
```

The expected value is not a constant — the spec resolves it at describe time. `CLIENT_VERSION` is
a tarball URL for a feature build, so it takes `pmm_agent_status.server_version` from
`pmm-admin status --json`. In that job the same call returned:

```json
"server_version": "3.10.0-...-0faa-2a005bcdd",
"agent_version":  "3.10.0-...-0faa-7b146773c",
"pmm_admin_version": "3.10.0-...-0faa-7b146773c"
```

So the test compared the client against a version the *server* reported, and the two disagreed.

## Root cause — the oracle, not the product

`2a005bcdd` and `7b146773c` are both pmm-submodules commits on PR #4483. The PR pushed three
builds inside 35 minutes (`2a005bc` at 00:04, `db686e3` at 00:32, `7b14677` at 00:38), and the
whole PR diff is `ci.py` + `ci.yml` — build orchestration only. The `percona/pmm` source under
those three builds never changed: every artifact in all three reports the same
`FullCommit: 698aed175d63fdf74a688a3a65f4fd27c4be8bf4`.

What differs is only the version *stamp*. A feature build re-stamps the client tarball with the
current pmm-submodules commit on every build, but reuses the cached server packages while the
source is unchanged — so those keep the stamp from the build that first produced them. Confirmed
on the image itself (`perconalab/pmm-server-fb:PR-4483-7b14677`, digest `sha256:8a2d4c25…`, the
digest the job pulled):

```
$ docker exec pmm-server /usr/sbin/pmm-managed --version
Version:    3.10.0-cursor-mongodb-unused-indexes-dashboard-0faa-2a005bcdd
Timestamp:  2026-08-24 23:52:49 (UTC)
FullCommit: 698aed175d63fdf74a688a3a65f4fd27c4be8bf4
```

23:52:49 is the `2a005bc` build — roughly 20 minutes before commit `7b14677` existed.

So `server_version == client version` is not an invariant of a feature build; it holds only while
every submodules commit happens to change server source. #1175 introduced this oracle with the
comment "The server under test comes from that same build, so it is the only valid reference for
the client's version" — that assumption is what broke, and this is our test bug, not a PMM defect:
client and server here are the same `percona/pmm` code, differing only in a build stamp.

## Changes

`cli/tests/generic.spec.ts` — for feature/RC builds, read the expected version from the **client**
(`pmm_agent_status.agent_version`, the pmm-agent binary shipped in the tarball under test) instead
of from the server. To keep that from being self-referential, the build id parsed out of the
`CLIENT_VERSION` tarball URL (`pmm-client-PR-4483-7b14677.tar.gz` → `7b14677`) must appear in it,
otherwise the spec throws — so the oracle stays anchored to the artifact actually under test, and
a genuinely mis-installed client is still caught.

Non-feature-build paths (`latest-tarball`, `3-dev-latest`, explicit versions) are untouched.

## Verification

Throwaway Linode VM following `.github/workflows/runner-integration-cli-tests.yml` step for step —
same FB server image `perconalab/pmm-server-fb:PR-4483-7b14677` (digest verified `sha256:8a2d4c25…`),
same client tarball `pmm-client-PR-4483-7b14677.tar.gz`, same
`--database pdpgsql=16 --database ps,ENCRYPTED_CLIENT_CONFIG=true` setup.

The mismatch reproduced exactly, on a freshly provisioned environment:

```
connected  True
server     3.10.0-cursor-mongodb-unused-indexes-dashboard-0faa-2a005bcdd
agent      3.10.0-cursor-mongodb-unused-indexes-dashboard-0faa-7b146773c
```

- **Before** (spec at `main`): both tests fail with the CI error verbatim —
  `Stdout does not contain Version: 3.10.0-…-2a005bcdd`.
- **After** (this branch, environment rebuilt from scratch first):
  `43 passed, 13 skipped` for `@generic|@unregister`, with
  `run pmm-admin --version` and `run pmm-admin summary --version` both green.
- `npm run lint` (eslint + `tsc --noEmit`) clean — 0 errors.

One caveat, stated plainly: in that final full run `PMM-T2227 - Verify tarball upgrade` timed out
at its 30s "Connected after install" poll (line 601) while installing the *latest released* client
into a fresh container — before it reaches any version assertion. Re-run on its own it passes
(`1 passed (21.5s)`), and it also passed in an earlier post-fix full run (`✓ 26.6s`), so it is this
VM being slow on a cold container install, not this change. It was green in the FB run too.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DctT8aaKTrNMqPX9T4yyyh)_