### PR TITLE
PMM-14109 Check the Advisors tooltip on the Advisors tab

### DIFF
--- a/codeceptjs-e2e/tests/configuration/pages/pmmSettingsPage.js
+++ b/codeceptjs-e2e/tests/configuration/pages/pmmSettingsPage.js
@@ -681,6 +681,11 @@ module.exports = {
         tooltips: {
           dataRetention: this.tooltips.advancedSettings.dataRetention,
           telemetry: this.tooltips.advancedSettings.telemetry,
+        },
+      },
+      {
+        subPage: this.advisorsSettingsUrl,
+        tooltips: {
           stt: this.tooltips.advancedSettings.stt,
         },
       },


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4478](https://github.com/Percona-Lab/pmm-submodules/pull/4478) — run [32995232794](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32995232794), check `E2E / Alerting and Settings UI tests / e2e tests: @fb-alerting|@fb-settings` (job [98262608187](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32995232794/job/98262608187))
- tests:
  - `codeceptjs-e2e/tests/configuration/verifyPMMSettingsPageFunctionality_test.js:247` / `@fb-settings` — PMM-T1227 + PMM-T1338 "Verify tooltip Read more links on PMM Settings page redirect to working pages"

## Base branch

This PR targets **`PMM-14109-improve-advisor-ux`** (PR #1083), not `main`. The failure only
exists on that branch paired with the PMM-14109 server build: on `main` the Advisors settings
still live on the Advanced tab and the current mapping is correct, so the same change against
`main` would break the test there. Merging this into #1083 is what turns the FB check green.

## What failed

`@fb-alerting|@fb-settings` was the only red check in that run — 45 passed, 1 failed:

```
element (Advisors tooltip) still not visible after 10 sec
locator.waitFor: Timeout 10000ms exceeded.
Call log:
  - waiting for locator('[data-testid=advisors-label-description]').first() to be visible
    at async verifyReadMoreLink (tests/configuration/pages/pmmSettingsPage.js:605:28)
    at async Object.verifyTooltip (tests/configuration/pages/pmmSettingsPage.js:616:9)
```

Not flaky — the scenario carries `.retry(3)` on top of the suite's `.retry(1)` and still failed.

## Root cause — a stale subpage mapping in this branch, not a product bug

percona/pmm#5656 moves the Advisor settings out of **Advanced settings** into a dedicated
**Advisors** tab: `Settings.tsx` renders `<AdvisorsForm/>` only when `tab === 'advisors'`
(`/settings/advisors`), and `AdvisorsForm.tsx` is the sole owner of the `advisors-label`
field whose description carries `data-testid="advisors-label-description"`.

This branch already followed that move everywhere else — the locator rename
(`$advanced-advisors-label-description` → `$advisors-label-description`), `advisorsSettingsUrl`,
`openAdvisorsSettings()`, the `advisors` tab entry, the split-out "Verify Advisors Section
Elements" scenario. The one place left behind is `getSubpageTooltips()`, which still lists the
Advisors (`stt`) tooltip under `advancedSettingsUrl`:

```js
{
  subPage: this.advancedSettingsUrl,
  tooltips: {
    dataRetention: …,
    telemetry: …,
    stt: this.tooltips.advancedSettings.stt,   // <- renders on /settings/advisors now
  },
},
```

PMM-T1227 walks that map, so it looked for the Advisors tooltip on the Advanced tab, where the
element no longer exists.

## Changes

`codeceptjs-e2e/tests/configuration/pages/pmmSettingsPage.js` — give the `stt` tooltip its own
`advisorsSettingsUrl` subpage entry instead of leaving it under Advanced settings.
`getSubpageTooltips()` has exactly one consumer (PMM-T1227), so nothing else is affected; the
tooltip's expected text and `https://per.co.na/advisors` link are unchanged and match
`Settings.messages.ts` on percona/pmm#5656.

## Verification

Throwaway Linode VM, FB server image `perconalab/pmm-server-fb:PR-4478-1cb361d` (the exact
image the failing run used, `3.10.0-PMM-14109-improve-advisor-ux-1cb361d43`), same
`pr.codecept.js` invocation as `runner-e2e-tests-codeceptjs.yml`:

- **Before** (branch `PMM-14109-improve-advisor-ux` as-is): `0 passed, 1 failed` — same
  assertion, same locator, same step trace as CI.
- **After** (this branch, synced onto the same VM): `1 passed` in 19s.
- Regression check — every `@fb-settings` scenario in that spec file:
  `PMM-T747 ✔, PMM-T841 ✔, PMM-T1227 ✔, PMM-T1967 skipped` → `3 passed, 1 skipped`.

The `@fb-alerting` half of the check and the other `@fb-settings` specs were green in CI both
before and after and are untouched by this change; the next FB run on #4478 is what confirms
the whole check end to end.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDzDSPsRrkqh6eWD3t4Kho)_