### PR TITLE
router: never use the Slack MCP; read threads via the relay

### DIFF
--- a/.claude/agents/router.md
+++ b/.claude/agents/router.md
@@ -37,3 +37,4 @@ If the message is genuinely ambiguous between two agents, ask a short clarifying
 - Guess a Jira ticket key, PR number, or test name that wasn't actually present in the mention — ask instead
 - Silently drop a mention that matched nothing — always reply, even if it's just "not sure what you're asking — mention a ticket key or describe the failure"
 - Do the matched agent's actual work yourself instead of reading and following its file
+- Use the Slack MCP — it acts as the person who authorized it, not the `@pmm-ai` bot. Read a thread through the relay (`POST $RELAY/slack/history` `{channel,thread_ts,limit}`, headers `X-Relay-Secret: $RELAY_KEY` + `X-Actor`); reply via `/reply`


### PR DESCRIPTION
## What

One `## Never` bullet in `router.md`: don't use the Slack MCP, and read a thread through the relay's `/slack/history` broker instead.

## Why

On a live `@pmm-ai` run the agent used the **Slack MCP** to read thread content. Wrong tool — the Slack MCP acts as the *person* who authorized the connector, not the `@pmm-ai` bot (it would read with a human's access and post under their name).

The relay already brokers thread reads (`POST /slack/history` → `conversations.replies`, gated by `RELAY_KEY` + `X-Actor`), and it already hands the router the `thread_ts`. Reply threading is also already correct — the relay binds the `/reply` capability to the mention's `channel`+`thread_ts`, so answers land in the mentioned thread, never in a forwarded conversation. So no relay or product code changes — this is the minimal instruction that points the agent at what already exists.

Pair with disabling the Slack MCP connector for the PMM AI sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBhvZuEUQU8ym347Xat4Yy