### PR TITLE
Fix the @claude push path, and make the reviewer post threads

### DIFF
--- a/.claude/skills/qa-code-review/SKILL.md
+++ b/.claude/skills/qa-code-review/SKILL.md
@@ -5,7 +5,7 @@ description: Review an open pull request in percona/pmm-qa — Playwright and Co
 
 # QA code review
 
-Reviews an **open PR in `percona/pmm-qa`**. Its only output is review threads, plus a summary comment when one is warranted (section 5); it never opens, edits, pushes to, approves or merges a PR.
+Reviews an **open PR in `percona/pmm-qa`**. Its output is review threads, plus a summary comment in the narrow cases section 6 allows; it never opens, edits, pushes to, approves or merges a PR.
 
 ## 1. Read the checks, never run the PR's tooling
 
@@ -45,9 +45,32 @@ A path with no reference gets section 3 and nothing more. Say that in the summar
 11. **A method with one caller does not need to exist.** Called exactly once → inline it at the call site and delete it. Applies to page-object methods, helpers, API-class methods and const files alike. Reuse that is only planned is not reuse. 🟡
 12. **No methods in a test file.** A test file holds tests. Behaviour belongs in a page object or a helper, whichever is more coherent for it — never declared next to the tests. This does not conflict with 11: 11 says do not create the abstraction when there is one caller, 12 says where it lives once it has earned existing. 🟡
 13. **`private` is a smell.** In practice a private method exists to carve out one extra step that a single method with an internal branch would have covered. A new `private` needs a stated reason; without one, ask for it to be folded into its caller. Dropping an existing `private` is a move in the right direction, not a finding. 🟡
-14. **Code comments get reduced, not reworded.** Every comment in the diff justifies itself or goes. Delete a comment that restates the code, narrates what a step is *not* doing, or banners a section. What survives: a non-obvious invariant, a workaround with its Jira link, a contract a caller cannot infer — one line each. 🟡
 
-## 4. Severity
+## 4. Comments in the diff
+
+**This is the check that slips.** Comments read as harmless next to a correct diff, so they get waved through — and the debt lands in the file forever. Reviewing them is not optional and not a nitpick to mention in passing: read every added or edited comment line, and every one that should not exist gets its **own thread**, 🟡. Never soften one to 🔵 and never let it ride on "the change itself is fine".
+
+A comment stays only if it carries what the code cannot:
+
+- a non-obvious invariant
+- a workaround, with the reason or Jira link that explains why it exists
+- a contract a caller cannot infer from the signature
+
+One or two lines each is the budget. Anything longer is describing a decision, and a decision belongs in the PR body or the commit message, where it is searchable and does not age in the file.
+
+Everything else is a finding:
+
+| Delete | Why |
+|---|---|
+| Restates the line below it | the code already said that |
+| Narrates what a step is *not* doing, or why an alternative was rejected | belongs in the commit message |
+| Banners a section or a file | structure is not documentation |
+| An explanation of mechanism longer than the change it sits on | PR body |
+| Reworded rather than removed in response to earlier feedback | the ask was to cut it |
+
+Accuracy does not earn a comment its place — a true comment that restates the code still goes. Match the density of the file being edited; a file that carries no comments is telling you what it wants.
+
+## 5. Severity
 
 | | Means |
 |---|---|
@@ -55,20 +78,24 @@ A path with no reference gets section 3 and nothing more. Say that in the summar
 | 🟡 **Should fix** | Real defect or convention break, not merge-stopping by itself. |
 | 🔵 **Nit** | Preference, or pre-existing debt this PR only brushes against. |
 
-## 5. Output
+## 6. Output
 
-- One thread per finding, anchored at the exact `file:line`.
+**The threads are the review.** Every finding is a thread; the summary is an exception, not a wrapper around them.
+
+- One thread per finding, anchored at the exact `file:line`. A finding about a file outside the diff still gets a thread whenever a line the PR *does* touch can carry it — anchor it there and name the other file in the body.
 - Thread body: the claim in one sentence, then why it matters, then the concrete change. Lead with the emoji.
 - Post each thread with `confirmed: true` where the tool takes it. Without it the comment is buffered and classified once the session ends, and a real finding can be dropped as a probe.
-- No summary comment when the threads already say everything. The threads are the review; a comment restating them is noise.
+- **Never count anything.** No tally of findings, no counts per severity, no "N issues found". A count exists only to head a summary, so writing one talks you into posting a summary you did not need.
+- Never restate a thread, list the files you read, walk through the diff, or report a check that passed. None of that is the review.
 - Nothing found at all: the whole summary is `LGTM!` — as a comment, never an approval. The one thing that goes with it is a gap section 1 or 2 left: no gate covers the diff, no reference covers a path. Clean checks that do cover the diff are worth no words.
 - Nothing of your own, but open threads you agree with: one sentence in each of those threads, and no summary comment at all.
-- Otherwise post one only for what has no line to anchor to: a finding about the body or the scope, a bot verdict with no file, a gate that misses the diff. Five lines at most, one of them the counts per severity. Never a walkthrough, a file table, or a restatement of a thread.
+- Otherwise post a summary only for what no line in the diff can carry: a finding about the body or the scope, a bot verdict with no file, a gate that misses the diff. Three sentences at most, and only the finding — never the author's reasoning confirmed back to them.
 - Use `gh pr comment --edit-last --create-if-none`, so a later run replaces the summary instead of adding another. Where no summary is warranted and an earlier run left one, edit that comment down to a single line saying nothing is outstanding — an edit, not a new comment. Touch no comment but your own.
 
-## 6. Never
+## 7. Never
 
 - Never approve, merge, push, or edit the PR's files.
 - Never post findings before section 1 has run.
 - Never raise a formatting nit a linter owns.
+- Never let an added comment through unread (section 4).
 - Never soften a rule to let a PR pass; say it is a Blocker and why.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,8 +25,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,6 +37,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          # This job runs an agent over PR-controlled content; nothing here pushes.
+          persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,12 +30,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
-          # checkout v6 persists the workflow GITHUB_TOKEN as an extraheader pulled in
-          # via `includeIf.gitdir`. The action tries to strip it but looks under
-          # `include.path`, so the header survives and outranks the app-token remote URL
-          # the action sets: pushes authenticate as github-actions[bot] and 403. Dropping
-          # it leaves the app token as the only credential, and its pushes -- unlike
-          # GITHUB_TOKEN's -- still trigger the E2E matrix on the new commit.
+          # The persisted GITHUB_TOKEN outranks the app-token remote URL the action sets,
+          # so leaving it here makes every push authenticate as github-actions[bot].
           persist-credentials: false
 
       - name: Run Claude Code

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -30,6 +30,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
+          # checkout v6 persists the workflow GITHUB_TOKEN as an extraheader pulled in
+          # via `includeIf.gitdir`. The action tries to strip it but looks under
+          # `include.path`, so the header survives and outranks the app-token remote URL
+          # the action sets: pushes authenticate as github-actions[bot] and 403. Dropping
+          # it leaves the app token as the only credential, and its pushes -- unlike
+          # GITHUB_TOKEN's -- still trigger the E2E matrix on the new commit.
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## What

`@claude` cannot push from `.github/workflows/claude.yml`. On [#1246](https://github.com/percona/pmm-qa/pull/1246) it did the requested work, committed locally, and then failed with `remote: Permission to percona/pmm-qa.git denied to github-actions[bot]` — so the review it had just implemented had to be applied by hand.

Two causes, both fixed here.

## Why

### 1. The job declared `contents: read`

No push rights at all. The action documents `contents` / `pull-requests` / `issues` as `write` for a workflow where Claude commits ([setup.md](https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md), [faq.md](https://github.com/anthropics/claude-code-action/blob/main/docs/faq.md)). Raised to match.

### 2. The push was not using the app token at all

This is the part that `contents: write` alone does not fix. From the [failing job's log](https://github.com/percona/pmm-qa/actions/runs/33102924585):

- `actions/checkout` v6.0.3 writes the workflow `GITHUB_TOKEN` to a separate credentials file and wires it in as `http.https://github.com/.extraheader` through **`includeIf.gitdir:…path`**:
  ```
  git config --local includeIf.gitdir:/home/runner/work/pmm-qa/pmm-qa/.git.path …/git-credentials-….config
  ```
- The action tries to strip that header, but looks for it under **`include.path`** (`src/github/operations/git-config.ts:87`). It found nothing and said so:
  ```
  Removing existing git authentication headers...
  No existing authentication headers to remove
  Updating remote URL with authentication...
  ```
- It then set an app-token remote URL — but the surviving `extraheader` outranks the URL's userinfo, so git authenticated as `github-actions[bot]` rather than `claude[bot]`. Hence the error naming `github-actions[bot]` even though `App token successfully obtained` appears earlier in the same log.

`persist-credentials: false` removes that credential, leaving the app token as the only one. This also matters beyond the 403: a push made with `GITHUB_TOKEN` **does not trigger workflows**, so had we only raised the permission, Claude's commits would land with no `E2E tests Matrix` run. Pushes from `claude[bot]` (a GitHub App installation token) do trigger it.

The pre-auth `git fetch origin <branch>` the action runs before configuring git auth is unauthenticated with this setting — fine here, `percona/pmm-qa` is public.

## Also here

**`claude-code-review.yml` drops its persisted credential too.** An earlier revision of this PR argued it was out of scope because that job only comments and never pushes. That answers the 403 but not the exposure: the job checks out PR-controlled content and runs an agent over it, with `GITHUB_TOKEN` left readable in `.git/config` for that content. It is exactly why `lint.yml:24-30` already sets `persist-credentials: false`, with a comment saying so. The token is read-only there, so this is hygiene rather than a hole — but the previous scope note read as if the question were settled, and it was not.

**The reviewer skill (`qa-code-review`) posts threads, not summaries.** Two failures, both visible on this PR:

- It posted zero review threads and one summary comment. `SKILL.md` asked for *"counts per severity"*, and a count only has a place at the head of a summary — so the rule kept talking the reviewer into writing one even when the finding could have been a thread. Counting is now forbidden outright, the threads are stated to *be* the review, and a finding about a file outside the diff anchors to whichever line the PR does touch.
- It let a six-line comment block through this diff without a word, in a repo whose house style is minimal comments. That check existed, but as item 14 of a fourteen-item list. It is now its own section with what earns a comment its place, and softening the finding is forbidden.

That second one applies to this PR: the `claude.yml` comment is cut from six lines to two, with the mechanism where it belongs — here in the body.

## Validation

- `actionlint` clean on both workflows.
- Workflow parses; `permissions` and the `checkout` `with:` block resolve as intended.
- The diagnosis is read off the failing run's own log, not inferred: the `includeIf.gitdir` config lines, the `No existing authentication headers to remove` message, and `App token successfully obtained` are all in run [33102924585](https://github.com/percona/pmm-qa/actions/runs/33102924585).

End-to-end proof needs a merge: the action validates the workflow server-side and skips on PRs that change it (*"expected … on PRs with workflow changes"*), so `@claude` will not answer on this PR. First real test is an `@claude` mention on a normal PR after merge.

## Upstream

The `include.path` vs `includeIf.gitdir` mismatch looks like a genuine bug in `claude-code-action` against `actions/checkout` v6 — worth reporting there. This PR is the repo-side workaround.


---
_Generated by [Claude Code](https://claude.ai/code)_