### PR TITLE
Pin the expected client version to the tarball under test

### DIFF
--- a/cli/tests/generic.spec.ts
+++ b/cli/tests/generic.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import * as cli from '@helpers/cli-helper';
 import { getPmmAdminMinorVersion } from '@helpers/pmm-admin';
 import { readZipFile } from '@helpers/zip-helper';
+import ExecReturn from '@support/types/exec-return.class';
 
 const PGSQL_USER = 'postgres';
 const PGSQL_PASSWORD = 'pass+this';
@@ -16,8 +17,15 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
   });
 
   let PMM_VERSION = `${process.env.CLIENT_VERSION}`;
-  if (/^https?:/.test(PMM_VERSION) || /pmm3-rc/.test(PMM_VERSION)) {
-    // Feature-build / RC clients trail v3 VERSION once an RC branches; take the version from the server.
+  // A feature-build tarball is named after the commit it was built from
+  // (pmm-client-PR-4486-b72741a.tar.gz), which is the only reliable reference for the client's
+  // version. The server cannot stand in for it: server RPMs are restored from an S3 cache keyed on
+  // the pmm submodule commit, so they keep the build metadata of whichever feature build first
+  // produced them, while the client tarball is rebuilt on every push.
+  const CLIENT_BUILD_SHA = PMM_VERSION.match(/-([0-9a-f]{7,40})\.tar\.gz$/)?.[1] ?? '';
+  if (!CLIENT_BUILD_SHA && (/^https?:/.test(PMM_VERSION) || /pmm3-rc/.test(PMM_VERSION))) {
+    // An untagged tarball or an RC client trails v3 VERSION once an RC branches; the server it
+    // shipped with is then the closest available reference.
     PMM_VERSION = JSON.parse(cli.execute('sudo pmm-admin status --json').stdout).pmm_agent_status?.server_version;
     if (!PMM_VERSION) throw new Error('Could not read server version from "pmm-admin status --json"');
   } else if (/latest-tarball|3-dev-latest/.test(PMM_VERSION)) {
@@ -26,6 +34,17 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
     PMM_VERSION = cli.execute('curl -s https://raw.githubusercontent.com/Percona-Lab/pmm-submodules/v3/VERSION')
       .stdout.trim();
   }
+
+  const expectClientVersion = async (output: ExecReturn) => {
+    if (!CLIENT_BUILD_SHA) {
+      await output.outContains(`Version: ${PMM_VERSION}`);
+      return;
+    }
+    const versionLine = output.getStdOutLines().find((line) => line.startsWith('Version:'));
+    expect(versionLine, `No "Version:" line in output: ${output.stdout}`).toBeDefined();
+    expect(versionLine, `pmm-admin does not report the client build under test (${CLIENT_BUILD_SHA})`)
+      .toContain(CLIENT_BUILD_SHA);
+  };
 
   test('Verify pt summary for mysql mongodb and pgsql', async ({}) => {
     await test.step('Verify pt summary returns correct exit code', async () => {
@@ -109,7 +128,7 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
   test('run pmm-admin --version', async ({}) => {
     const output = await cli.exec('sudo pmm-admin --version');
     await output.assertSuccess();
-    await output.outContains(`Version: ${PMM_VERSION}`);
+    await expectClientVersion(output);
   });
 
   /**
@@ -136,7 +155,7 @@ test.describe('PMM Client "Generic" CLI tests', { tag: '@generic' }, () => {
   test('run pmm-admin summary --version', async ({}) => {
     const output = await cli.exec('sudo pmm-admin summary --version');
     await output.assertSuccess();
-    await output.outContains(`Version: ${PMM_VERSION}`);
+    await expectClientVersion(output);
   });
 
   test('PMM-T1219 - verify pmm-admin summary includes targets from vmagent', async ({}) => {


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4486](https://github.com/Percona-Lab/pmm-submodules/pull/4486) — run [32833635566](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32833635566), check `CLI / Integration tests / CLI / Integration / Generic` (job [97757610180](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32833635566/job/97757610180))
- tests:
  - `cli/tests/generic.spec.ts:109` / `@generic` — "run pmm-admin --version"
  - `cli/tests/generic.spec.ts:136` / `@generic` — "run pmm-admin summary --version"

## What failed

`CLI / Integration / Generic` was the only red check in that run. Both tests failed on
the same mismatch:

```
Expected substring: "Version: 3.10.0-fix-switch-branch-slash-names-86ad073d8"
Received string:    "ProjectName: pmm-admin
Version: 3.10.0-fix-switch-branch-slash-names-b72741a16
...
```

`b72741a16` is the PR's head commit — the build actually under test. `86ad073d8` is an
earlier commit on the same branch, from **21 Aug**.

## Root cause — a wrong reference in our test, not a product bug

The feature-build branch of the version resolution took the expected client version from
the **server**:

```ts
PMM_VERSION = JSON.parse(cli.execute('sudo pmm-admin status --json').stdout).pmm_agent_status?.server_version;
```

That assumed server and client always carry the same build metadata in a feature build.
They do not, and the reason is deliberate:

- `full_pmm_version` is `<VERSION>-<branch>-<pmm-submodules short sha>`, stamped at compile
  time from the pmm-submodules checkout ([`build/scripts/vars`](https://github.com/percona/pmm/blob/main/build/scripts/vars)).
- Server RPMs are restored from an S3 build cache whose key is derived from the **pmm
  submodule commit**, not from `full_pmm_version` — `prepare_specs()` in
  [`build/scripts/build-server-rpm`](https://github.com/percona/pmm/blob/main/build/scripts/build-server-rpm)
  says so in its own comment: *"This keeps the cache key stable across pushes that don't
  change them, so the package is rebuilt only when the branch actually differs from its
  base in them."*
- The client tarball has no such cache and is rebuilt on every push.

PR #4486 only edits `ci.py`, so its later commits never move the pmm submodule pointer.
Every push therefore reuses the server RPMs first built at `86ad073d8` — carrying that
commit's stamp — while the client tarball is rebuilt and stamped `b72741a16`. Any
pmm-submodules PR that touches build scripts alone hits this.

The binaries themselves are fine and come from the same source: the client reports
`FullCommit: ccca197e22d3ddbeb7a693e2fc7f8ff47e732d95` and the server reports
`managed.full_version: ccca197e22d3ddbeb7a693e2fc7f8ff47e732d95`. Only the cosmetic
version label differs. Nothing to fix in PMM.

## The fix

Match the client against the commit named in **its own tarball URL**
(`pmm-client-PR-4486-b72741a.tar.gz`), which is the artifact actually under test. The
server-derived path is kept only for inputs that don't name a commit (`pmm3-rc`, an
untagged `pmm-client-latest.tar.gz`), where it remains the closest available reference.

This is a tighter check than before, not a looser one: it pins the client to the exact
commit its tarball was built from, instead of to a server that may legitimately carry
different build metadata. Verified by negative control below.

## Verification

Reproduced and fixed on a throwaway Linode VM running the exact inputs from the failed
job (`perconalab/pmm-server-fb:PR-4486-b72741a`, client tarball
`pmm-client-PR-4486-b72741a.tar.gz`, `--database pdpgsql=16 --database ps,ENCRYPTED_CLIENT_CONFIG=true`),
following `.github/workflows/runner-integration-cli-tests.yml`.

**Reproduction** — the pulled image digest matched the one the failed job recorded
(`sha256:ed5a7052…`), and the server it started reported:

```
"version": "3.10.0-fix-switch-branch-slash-names-86ad073d8",
"timestamp": "2026-08-21T21:26:54Z"        <- binaries built 21 Aug, image built 25 Aug
```

while the client from the same build reported `3.10.0-fix-switch-branch-slash-names-b72741a16`.
Running the tests on `main` reproduced both failures with byte-identical error text.

**A/B over the full CI tag** (`@generic|@unregister`), each leg on a freshly restored
server + client registration + databases:

| ref | result |
|-----|--------|
| `main` | **2 failed** (the two above), 42 passed, 13 skipped |
| this branch | **0 failed, 44 passed**, 13 skipped |

**Negative control** — pointing `CLIENT_VERSION` at a different build's tarball
(`pmm-client-PR-4486-86ad073.tar.gz`) while the installed client is `b72741a16` still
fails, as it should:

```
Error: pmm-admin does not report the client build under test (86ad073)
Expected substring: "86ad073"
Received string:    "Version: 3.10.0-fix-switch-branch-slash-names-b72741a16"
```

`cd cli && npm run lint` (eslint + tsc) is clean — 0 errors; the 74 warnings are
pre-existing `playwright/no-skipped-test` ones.

## Notes, not fixed here

Two things surfaced during the investigation that are out of scope for this PR:

1. A feature-build server image tagged `PR-4486-b72741a` reports `…-86ad073d8` internally.
   That is the documented cache behaviour above, and the binaries are correct, but it is
   worth knowing when reading a version off a staging instance.
2. `PMM-T1219` runs `unzip pmm-summary.zip -d pmm-summary-logs` with no `-o`, so it blocks
   forever on the overwrite prompt if the target directory already exists. CI never hits
   this (every run gets a fresh runner), but it hangs local re-runs.