### PR TITLE
Wait out a stalled dashboard instead of failing after 5s

### DIFF
--- a/codeceptjs-e2e/tests/pages/dashboardPage.js
+++ b/codeceptjs-e2e/tests/pages/dashboardPage.js
@@ -1191,24 +1191,36 @@ module.exports = {
     I.waitForVisible(this.annotationText(title), 30);
   },
 
+  // Grafana mounts a panel only once it intersects the viewport, so page down
+  // until it shows up rather than a fixed number of times. grabNumberOfVisibleElements
+  // carries no deadline of its own, so a dashboard that stalls the renderer delays the
+  // check instead of failing it.
+  async scrollToGraph(graphLocator, maxPageDowns = 40) {
+    for (let i = 0; i <= maxPageDowns; i++) {
+      if (await I.grabNumberOfVisibleElements(graphLocator) > 0) break;
+
+      I.pressKey('PageDown');
+      I.wait(1);
+    }
+
+    I.waitForElement(graphLocator, 30);
+    I.scrollTo(graphLocator);
+  },
+
   async verifyMetricsExistence(metrics) {
     I.click(this.fields.reportTitle);
     await adminPage.performPageDown(5);
     I.waitForElement(this.graphsLocator(metrics[0]), 60);
     for (const i in metrics) {
-      I.pressKey('PageDown');
       await this.expandEachDashboardRow();
-      I.waitForElement(this.graphsLocator(metrics[i]), 5);
-      I.scrollTo(this.graphsLocator(metrics[i]));
+      await this.scrollToGraph(this.graphsLocator(metrics[i]));
     }
   },
 
   async verifyMetricsExistencePartialMatch(metrics) {
     for (const i in metrics) {
-      I.pressKey('PageDown');
       await this.expandEachDashboardRow();
-      I.waitForElement(this.graphsLocatorPartialMatch(metrics[i]), 5);
-      I.scrollTo(this.graphsLocatorPartialMatch(metrics[i]));
+      await this.scrollToGraph(this.graphsLocatorPartialMatch(metrics[i]));
     }
   },
 


### PR DESCRIPTION
## Failures fixed (investigator)

- source: nightly CI run [33025886298](https://github.com/percona/pmm-qa/actions/runs/33025886298) — `Nightly E2E tests Matrix (remote PMM Server)` #282 on `main`, job [`test execution / @nightly`](https://github.com/percona/pmm-qa/actions/runs/33025886298/job/98366973319)
- tests:
  - `codeceptjs-e2e/tests/dashboards/verifyPostgresqlDashboards_test.js:84` / `@nightly @dashboards` — PMM-T2048 "Verify PostgreSQL Instances Overview Extended metrics"

## What failed

`test execution / @nightly` was the only red job in that run — 70 passed, 1 failed, 44 skipped,
and `launchable gate` confirmed nothing was quarantined (`Quarantined (Ignored) | 0`,
`Actionable Failures | 1`). One assertion:

```
element ([data-testid*="data-testid Panel header"][data-testid*="Top 5 Deleted Tuples Rate"])
  still not present on page after 5 sec
locator.waitFor: Timeout 5000ms exceeded.
  at async Object.verifyMetricsExistencePartialMatch (tests/pages/dashboardPage.js:1209:7)
```

## Root cause — the panel was there; the page had stopped painting

Not a missing panel, and not a PMM regression. From the run's own Playwright trace
(`artifacts_@nightly` → `trace/…PMM-T2048….failed.zip`):

| t (trace ms) | what |
|---|---|
| 1531449 | `keyboardPress` — the loop's blind `PageDown` for this metric |
| 1531890 | **last screencast frame** — after a steady ~20 ms cadence |
| 1532144 | iframe DOM snapshot still carries `data-testid="data-testid Panel header Top 5 Deleted Tuples Rate"` (`data-viz-panel-key: panel-131`) |
| 1533274 | the failing `waitForSelector` starts |
| ~1538274 | 5 s elapsed → failure |
| 1541454 | **next screencast frame** — 9.6 s after the last one |

The DOM snapshots taken during and after the wait are fully-referenced
(`[[3, 858]]`, `[[4, 858]]`) — byte-identical to the one that contains the panel — so the
element never left the DOM. The page simply stopped repainting for 9.6 s straight after the
`PageDown`, and the selector query never got to run inside the 5 s it was given. The failure
screenshot is pixel-identical to the screencast frame at 1531890, which is the same thing seen
from the other side.

That run's renderer was under load throughout: 18 repaint gaps over 1.5 s, one of 4.0 s, before
the 9.6 s one. 5 s was inside the noise.

The panel itself is fine. On the exact image the nightly ran
(`perconalab/pmm-server:3-dev-latest`, digest `sha256:11e321d9…`, the same digest Launchable
recorded for that session), Grafana serves the dashboard with 102 panels including
`Top 5 Deleted Tuples Rate` and `Deleted Tuples Rate`.

## Why the helper is exposed to this

`verifyMetricsExistence` / `verifyMetricsExistencePartialMatch` asserted each panel with a fixed
5 s after pressing `PageDown` exactly once. These dashboards are `preload: false`, so Grafana
mounts a panel only when it intersects the viewport (`LazyLoader` in `@grafana/scenes`, used by
`DashboardGridItemRenderer`). One blind viewport-sized jump per metric therefore asserts against
whatever the app happens to have mounted, on a 5 s deadline.

## The fix

Page down until the panel is actually there, bounded at 40, then assert with 30 s.
`grabNumberOfVisibleElements` carries no deadline of its own, so a stalled renderer now delays
the check instead of failing it, and no panel can be paged past unrendered. On the common path
the panel is already rendered, so this scrolls **less** than before, not more.

## Verification

- Reproduced the environment on a throwaway Linode VM: same server image digest, `pdpgsql` +
  `pgsql` via the unmodified `pmm-framework`, tests run in
  `mcr.microsoft.com/playwright:v1.62.1-noble` (the Chromium build CI uses — `151.0.7922.34`),
  1 worker.
- PMM-T2048 did **not** reproduce: 5/5 green on `main` (4 pinned to `--cpus=2 --memory=7g` to
  match a GitHub `ubuntu-22.04` runner, 1 unconstrained).
  Expected — the trace shows a load-dependent stall, not a deterministic defect.
- With the fix: PMM-T2048 3/3 green, and the whole PostgreSQL dashboards suite gives the
  **same result on the fix branch and on `main`** — 5 passed / 2 failed either way, the same two
  (PMM-T2051, PMM-T2053), both `Expected 0 Elements without data` because this VM has no
  `pdpgsql-patroni` shard. Both passed in the nightly, so they are an artefact of the repro
  environment, not of this change. It is also faster: PMM-T2048 took **153 s** in-suite against
  **268 s** on `main`, and 3 m against 4 m standalone — the helper scrolls less than it used to.

Only the next nightly can confirm the failure is gone for good — a stall this change is meant to
survive is exactly what would not show up on a quiet VM. What is verified here is that the
assertion no longer carries a 5 s deadline, that the suite behaves identically to `main`, and
that it runs faster.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqfzFkRjZ5kBDY5uFQFhkW)_