### PR TITLE
Wait for the first low-resolution scrape in the psmdb setup

### DIFF
--- a/qa-integration/pmm_psmdb-pbm_setup/configure-agents.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/configure-agents.sh
@@ -2,6 +2,7 @@
 set -e
 
 source "$(dirname "${BASH_SOURCE[0]}")/wait-for-pmm-agent.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/wait-for-metrics.sh"
 
 pmm_mongo_user=${PMM_MONGO_USER:-pmm}
 pmm_mongo_user_pass=${PMM_MONGO_USER_PASS:-pmmpass}
@@ -52,6 +53,7 @@ DEBUG_FLAG=""
 
 random_number=$RANDOM
 nodes="rs101 rs102 rs103"
+declare -A added_services=()
 for node in $nodes
 do
     echo "configuring pmm agent on $node"
@@ -63,6 +65,7 @@ do
       echo
       docker compose -f docker-compose-rs.yaml exec -T $node pmm-admin add mongodb --enable-all-collectors --agent-password=mypass --environment=psmdb-dev --cluster=replicaset --replication-set=rs "${client_credentials_flags[@]}" --host=${node} --port=27017 ${node}${gssapi_service_name_part}_${random_number}
     fi
+    added_services[$node]="${node}${gssapi_service_name_part}_${random_number}"
 done
 echo
 echo "adding some data"
@@ -86,3 +89,14 @@ db.students.insertMany([
 
 db.createView( 'firstYears', 'students', [{ \$match: { year: 1 } }]);
 EOF
+
+echo
+echo "waiting for the first low-resolution scrape of the mongodb exporters"
+for node in "${!added_services[@]}"
+do
+    # An arbiter holds no data, so dbstats never reports for it.
+    if [[ $mongo_setup_type == "psa" && $node == "rs103" ]]; then
+      continue
+    fi
+    wait_for_dbstats_metrics docker-compose-rs.yaml "$node" "${added_services[$node]}"
+done

--- a/qa-integration/pmm_psmdb-pbm_setup/wait-for-metrics.sh
+++ b/qa-integration/pmm_psmdb-pbm_setup/wait-for-metrics.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# The dbstats, collstats and indexstats collectors ride PMM's low-resolution scrape job
+# (60s by default), so `pmm-admin add` returning does not mean their metrics exist yet --
+# the first low-resolution scrape lands up to a full interval later, and the vmagent
+# remote-write flush after it. Dashboard tests start within seconds of setup finishing,
+# so wait for the first sample here instead of leaving every such test to race it.
+#
+# Bounded and non-fatal on purpose: if the metrics never arrive that is a real "PMM
+# collects nothing here" signal, and the test that asserts on those panels must still be
+# the thing that reports it.
+wait_for_dbstats_metrics() {
+    local compose_file=$1 node=$2 service=$3 timeout=${4:-180}
+    local deadline=$((SECONDS + timeout))
+
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        if docker compose -f "$compose_file" exec -T -e SVC="$service" "$node" bash -c \
+            'curl -sk -u "$PMM_AGENT_SERVER_USERNAME:$PMM_AGENT_SERVER_PASSWORD" \
+               --data-urlencode "query=count(mongodb_dbstats_dataSize{service_name=\"$SVC\"})" \
+               "https://$PMM_AGENT_SERVER_ADDRESS/prometheus/api/v1/query"' \
+            2>/dev/null | grep -q '"result":\[{'; then
+            echo "mongodb_dbstats_* metrics present for ${service}"
+            return 0
+        fi
+        sleep 5
+    done
+
+    echo "WARNING: no mongodb_dbstats_* metrics for ${service} after ${timeout}s" >&2
+    return 0
+}


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4474](https://github.com/Percona-Lab/pmm-submodules/pull/4474) — run [32990399909](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32990399909), check `E2E / MongoDB Exporter tests / e2e tests: @mongodb-exporter` (job [98246373631](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32990399909/job/98246373631))
- tests:
  - `codeceptjs-e2e/tests/verifyMongodbDashboards_test.js:60` / `@mongodb-exporter` — PMM-T1333 "Verify MongoDB - MongoDB Collections Overview"

## What failed

`@mongodb-exporter` was the only red check in that run (1 of 48). PMM-T1333 failed on the
final assertion of the MongoDB Collections Overview dashboard:

```
Expected 2 Elements without data but found 7 on Dashboard .../mongodb-collections-overview
Report Names are Top 5 Databases By Size, Indexes in Database (All),
Avg Object Size in Database (All), Index Size in Database (All), Data Size for Database (All),
Top 5 Hottest Collections by Read (Rate), Top 5 Hottest Collections by Write (Rate)
```

The test tolerates 2 empty panels, so the excess is exactly **five** panels — and all five are
the ones backed by `mongodb_dbstats_*`. The Playwright trace from the failing job shows why:
every `mongodb_dbstats_*` query came back empty, while every `mongodb_top_*` query returned
data.

```
avg by(database) (topk(5, mongodb_dbstats_dataSize{...service_name=~"rs101_1275"}))
  -> {"results":{"A":{"status":200,"frames":[]}}}
sum(mongodb_dbstats_indexes{...service_name=~"rs101_1275"})
  -> {"results":{"A":{"status":200,"frames":[]}}}
count(mongodb_top_commands_time{...service_name=~"rs101_1275"})
  -> 748 bytes of frames
```

## Root cause — the setup returns before the low-resolution scrape has happened

`mongodb_dbstats_*` rides PMM's **low-resolution** scrape job, not the high-resolution one
(`managed/services/victoriametrics/scrape_configs.go` puts `dbstats`, `indexstats`, `collstats`,
`fcv`, `pbm`, `shards`, `currentopmetrics` on `lr`; only `diagnosticdata`, `replicasetstatus`
and `topmetrics` are on `hr`). The default LR interval is **60s**
(`managed/models/settings.go`). So `pmm-admin add` returning tells you nothing about whether a
dbstats sample exists yet — the first one lands anywhere up to a full interval later.

The failing job's timing lines up exactly. From the job's step timestamps and `pmm-managed.log`:

| Time | Event |
|---|---|
| 16:52:37 | `Run Setup for E2E Tests` starts |
| 16:56:40 / 16:56:43 / 16:56:47 | `pmm-admin add mongodb` for rs101 / rs102 / rs103 — the last seconds of setup |
| 16:56:48 | setup step ends, test step starts |
| ~16:57:22 | PMM-T1333 takes its snapshot of empty panels (**~T+35s**) |

`configure-agents.sh` registers the agents, generates data, and returns; the workflow starts the
tests immediately. The assertion itself is a single instantaneous count with no retry
(`dashboardPage.js` → `verifyThereAreNoGraphsWithoutData`), so it either beats the first
low-resolution scrape or it does not.

Measured directly on a throwaway Linode VM running the FB build
`perconalab/pmm-server-fb:PR-4474-fa8979d` with the matching client tarball and the same
`--database psmdb` setup — time from `pmm-admin add mongodb --enable-all-collectors` to the
first `mongodb_dbstats_dataSize` sample reaching VictoriaMetrics, across 8 registrations:

```
19s  20s  30s  35s  40s  55s  64s  80s
```

The test asserts ~35-45s after the setup returns, right in the middle of that spread. That is
why this check is red some runs and green others, and why it gets *less* reliable the faster the
runner is.

## Not a product bug, and not a stale assertion

Both ruled out on that same VM and FB image:

- `mongodb_dbstats_dataSize` is collected normally — 15 series (5 databases × 3 services) once
  the LR scrape has come round, so the FB build's dbstats collector is fine.
- PMM-T1333 **passes** unchanged against that environment once the data has landed
  (`Number of no data and N/A elements is = 0`).

## The fix

New `qa-integration/pmm_psmdb-pbm_setup/wait-for-metrics.sh`, wired into
`configure-agents.sh` after the agents are registered and the data is generated: poll PMM until
`mongodb_dbstats_dataSize` exists for each service the setup just added, then return. It sits
next to the existing `wait-for-pmm-agent.sh`, which covers the same class of gap one step
earlier in the same script.

The assertion is untouched — the tolerated-empty count stays at 2. The wait is bounded (180s)
and **non-fatal**: if the metrics genuinely never arrive, the setup warns and continues so the
test that asserts on those panels is still the thing that reports it, rather than the signal
being swallowed by a green setup.

The psa arbiter (`rs103`) is skipped — it holds no data, so dbstats never reports for it, the
same exclusion the script already makes for its pbm agent.

## Verification

All on a Linode VM with the failing run's own FB build (server image
`perconalab/pmm-server-fb:PR-4474-fa8979d`, client tarball `pmm-client-PR-4474-fa8979d.tar.gz`),
`--database psmdb`, PMM-T1333 driven by `codeceptjs run -c pr.codecept.js --grep PMM-T1333`.

**Before** — services registered fresh, test run immediately (the CI condition), first dbstats
sample landed at T+80s:

```
I say "Number of no data and N/A elements is = 5"
Expected 2 Elements without data but found 5 ... Report Names are
Top 5 Databases By Size, Indexes in Database (All), Avg Object Size in Database (All),
Index Size in Database (All), Data Size for Database (All)
FAIL | 0 passed, 1 failed
```

The same five dbstats panels CI reported, and the exact size of CI's excess over the tolerance.

**After** — same sequence with the wait in place:

```
registered at 18:37:52
mongodb_dbstats_* metrics present for rs101_93002
mongodb_dbstats_* metrics present for rs102_93002
mongodb_dbstats_* metrics present for rs103_93002
setup wait: 73s, setup returns at 18:39:05
test starts 18:39:05
I say "Number of no data and N/A elements is = 0"
OK | 1 passed
```

**Full setup path, freshly provisioned** — `pmm-framework --database psmdb` re-run end to end
from this branch (`docker compose down -v` + rebuild, new services `rs*_7546`), so the wait ran
inside the real `configure-agents.sh` rather than being sourced by hand. Its output is the
setup's final action in the setup log:

```
+ echo 'waiting for the first low-resolution scrape of the mongodb exporters'
mongodb_dbstats_* metrics present for rs101_7546
mongodb_dbstats_* metrics present for rs102_7546
mongodb_dbstats_* metrics present for rs103_7546
+ return 0
```

and PMM-T1333 against that environment:

```
var-service_name=rs101_7546
I say "Number of no data and N/A elements is = 0"
OK | 1 passed
```

### What this does not prove

- The two `(Rate)` panels that made up the rest of CI's 7 sit inside the existing tolerance of
  2 and were not reproduced separately; they are a young-data artifact of the same window
  (`rate()` needs two samples) and this change does not target them.
- The wait cost is one LR interval at most, once per psmdb setup — 47s and 73s in the two runs
  above. The next real FB/nightly run is what confirms the added wall-clock is acceptable in CI
  and that the check stays green across runs.
- Only `configure-agents.sh` (the `rs101-rs103` replica set) is wired up. `configure-extra-agents.sh`
  (`rs201-rs203`, the `extra` profile) has the same shape and would benefit from the same wait;
  it runs after this one, so its services already get some of the interval for free. Left out to
  keep this to the failing path.


---
_Generated by [Claude Code](https://claude.ai/code/session_011zkf5D4RrXw3F7baPG66nZ)_