### PR TITLE
Wait for MySQL to come back instead of sleeping 5s

### DIFF
--- a/qa-integration/pmm_qa/mysql/tasks/prepare_install_mysql.yml
+++ b/qa-integration/pmm_qa/mysql/tasks/prepare_install_mysql.yml
@@ -134,8 +134,6 @@
 - name: Restart MySQL docker container
   shell: docker restart {{ container_prefix }}{{ index }}
 
-# No credentials: mysqladmin ping exits 0 as soon as the server answers, even
-# on Access denied, so this waits for the restart alone.
 - name: Wait for MySQL to accept connections
   shell: docker exec {{ container_prefix }}{{ index }} /usr/local/mysql/bin/mysqladmin ping
   register: mysql_ready

--- a/qa-integration/pmm_qa/mysql/tasks/prepare_install_mysql.yml
+++ b/qa-integration/pmm_qa/mysql/tasks/prepare_install_mysql.yml
@@ -134,9 +134,15 @@
 - name: Restart MySQL docker container
   shell: docker restart {{ container_prefix }}{{ index }}
 
-- name: Wait 5 seconds for MySQL to start
-  pause:
-    seconds: 5
+- name: Wait for MySQL to accept connections
+  shell: >
+    docker exec {{ container_prefix }}{{ index }} mysql --connect-expired-password
+    -uroot -p'{{ mysql_root_password }}' -e "SELECT 1"
+  register: mysql_ready
+  until: mysql_ready.rc == 0
+  retries: 30
+  delay: 2
+  changed_when: false
 
 - name: Change root password + allow root from any host (Percona Server for MySQL 5.7)
   shell: >

--- a/qa-integration/pmm_qa/mysql/tasks/prepare_install_mysql.yml
+++ b/qa-integration/pmm_qa/mysql/tasks/prepare_install_mysql.yml
@@ -134,10 +134,10 @@
 - name: Restart MySQL docker container
   shell: docker restart {{ container_prefix }}{{ index }}
 
+# No credentials: mysqladmin ping exits 0 as soon as the server answers, even
+# on Access denied, so this waits for the restart alone.
 - name: Wait for MySQL to accept connections
-  shell: >
-    docker exec {{ container_prefix }}{{ index }} mysql --connect-expired-password
-    -uroot -p'{{ mysql_root_password }}' -e "SELECT 1"
+  shell: docker exec {{ container_prefix }}{{ index }} /usr/local/mysql/bin/mysqladmin ping
   register: mysql_ready
   until: mysql_ready.rc == 0
   retries: 30


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4545](https://github.com/Percona-Lab/pmm-submodules/pull/4545) — run [32919785512](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32919785512), check `E2E / Alerting and Settings UI tests / e2e tests: @fb-alerting|@fb-settings` (job [98030936252](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32919785512/job/98030936252))
- tests: none — the job died in **setup**, before a single test ran (`launchable record tests` then failed with `FileNotFoundError: 'tests/output/result.xml'`)

## What failed

`@fb-alerting|@fb-settings` was the only red check in that run. The `mysql/mysql-setup.yml`
playbook failed on the task right after the container restart:

```
TASK [Chance root password Percona Server for MySQL 8.0+] ***********************
fatal: [localhost]: FAILED! => {"cmd": "docker exec mysql_pmm_9_7_1 mysql --connect-expired-password -uroot -p'...' -e \"ALTER USER 'root'@'localhost' ...\"",
 "rc": 1,
 "stderr": "ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/tmp/mysql.sock' (2)"}
...
localhost : ok=25 changed=14 unreachable=0 failed=1 skipped=10 rescued=0 ignored=1
ERROR: mysql/mysql-setup.yml playbook execution failed.
```

`ERROR 2002` on the socket means mysqld simply was not listening yet — nothing to do with
PR #4545's QAN search change, and nothing to do with the tests it gates. This is the only FB
job that uses `--database mysql` (upstream MySQL, default 9.7); every `--database ps` job takes
a different playbook, which is why nothing else in that run went red.

## Root cause

`qa-integration/pmm_qa/mysql/tasks/prepare_install_mysql.yml` restarts the whole container and
then guesses how long the restart takes:

```yaml
- name: Restart MySQL docker container
  shell: docker restart {{ container_prefix }}{{ index }}

- name: Wait 5 seconds for MySQL to start
  pause:
    seconds: 5
```

Two things make that budget thin. `docker restart` reports `delta: 0:00:10.5–11.9` in every run
I looked at — the full SIGTERM grace period — so mysqld is **SIGKILLed** and comes back through
InnoDB crash recovery rather than a clean start. And the 5s pause predates the container restart:
it was written for `systemctl restart mysql` (which returns once the service is up) and was
reused as-is when `docker restart` was added in front of it in
[#1038](https://github.com/percona/pmm-qa/pull/1038). The result is a fixed 5-second bet on how
fast the runner is.

## Fix

Poll instead of sleeping:

```yaml
- name: Wait for MySQL to accept connections
  shell: docker exec {{ container_prefix }}{{ index }} /usr/local/mysql/bin/mysqladmin ping
  register: mysql_ready
  until: mysql_ready.rc == 0
  retries: 30
  delay: 2
  changed_when: false
```

`mysqladmin ping` is the standard readiness probe and needs no credentials: it exits 0 as soon as
the server answers, *including* on `Access denied` (documented behaviour, and verified on the VM —
`ping` with a bogus password → `rc=0`, `ping` with mysqld stopped → `rc=1`). That matters here
because root's initial password is still expired at this point: my first attempt probed with
`mysql -e "SELECT 1"` and it never went green, because an expired password puts the session in
sandbox mode and the `SELECT` comes back `ERROR 1820`. `mysqladmin` is not symlinked into `PATH`
by either install branch, hence the full `/usr/local/mysql/bin/` path — the same path in the 5.7
and the 8.0+ tarball layouts. Nothing else in `qa-integration/` uses this restart-then-sleep
pattern.

Assertions are untouched; this only fixes the setup.

## Verification

Throwaway Linode VM, PMM Server from this FB build (`perconalab/pmm-server-fb:PR-4545-f56da1b`),
the same `pmm-framework --database mysql` the job runs, FB client tarball.

- **Before the fix**, at `main` — 3 full setup runs, all green: on a stock 6-vCPU box, on the same
  box saturated with `stress-ng --cpu 24`, and with 4 of 6 CPUs offlined to mimic a 2-core GitHub
  runner. So the red run did **not** reproduce as red here. What did reproduce is the mechanism:
  `docker restart` took 10.5s (SIGKILL) in every run, and a restart→reachable measurement loop
  came back at **1.4s** on 6 cores and **1.6–2.4s** on 2 — i.e. this box lands inside the 5s
  budget, and the GitHub runner landed outside it.
- **After the fix**, fresh setup on the same box, 2 cores: the first `mysqladmin ping` **failed**
  (`FAILED - RETRYING … (30 retries left)`) and the second succeeded — so the loop genuinely
  engaged, mysqld was not up when the old code would have connected — and the playbook finished
  `EXIT=0`, `failed=0`.

What this does not prove: that the exact GitHub-runner timing is gone, since it never went red
here. What the fix removes is the fixed budget itself — the wait is now bounded by mysqld being
reachable (up to 60s) rather than by a guess. Only the next real FB/nightly run on a slow runner
can confirm the recurrence is gone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjF4YrMUcEKvmLMspBqDr5)_