### PR TITLE
investigator: comment back on the FB PR after triaging a red run

### DIFF
--- a/.claude/agents/investigator.md
+++ b/.claude/agents/investigator.md
@@ -80,7 +80,16 @@ Once you have what you're investigating and a ref, use marker `## Failures fixed
 
 ## Relay the result
 
-If a human asked directly (or was routed here via Slack), report back what you found: fixed + PR link, blocked fix + draft PR link (note it's blocked), product-bug + report (no fix), not-a-bug + the correct way to do it, didn't reproduce, or already-in-flight/already-reported. If this ran from a CI/FB trigger payload with nobody waiting synchronously, no further reporting is needed — your PR (or lack of one) is the record.
+Never just produce output and move on — close the loop with whoever is waiting on it.
+
+- **Asked directly (or routed via Slack)** — report back what you found: fixed + PR link, blocked fix + draft PR link (note it's blocked), product-bug + report (no fix), not-a-bug + the correct way to do it, didn't reproduce, or already-in-flight/already-reported.
+- **FB source (a `Percona-Lab/pmm-submodules` PR went red)** — **always** post a brief comment (3–4 sentences) on that PR, via the GitHub MCP `add_issue_comment` (owner `Percona-Lab`, repo `pmm-submodules`, the PR number), so the dev sees their red FB run was actually looked at — not silently triaged. Say what happened, the verdict, and the next step:
+  - **Flaky / didn't reproduce** → the failing test(s) look flaky and didn't reproduce; their PR change isn't implicated; PMM-QA is addressing it (stabilizing/tracking the test).
+  - **pmm-qa test or setup-data bug** → it reproduced, it's a pmm-qa test/setup issue (not their change), here's the fix PR; for a **blocked** fix, the test now expects behavior from `<upstream PR>` not on `main` yet — link the draft PR and note it's expected red until that lands.
+  - **Product bug** → it reproduced as a real PMM/Grafana bug (not a test issue); filed `PMM-XXXX` for a product fix — link it.
+
+  Keep it to those few sentences, and end with the Claude Code attribution footer. If the cross-org comment is refused (the GitHub App lacks write on `Percona-Lab`), say so in your run output so a human can post it — never drop the loop silently.
+- **pmm-qa's own scheduled CI on `main`** — no dev PR to answer; your pmm-qa PR (or lack of one) is the record.
 
 ## Never
 


### PR DESCRIPTION
## What

When Investigator runs from the **FB source** (a `Percona-Lab/pmm-submodules` PR went red), it now **always posts a brief 3–4 sentence comment on that PR** with what happened, the verdict, and the next step — instead of only producing a pmm-qa PR (or nothing) and treating "the PR is the record" as enough.

## Why

Devs whose submodules PR went red saw the FB failure but never heard that it was looked at. The point is to close the loop: they should know their PR's issue was validated, not silently triaged. Critically, that includes the **flaky** case — "the failing test looks flaky, your change isn't implicated, PMM-QA is addressing it" — so a flake still gets an explicit, reassuring reply rather than silence.

## Behavior (`.claude/agents/investigator.md`, "Relay the result")

- **Flaky / didn't reproduce** → say it's flaky, their change isn't implicated, PMM-QA is on it.
- **pmm-qa test / setup-data bug** → reproduced, it's a test/setup issue (not their change), link the fix PR; blocked fixes note the upstream PR + expected-red.
- **Product bug** → reproduced as a real PMM/Grafana bug, filed `PMM-XXXX`, link it.
- Comment posts via GitHub MCP `add_issue_comment` and ends with the Claude Code attribution footer.
- The pmm-qa **scheduled-CI** source is unchanged (no dev PR to answer).

## Note

The comment targets the **pmm-submodules PR** (the one FB Tests ran on and that Investigator is fired with). Posting to `Percona-Lab/*` needs the GitHub App to have write there — the tracked cross-org go-live item; if the comment is refused, Investigator surfaces that so a human can post it rather than dropping the loop. Docs/instructions only — no relay or product code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBhvZuEUQU8ym347Xat4Yy

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBhvZuEUQU8ym347Xat4Yy)_