### PR TITLE
Take the expected client version from the client, not the server

### DIFF
--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -15,11 +15,18 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     await result1.outContains('pmm-admin', 'pmm-client is not installed/connected locally, please run pmm3-client-setup script');
   });
 
+  // Commit the client tarball was built from, when CLIENT_VERSION points at a feature build.
+  // It is the only version fact CI states independently of the machine under test.
+  const CLIENT_ARTIFACT_COMMIT = /-([0-9a-f]{7,40})\.tar\.gz$/.exec(`${process.env.CLIENT_VERSION}`)?.[1];
+
   let PMM_VERSION = `${process.env.CLIENT_VERSION}`;
   if (/^https?:/.test(PMM_VERSION) || /pmm3-rc/.test(PMM_VERSION)) {
-    // Feature-build / RC clients trail v3 VERSION once an RC branches; take the version from the server.
-    PMM_VERSION = JSON.parse(cli.execute('sudo pmm-admin status --json').stdout).pmm_agent_status?.server_version;
-    if (!PMM_VERSION) throw new Error('Could not read server version from "pmm-admin status --json"');
+    // Feature-build / RC clients trail v3 VERSION once an RC branches, so the expected version has
+    // to come from the installed client. Not from the server: build-server-rpm restores pmm-server
+    // RPMs from the S3 build cache whenever the PMM sources are unchanged, so a feature-build server
+    // keeps the full_pmm_version of the build that produced them and legitimately lags the client.
+    PMM_VERSION = JSON.parse(cli.execute('sudo pmm-admin status --json').stdout).pmm_admin_version;
+    if (!PMM_VERSION) throw new Error('Could not read client version from "pmm-admin status --json"');
   } else if (/latest-tarball|3-dev-latest/.test(PMM_VERSION)) {
     // TODO: refactor to use docker hub API to remove file-update dependency
     // See: https://github.com/Percona-QA/package-testing/blob/master/playbooks/pmm2-client_integration_upgrade_custom_path.yml#L41
@@ -110,6 +117,9 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     const output = await cli.exec('sudo pmm-admin --version');
     await output.assertSuccess();
     await output.outContains(`Version: ${PMM_VERSION}`);
+    if (CLIENT_ARTIFACT_COMMIT) {
+      await output.outContains(CLIENT_ARTIFACT_COMMIT, `pmm-admin is not the client built from ${process.env.CLIENT_VERSION}`);
+    }
   });
 
   /**
@@ -137,6 +147,9 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     const output = await cli.exec('sudo pmm-admin summary --version');
     await output.assertSuccess();
     await output.outContains(`Version: ${PMM_VERSION}`);
+    if (CLIENT_ARTIFACT_COMMIT) {
+      await output.outContains(CLIENT_ARTIFACT_COMMIT, `pmm-admin is not the client built from ${process.env.CLIENT_VERSION}`);
+    }
   });
 
   test('PMM-T1219 - verify pmm-admin summary includes targets from vmagent', async ({}) => {


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4483](https://github.com/Percona-Lab/pmm-submodules/pull/4483) — run [32833894562](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32833894562), check `CLI / Integration tests / CLI / Integration / Generic` (job [97758402618](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32833894562/job/97758402618))
- tests:
  - `cli/tests/generic.spec.ts:109` / `@generic` — "run pmm-admin --version"
  - `cli/tests/generic.spec.ts:136` / `@generic` — "run pmm-admin summary --version"

## What failed

`CLI / Integration / Generic` was the only red check in that run. Both tests failed on the same
assertion, comparing the client's version against a version string that belongs to the server:

```
Error: Stdout does not contain Version: 3.10.0-cursor-mongodb-unused-indexes-dashboard-0faa-2a005bcdd, !

Expected substring: "Version: 3.10.0-cursor-mongodb-unused-indexes-dashboard-0faa-2a005bcdd"
Received string:    "ProjectName: pmm-admin
Version: 3.10.0-cursor-mongodb-unused-indexes-dashboard-0faa-4bf37bcd5
...
  at cli/tests/generic.spec.ts:112:5
```

Not a flake — deterministic across the last three FB builds on that PR, and the pattern is exact:

| FB build | submodules HEAD | server reports | client reports | Generic |
|---|---|---|---|---|
| [2599](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32792140389) | `2a005bcdd` | `…-2a005bcdd` | `…-2a005bcdd` | ✅ |
| [2601](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32794075374) / [2602](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32794472638) | `7b146773c` | `…-2a005bcdd` | `…-7b146773c` | ❌ |
| [2604](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32833894562) | `4bf37bcd5` | `…-2a005bcdd` | `…-4bf37bcd5` | ❌ |

The server is pinned at the version of the *first* of those builds while the client tracks each push.

## Root cause — the test reads the client's expected version off the server

`cli/tests/generic.spec.ts` resolved `PMM_VERSION` for feature builds from
`pmm-admin status --json` → `pmm_agent_status.server_version`, i.e. from **PMM Server**, and then
asserted that `pmm-admin --version` prints it. That assumes a feature build's server and client
always carry the same version string. They do not.

`build/scripts/build-server-rpm` keys its S3 build cache on the PMM **source** commit, not on the
submodules commit that names the build:

```bash
# prepare_specs(): "the package commit (and thus its S3 cache key) is derived from
# the last commit that touched these paths rather than HEAD. This keeps the cache key
# stable across pushes that don't change them"
...
# is_build_needed(): aws s3 sync s3://pmm-build-cache/PR-BUILDS/${cache_dist}/${spec_name}-${rpm_version} …
```

`full_pmm_version` (`<VERSION>-<branch>-<short sha>`, from `build/scripts/vars`) is baked into the
RPM at build time. When a push changes nothing under the PMM sources, `is_build_needed` restores the
cached RPMs and the rebuild is skipped — so the server keeps the `full_pmm_version` of whichever
build first produced them. The client tarball has no such cache and is rebuilt on every push.

[`4bf37bcd5`](https://github.com/Percona-Lab/pmm-submodules/commit/4bf37bcd5fe40d2eb603dd6db9faeb1f776c2617)
touches only `ci.py`, so this is exactly what happened. Confirmed on the image itself — its OCI label
says `PR-4483-4bf37bc` and it was pushed at 09:47, but its PMM version is stamped 10 hours earlier:

```
$ curl -sk -u admin:admin https://127.0.0.1:8443/v1/server/version
"version": "3.10.0-cursor-mongodb-unused-indexes-dashboard-0faa-2a005bcdd",
"timestamp": "2026-08-24T23:52:49Z"
```

This is the build cache working as designed, so there is nothing to report against PMM or the FB
pipeline — the wrong invariant is ours.

## The fix

Take the expected version from the **client** (`pmm_admin_version`, already in the same JSON the
test parses), not from the server.

On its own that would make the assertion self-referential, so it is anchored to the one version fact
CI states independently of the box under test: the commit in the `CLIENT_VERSION` tarball URL. Both
tests now also require that commit to appear in the reported version, which is what actually proves
`pmm-admin` is the artifact CI asked for. Nothing was loosened.

## Verification

Reproduced and verified on a throwaway Linode VM running the failed run's exact environment —
server `perconalab/pmm-server-fb:PR-4483-4bf37bc`, client tarball `pmm-client-PR-4483-4bf37bc.tar.gz`,
`pmm-framework --database pdpgsql=16 --database ps,ENCRYPTED_CLIENT_CONFIG=true`, following
`runner-integration-cli-tests.yml`:

- **Before** (`main`) — the CI failure, byte for byte: `2 failed`, both on
  `Expected substring: "Version: …-2a005bcdd"` / `Received: "…Version: …-4bf37bcd5"`.
- **After** (this branch) — `2 passed`; full `@generic|@unregister` run: `42 passed, 13 skipped`.
- **The anchor still bites** — pointing `CLIENT_VERSION` at the `2a005bc` tarball while the `4bf37bc`
  client is installed fails as it should:
  `Error: Stdout does not contain 2a005bc, pmm-admin is not the client built from …-2a005bc.tar.gz!`
- `npm run lint` (eslint + tsc): `0 errors`, `Lint OK`.

Two other tests failed on the repro VM — `PMM-T1219` (`unzip: not found`) and `PMM-T2227`
(`No such container: tarball_client`). Both are gaps in my VM, not this change: they fail
identically on `main` in the same environment and both pass in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YH1Xd1HBKkaf7G5HcFYn8z)_