### PR TITLE
PMM-15031 Guard the PMM logo in Grafana email templates

### DIFF
--- a/e2e_tests/tests/api/emailTemplates.test.ts
+++ b/e2e_tests/tests/api/emailTemplates.test.ts
@@ -2,15 +2,12 @@ import { expect } from '@playwright/test';
 import pmmTest from '@fixtures/pmmTest';
 import GrafanaHelper from '@helpers/grafana.helper';
 
-// PMM-15031: every Percona-branded Grafana email template renders one shared mjml
-// header partial, so the single logo URL in it is a whole-product dependency on a
-// host nobody in PMM owns. The rebranding deleted the percona.com product-logo file
-// and silently broke the logo in every PMM email at once.
+const ABSOLUTE_IMAGE_SRC = /<img\b[^>]*\bsrc="(https?:\/\/[^"]+)"/g;
+// PMM-15031: the rebranding deleted this file, and the logo vanished from every PMM email.
 const REMOVED_LOGO_URL =
   'https://www.percona.com/wp-content/uploads/product-logos/PMM-logo-horizontal-400-dark-text.png';
-// The templates Grafana ships with the Percona header. alert_notification.html and
-// alert_notification_example.html are deliberately absent: they are legacy-alerting
-// leftovers that were never rebranded and still carry a grafana.com logo.
+// alert_notification.html and alert_notification_example.html are excluded on purpose: they are
+// legacy-alerting leftovers that were never rebranded and still carry a grafana.com logo.
 const BRANDED_TEMPLATES = [
   'invited_to_org',
   'new_user_invite',
@@ -23,58 +20,32 @@ const BRANDED_TEMPLATES = [
   'welcome_on_signup',
 ];
 
-const headerLogoUrl = (templateName: string, html: string): string => {
-  const firstAbsoluteImage = [...html.matchAll(/<img\b[^>]*\bsrc="(https?:\/\/[^"]+)"/g)][0];
-
-  expect(firstAbsoluteImage, `${templateName}.html should carry a header logo <img>`).toBeDefined();
-
-  return firstAbsoluteImage[1];
-};
-
-// Tagged @alerting so it runs on the FB job that already boots a plain PMM server —
-// ng_alert_notification.html, the email PMM itself sends most, is one of the templates
-// asserted here.
-pmmTest(
-  'PMM-T2285 - Verify the PMM logo in every Grafana email template resolves to a real image @alerting',
-  async ({ request }) => {
-    const logoUrls = new Set<string>();
-
-    for (const templateName of BRANDED_TEMPLATES) {
-      await pmmTest.step(`${templateName}.html points at a logo that still exists`, async () => {
-        const response = await request.get(`graph/public/emails/${templateName}.html`, {
-          headers: GrafanaHelper.getAuthHeader(),
-        });
-
-        expect(
-          response.status(),
-          `Reading email template ${templateName}.html returned ${response.status()}`,
-        ).toBe(200);
-
-        const logoUrl = headerLogoUrl(templateName, await response.text());
-
-        expect(
-          logoUrl,
-          `${templateName}.html still points at the percona.com product-logo URL removed by the rebranding`,
-        ).not.toBe(REMOVED_LOGO_URL);
-
-        logoUrls.add(logoUrl);
+for (const templateName of BRANDED_TEMPLATES) {
+  pmmTest(
+    `PMM-T2285 - ${templateName} email template logo resolves to a real image @alerting`,
+    async ({ request }) => {
+      const template = await request.get(`graph/public/emails/${templateName}.html`, {
+        headers: GrafanaHelper.getAuthHeader(),
       });
-    }
 
-    for (const logoUrl of logoUrls) {
-      await pmmTest.step(`${logoUrl} serves an image`, async () => {
-        const response = await request.get(logoUrl);
+      expect(template.status(), `Reading ${templateName}.html`).toBe(200);
 
-        expect(response.status(), `Fetching the email logo returned ${response.status()}`).toBe(200);
+      const logoUrls = [...(await template.text()).matchAll(ABSOLUTE_IMAGE_SRC)].map(([, url]) => url);
 
-        // Not redundant with the status assertion: docs.percona.com answers a missing
-        // asset with its 404 *page* under HTTP 200, so only the content type tells a
-        // published logo apart from a broken link that a mail client renders as a gap.
-        expect(
-          response.headers()['content-type'],
-          `The email logo URL served "${response.headers()['content-type']}" instead of an image`,
-        ).toMatch(/^image\//);
-      });
-    }
-  },
-);
+      expect(logoUrls, `${templateName}.html carries no absolute <img> src`).not.toHaveLength(0);
+
+      const [logoUrl] = logoUrls;
+
+      expect(logoUrl, `${templateName}.html still points at the URL the rebranding removed`).not.toBe(
+        REMOVED_LOGO_URL,
+      );
+
+      const logo = await request.get(logoUrl);
+
+      expect(logo.status(), `Fetching ${logoUrl}`).toBe(200);
+      // docs.percona.com serves a missing asset as its 404 page under HTTP 200, so only the content
+      // type tells a published logo apart from the gap a mail client would render.
+      expect(logo.headers()['content-type'], `${logoUrl} served a non-image`).toMatch(/^image\//);
+    },
+  );
+}

--- a/e2e_tests/tests/api/emailTemplates.test.ts
+++ b/e2e_tests/tests/api/emailTemplates.test.ts
@@ -1,0 +1,80 @@
+import { expect } from '@playwright/test';
+import pmmTest from '@fixtures/pmmTest';
+import GrafanaHelper from '@helpers/grafana.helper';
+
+// PMM-15031: every Percona-branded Grafana email template renders one shared mjml
+// header partial, so the single logo URL in it is a whole-product dependency on a
+// host nobody in PMM owns. The rebranding deleted the percona.com product-logo file
+// and silently broke the logo in every PMM email at once.
+const REMOVED_LOGO_URL =
+  'https://www.percona.com/wp-content/uploads/product-logos/PMM-logo-horizontal-400-dark-text.png';
+// The templates Grafana ships with the Percona header. alert_notification.html and
+// alert_notification_example.html are deliberately absent: they are legacy-alerting
+// leftovers that were never rebranded and still carry a grafana.com logo.
+const BRANDED_TEMPLATES = [
+  'invited_to_org',
+  'new_user_invite',
+  'ng_alert_notification',
+  'passwordless_verify_existing_user',
+  'passwordless_verify_new_user',
+  'reset_password',
+  'signup_started',
+  'verify_email',
+  'welcome_on_signup',
+];
+
+const headerLogoUrl = (templateName: string, html: string): string => {
+  const firstAbsoluteImage = [...html.matchAll(/<img\b[^>]*\bsrc="(https?:\/\/[^"]+)"/g)][0];
+
+  expect(firstAbsoluteImage, `${templateName}.html should carry a header logo <img>`).toBeDefined();
+
+  return firstAbsoluteImage[1];
+};
+
+// Tagged @alerting so it runs on the FB job that already boots a plain PMM server —
+// ng_alert_notification.html, the email PMM itself sends most, is one of the templates
+// asserted here.
+pmmTest(
+  'PMM-T2285 - Verify the PMM logo in every Grafana email template resolves to a real image @alerting',
+  async ({ request }) => {
+    const logoUrls = new Set<string>();
+
+    for (const templateName of BRANDED_TEMPLATES) {
+      await pmmTest.step(`${templateName}.html points at a logo that still exists`, async () => {
+        const response = await request.get(`graph/public/emails/${templateName}.html`, {
+          headers: GrafanaHelper.getAuthHeader(),
+        });
+
+        expect(
+          response.status(),
+          `Reading email template ${templateName}.html returned ${response.status()}`,
+        ).toBe(200);
+
+        const logoUrl = headerLogoUrl(templateName, await response.text());
+
+        expect(
+          logoUrl,
+          `${templateName}.html still points at the percona.com product-logo URL removed by the rebranding`,
+        ).not.toBe(REMOVED_LOGO_URL);
+
+        logoUrls.add(logoUrl);
+      });
+    }
+
+    for (const logoUrl of logoUrls) {
+      await pmmTest.step(`${logoUrl} serves an image`, async () => {
+        const response = await request.get(logoUrl);
+
+        expect(response.status(), `Fetching the email logo returned ${response.status()}`).toBe(200);
+
+        // Not redundant with the status assertion: docs.percona.com answers a missing
+        // asset with its 404 *page* under HTTP 200, so only the content type tells a
+        // published logo apart from a broken link that a mail client renders as a gap.
+        expect(
+          response.headers()['content-type'],
+          `The email logo URL served "${response.headers()['content-type']}" instead of an image`,
+        ).toMatch(/^image\//);
+      });
+    }
+  },
+);


### PR DESCRIPTION
> [!WARNING]
> Draft — this is dependent on https://github.com/percona/pmm/pull/5829 and https://github.com/percona/grafana/pull/921. **The test fails on `main` today and will keep failing until the docs asset is actually published.** Do not merge before then; see [Why this is a draft](#why-this-is-a-draft).

Adds `PMM-T2285`, a regression test for [PMM-15031](https://perconadev.atlassian.net/browse/PMM-15031).

## What broke

Every Percona-branded Grafana email template renders one shared mjml header partial, so the single logo URL in it is a whole-product dependency on a host nobody in PMM owns. The rebranding deleted `https://www.percona.com/wp-content/uploads/product-logos/PMM-logo-horizontal-400-dark-text.png`, and the logo vanished from nine email templates at once. Nothing in CI noticed, and nothing would have: the templates are static files nobody asserts on, and a broken remote image renders as an empty gap rather than an error.

## What the test does

One test per template — nine in total. Each reads its template off the running server (`graph/public/emails/<name>.html`), takes the first absolute `<img src>`, asserts it is not the URL the rebranding removed, then fetches it and requires **HTTP 200 and a `content-type` of `image/*`**.

The content-type assertion is the load-bearing one. `docs.percona.com` serves a missing asset as its 404 *page* under **HTTP 200**, so a status check alone calls a broken logo healthy:

```
$ curl -sSL -o /dev/null -w '%{http_code} %{content_type} %{url_effective}\n' \
    https://docs.percona.com/percona-monitoring-and-management/assets/pmm-logo-email.png
200 text/html; charset=utf-8 https://docs.percona.com/percona-monitoring-and-management/3/404.html
```

`alert_notification.html` and `alert_notification_example.html` are excluded on purpose: legacy-alerting leftovers that were never rebranded and still carry a grafana.com logo.

## Why this is a draft

The fix is split across two open PRs — percona/pmm#5829 publishes `pmm-logo-email.png` to the docs site, percona/grafana#921 repoints the templates at it. Neither is merged, and the asset is not live, so the test correctly fails right now. Merging it before the asset deploys would turn the `alerting` FB job red for everyone.

The control that proves it is only this one file, and not the hosting approach: `assets/pmm-logo.png`, a sibling in the same docs folder, serves `200 image/png` at exactly the URL shape the templates use.

## Reachability

Tagged `@alerting`, an existing tag already wired to the `alerting` job in `fb-e2e-suite.yml`, which boots a plain PMM server (`setup_services: '-h'`) — no workflow change needed. `npx playwright test --list --grep @alerting` shows all nine.

## Verification

Manual QA ran on a throwaway Linode VM: PMM `3.10.0-v3-97091abda` with a MailHog SMTP catcher, sending real org-invite, alert-notification and password-reset emails. All three branches of the test were exercised live rather than reasoned about:

| Server state | Result |
|---|---|
| Stock 3.10.0 | fails on the removed percona.com URL |
| PR 921 templates, live docs URL | fails on `content-type: text/html` |
| PR 921 templates, a published asset URL | passes |

`npm run lint` (eslint + `tsc --noEmit`) passes.

## Follow-up, not addressed here

The templates use the **unversioned** docs path, which `mike` 301-redirects to the current default version (`/3/` today). When PMM 4 docs become the default that redirect moves to `/4/`, and every PMM 3 email breaks unless the asset is carried into the PMM 4 tree. Raised on percona/grafana#921 rather than worked around in the test — this test would catch it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFr1s2N1cZvLUN3od54azU)_

[PMM-15031]: https://perconadev.atlassian.net/browse/PMM-15031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ