### PR TITLE
Record the jenkins-pipelines scope rule in the repos skill

### DIFF
--- a/.claude/skills/repos/SKILL.md
+++ b/.claude/skills/repos/SKILL.md
@@ -14,7 +14,24 @@ description: PMM GitHub repository map, GitHub access (MCP-first), and rules for
 | `percona/grafana` | Grafana UI | **No** (read/diff only) |
 | `percona/percona-helm-charts` | Helm charts — `pmm`, `pmm-ha`, `pmm-ha-dependencies` (K8s/HA deploys) | **No** (read/diff only) |
 | `Percona-Lab/pmm-submodules` | FB integration | Different org — see **Cross-org access** below |
-| `Percona-Lab/jenkins-pipelines` | Jenkins defs | Different org — see **Cross-org access** below |
+| `Percona-Lab/jenkins-pipelines` | Jenkins defs | Different org — see **Cross-org access** below. **PMM owns `pmm/` only** — see below |
+
+### jenkins-pipelines is multi-team
+
+Every top-level directory belongs to a different team (`.github/CODEOWNERS`): `ppg`, `ps`, `pxc`,
+`pxb`, `psmdb`, `pbm`, the distributions, `cloud`. **Stay inside `pmm/`** — never edit, lint, gate
+or report on another one, and don't "fix in passing" a problem noticed there.
+
+Two shared libraries, only one of them ours:
+
+- **`vars/` at the repo root** is loaded as `lib@master` by *every* product's builds. Call its
+  steps freely; changing one changes everyone's CI. Raise it with the owners instead.
+- **`pmm/v3/vars/`** is PMM's own, loaded as `v3lib@master` via `libraryPath: 'pmm/v3/'`. This is
+  the right home for a PMM-only step.
+
+PMM pipelines live in `pmm/v3/` (`pmm3-*.groovy`). They only provision and invoke the test
+suites — the test logic itself lives in this repo (`qa-integration/pmm_qa`, `e2e_tests`), which
+they clone at `PMM_QA_GIT_BRANCH` and rsync to `/srv/pmm-qa`.
 
 ## GitHub access — MCP-first
 


### PR DESCRIPTION
+18 lines in `.claude/skills/repos/SKILL.md`. No test or code changes.

## Why

`Percona-Lab/jenkins-pipelines` already has a row in the repo map, but nothing says what an agent needs to know before touching it:

- **Every top-level directory belongs to a different team** (`.github/CODEOWNERS`) — `ppg`, `ps`, `pxc`, `pxb`, `psmdb`, `pbm`, the distributions, `cloud`. PMM owns `pmm/`.
- **There are two shared libraries and only one is ours.** Root `vars/` is loaded as `lib@master` by *every* product's builds, so changing a step there changes everyone's CI. `pmm/v3/vars/` is PMM's own, loaded as `v3lib@master` via `libraryPath: 'pmm/v3/'`.
- The `pmm3-*` pipelines only provision and invoke the suites — the test logic lives in this repo (`qa-integration/pmm_qa`, `e2e_tests`), cloned at `PMM_QA_GIT_BRANCH` and rsynced to `/srv/pmm-qa`.

This is not hypothetical. Working on Percona-Lab/jenkins-pipelines#4366 I built a lint gate over the whole repo — every product's `.groovy` files plus root `vars/` — before being told PMM touches `pmm/` and nothing else. Rewriting it cost a full force-push.

## Why here and not in that repo

I first wrote this as an `AGENTS.md` inside `jenkins-pipelines/pmm/`. That does not work: nested memory files load only once an agent is already reading a file in that directory, which is after the point the scope rule matters. A root-level file there would load, but a root-level file in a repo eight other teams share is exactly the thing this rule says not to do.

This skill loads in every session, from a repo we own outright, before an agent opens anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcEM8jZrmdWWDJH65wxA2D

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcEM8jZrmdWWDJH65wxA2D)_