### PR TITLE
Wait for both mongodb_exporter scrape jobs in PMM-T1333

### DIFF
--- a/codeceptjs-e2e/tests/pages/dashboardPage.js
+++ b/codeceptjs-e2e/tests/pages/dashboardPage.js
@@ -1312,7 +1312,7 @@ module.exports = {
     while (currentIteration++ <= timeoutInSeconds) {
       numberOfNAElements = await I.grabNumberOfVisibleElements(this.fields.reportTitleWithNA);
 
-      if (numberOfNAElements < acceptableNACount) {
+      if (numberOfNAElements <= acceptableNACount) {
         return;
       }
 

--- a/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
+++ b/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
@@ -63,12 +63,6 @@ Scenario(
   }) => {
     const mongoService = await inventoryAPI.getServiceDetailsByPartialDetails({ cluster: 'replicaset', service_name: 'rs101' });
 
-    // Wait for the service's metrics before loading the dashboard, not after: Grafana
-    // resolves $database and $replication_set once, at page load, and never re-resolves
-    // them on refresh, so a dashboard opened before the first scrape keeps empty
-    // variables - and empty panels - for the rest of the test. mongodb_dbstats_* needs
-    // its own wait because PMM collects it on the exporter's low-resolution (1m) job,
-    // up to a minute behind the 5s job every other panel here reads.
     await grafanaAPI.waitForMetric('mongodb_top_commands_count', { type: 'service_name', value: mongoService.service_name }, 120);
     await grafanaAPI.waitForMetric('mongodb_dbstats_dataSize', { type: 'service_name', value: mongoService.service_name }, 120);
 

--- a/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
+++ b/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
@@ -59,9 +59,18 @@ Scenario(
 Scenario(
   'PMM-T1333 - Verify MongoDB - MongoDB Collections Overview @mongodb-exporter @nightly @gssapi-nightly',
   async ({
-    I, dashboardPage, inventoryAPI, adminPage,
+    I, dashboardPage, inventoryAPI, adminPage, grafanaAPI,
   }) => {
     const mongoService = await inventoryAPI.getServiceDetailsByPartialDetails({ cluster: 'replicaset', service_name: 'rs101' });
+
+    // Wait for the service's metrics before loading the dashboard, not after: Grafana
+    // resolves $database and $replication_set once, at page load, and never re-resolves
+    // them on refresh, so a dashboard opened before the first scrape keeps empty
+    // variables - and empty panels - for the rest of the test. mongodb_dbstats_* needs
+    // its own wait because PMM collects it on the exporter's low-resolution (1m) job,
+    // up to a minute behind the 5s job every other panel here reads.
+    await grafanaAPI.waitForMetric('mongodb_top_commands_count', { type: 'service_name', value: mongoService.service_name }, 120);
+    await grafanaAPI.waitForMetric('mongodb_dbstats_dataSize', { type: 'service_name', value: mongoService.service_name }, 120);
 
     I.amOnPage(
       I.buildUrlWithParams(dashboardPage.mongoDbCollectionsOverview.clearUrl, {
@@ -74,10 +83,7 @@ Scenario(
     dashboardPage.waitForDashboardOpened();
     await adminPage.performPageDown(5);
     await dashboardPage.verifyMetricsExistence(dashboardPage.mongoDbCollectionsOverview.metrics);
-    // The Datasize panels read mongodb_dbstats_*, which PMM scrapes on the exporter's
-    // low-resolution (1m) job, so on a freshly registered service their first sample can
-    // land up to a minute after the 5s panels on the same dashboard already have data.
-    await dashboardPage.waitForGraphsToHaveData(2, 120);
+    await dashboardPage.waitForGraphsToHaveData(2, 60);
   },
 );
 

--- a/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
+++ b/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
@@ -74,7 +74,10 @@ Scenario(
     dashboardPage.waitForDashboardOpened();
     await adminPage.performPageDown(5);
     await dashboardPage.verifyMetricsExistence(dashboardPage.mongoDbCollectionsOverview.metrics);
-    await dashboardPage.verifyThereAreNoGraphsWithoutData(2);
+    // The Datasize panels read mongodb_dbstats_*, which PMM scrapes on the exporter's
+    // low-resolution (1m) job, so on a freshly registered service their first sample can
+    // land up to a minute after the 5s panels on the same dashboard already have data.
+    await dashboardPage.waitForGraphsToHaveData(2, 120);
   },
 );
 


### PR DESCRIPTION
## Failures fixed (investigator)

- source: [Percona-Lab/pmm-submodules#4474](https://github.com/Percona-Lab/pmm-submodules/pull/4474) — run [32990399909](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32990399909), check `E2E / MongoDB Exporter tests / e2e tests: @mongodb-exporter` (job [98283651400](https://github.com/Percona-Lab/pmm-submodules/actions/runs/32990399909/job/98283651400))
- tests:
  - `codeceptjs-e2e/tests/verifyMongodbDashboards_test.js:59` / `@mongodb-exporter` — PMM-T1333 "Verify MongoDB - MongoDB Collections Overview"

## What failed

`@mongodb-exporter` was the only red check in that run (all 47 others green). One actionable
failure, nothing quarantined:

```
Expected 2 Elements without data but found 5 on Dashboard .../d/mongodb-collections-overview?from=now-5m&...
Report Names are Top 5 Databases By Size, Indexes in Database (All), Avg Object Size in Database (All),
Index Size in Database (All), Data Size for Database (All)
```

Those five panels are exactly the five on the dashboard that read `mongodb_dbstats_*`. Every
other panel — all `mongodb_top_*` — had data, which the failure screenshot confirms.

## Root cause: the test races the scrape it asserts on

PMM splits the mongodb_exporter into two scrape jobs (`managed/services/victoriametrics/scrape_configs.go`),
confirmed on the client's own vmagent config:

| job | interval | collectors | panels on this dashboard |
| --- | --- | --- | --- |
| `mongodb_exporter_<id>_hr` | **5s** | diagnosticdata, replicasetstatus, topmetrics | 8 panels (`mongodb_top_*`) |
| `mongodb_exporter_<id>_lr` | **1m** | dbstats, indexstats, collstats | 5 panels (`mongodb_dbstats_*`) |

The test asserted on empty panels the instant the dashboard rendered. From the run's own
Playwright trace, the first `mongodb_top_*` sample landed at **18:52:20** — one second before
the psmdb setup step reported OK, four before CodeceptJS started — and the assertion fired at
**18:53:05**, 45s later. All five dbstats queries came back with no series at all:

```json
{"expr":"sum(mongodb_dbstats_indexes{database=~\"(admin|config|local|students|test)\",service_name=~\"rs101_7523\"})"}
-> {"results":{"A":{"status":200,"frames":[]}}}
```

vmagent staggers a new target's first scrape within its interval, so on a freshly registered
service the 1m job can produce nothing for up to a minute while the 5s job is already 9 samples
in. Measured across five setup cycles on a throwaway VM with this PR's server/client images, the
dbstats lag behind the 5s job was **1s, 11s, 15s, 20s and 41s** — and >45s in the failing CI run.

Two things kept this hidden until now:

- pmm-qa's own nightly runs the whole spec file, so minutes of other scenarios elapse before
  PMM-T1333 opens the dashboard. It was green on `main` the same morning.
- On FB the Launchable subset selected **only** this scenario (6 skipped), so it ran immediately
  after setup.

## Why the fix waits *before* the page load

Waiting after the dashboard is open is not enough, and a run on the VM showed why: Grafana
resolves `$database`, `$collection` and `$replication_set` once, at page load, from
`mongodb_top_commands_count` / `mongodb_mongod_replset_my_state`, and never re-resolves them on
refresh. A dashboard opened before the service's first scrape keeps *empty* variables — and empty
panels — for the whole test: that run sat there for 3 minutes and failed with **12** empty panels,
not 5.

So the fix waits for both scrape jobs through the API (`grafanaAPI.waitForMetric`, the same
helper `inventoryAPI` already uses) before `I.amOnPage`, then keeps the panel check.

**The tolerated-empty-panel count stays at 2.** Raising it to 5 would have made the test green
while switching off a real "PMM shows no data here" signal.

Second commit also fixes `waitForGraphsToHaveData`: its loop exited only when the count was
strictly *below* the acceptable one, while its own final assertion accepts `<=`. It therefore
burned the entire timeout on every run where exactly the acceptable number of panels was empty.
Same verdict as before, reached as soon as it is true.

## Verified

On a throwaway Linode VM with this run's FB images
(`perconalab/pmm-server-fb:PR-4474-fa8979d`, matching client tarball), driving the same steps as
`runner-e2e-tests-codeceptjs.yml` — fresh server + `pmm-framework --database psmdb`, then the
scenario started the instant setup returned, which is the window CI hits:

| environment | code | result |
| --- | --- | --- |
| services 6.7 min old (warm) | `main` | PASS — the test is fine once the data exists |
| dashboard opened before any metric existed | post-load wait only | FAIL, 12 empty panels — waiting after page load does not help |
| test started the instant setup returned; HR at +5s, dbstats at +15s | **this PR** | **PASS** in 52s, both waits visibly engaging |
| test started the instant setup returned; dbstats only 11s behind HR | `main` | PASS (`no data elements = 0`) — the lucky half of the coin flip |

That last row is the point: `main` is not reliably red in the tight window, it is a race. The
dbstats lag has to exceed the ~40s the scenario spends scrolling panels before it asserts, which
is what happened in CI (>45s) and did not on that cycle (11s). In the healthy state the dashboard
reports **0** empty panels, so the tolerance of 2 was never the binding constraint — the five
dbstats panels are the whole failure.

What only the next real FB / nightly run can confirm: the other 9 callers of
`waitForGraphsToHaveData` (`@service-account`, `@rbac`, `pmm_ps_replica_integration`) are not
exercised here — the VM had psmdb only. The `<=` change cannot turn a passing assertion into a
failing one (the post-loop assertion is unchanged and already accepts `<=`); it only stops the
wait earlier.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3NWHtnuS7ZactH8ysFk58)_