### PR TITLE
Give PMM Server a tolerant healthcheck in the external ClickHouse compose

### DIFF
--- a/codeceptjs-e2e/docker-compose-clickhouse.yml
+++ b/codeceptjs-e2e/docker-compose-clickhouse.yml
@@ -34,7 +34,7 @@ services:
       test: [ "CMD", "curl", "-f", "http://127.0.0.1:8080/v1/server/readyz" ]
       interval: 5s
       timeout: 3s
-      retries: 40
+      retries: 10
       start_period: 60s
 
   pmm-client:

--- a/codeceptjs-e2e/docker-compose-clickhouse.yml
+++ b/codeceptjs-e2e/docker-compose-clickhouse.yml
@@ -28,11 +28,8 @@ services:
       - PMM_CLICKHOUSE_DATABASE=pmm
       - PMM_CLICKHOUSE_ADDR=external-clickhouse:9000
       - PMM_ENABLE_INTERNAL_PG_QAN=1
-    # PMM Server's own image healthcheck allows ~37s (start-period 25s, 3 x 4s)
-    # before it flags the container unhealthy, but a cold start needs longer than
-    # that. Compose aborts `up` the moment a service_healthy dependency turns
-    # unhealthy, so pmm-client below would fail on a slow runner. Same override as
-    # cli/test-setup/docker-compose-scrape-intervals.yml.
+    # The image healthcheck gives up before a cold PMM Server answers readyz,
+    # which aborts `up` for the service_healthy dependents below.
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://127.0.0.1:8080/v1/server/readyz" ]
       interval: 5s

--- a/codeceptjs-e2e/docker-compose-clickhouse.yml
+++ b/codeceptjs-e2e/docker-compose-clickhouse.yml
@@ -28,6 +28,17 @@ services:
       - PMM_CLICKHOUSE_DATABASE=pmm
       - PMM_CLICKHOUSE_ADDR=external-clickhouse:9000
       - PMM_ENABLE_INTERNAL_PG_QAN=1
+    # PMM Server's own image healthcheck allows ~37s (start-period 25s, 3 x 4s)
+    # before it flags the container unhealthy, but a cold start needs longer than
+    # that. Compose aborts `up` the moment a service_healthy dependency turns
+    # unhealthy, so pmm-client below would fail on a slow runner. Same override as
+    # cli/test-setup/docker-compose-scrape-intervals.yml.
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://127.0.0.1:8080/v1/server/readyz" ]
+      interval: 5s
+      timeout: 3s
+      retries: 40
+      start_period: 60s
 
   pmm-client:
     image: perconalab/pmm-client:3-dev-latest


### PR DESCRIPTION
## Failures fixed (investigator)

- source: Percona-Lab/pmm-submodules PR #4498 — run [33155754795](https://github.com/Percona-Lab/pmm-submodules/actions/runs/33155754795), check `E2E / Docker configuration tests / e2e tests: @docker-configuration` (CodeceptJS job, `setup_services: '-h'`)
- tests:
  - `codeceptjs-e2e/tests/QAN/externalClickhouse_test.js:11` / `@docker-configuration` — `BeforeSuite` for `PMM-T1218 Verify PMM with external Clickhouse`, which also skipped PMM-T2020, PMM-T2018, PMM-T2019 and PMM-T2006

## What failed

```
✖ "before all" hook: BeforeSuite for "PMM-T1218 Verify PMM with external Clickhouse @docker-configuration @cli" in 57558ms

The "PMM_SERVER_IMAGE=perconalab/pmm-server-fb:PR-4498-700bc38 docker compose -f docker-compose-clickhouse.yml up -d"
command was expected to run without any errors, but the error found: ...
  at Grafana.verifyCommand (tests/helper/grafana_helper.js:265:14)

FAIL  | 0 passed, 1 failed, 1 failedHooks, 4 skipped
```

CodeceptJS truncates the captured stderr in that assertion, so the real message
only shows up when the command is run by hand. Reproduced on a throwaway VM with
the exact FB image:

```
Container pmm-server-external-clickhouse  Error dependency pmm-server-external-clickhouse failed to start
dependency failed to start: container pmm-server-external-clickhouse is unhealthy
```

## Root cause — the compose readiness gate, not the product

PMM Server's own image healthcheck (`build/docker/server/Dockerfile.el9`) is

```
HEALTHCHECK --interval=4s --timeout=2s --start-period=25s --retries=3 CMD curl -sf http://127.0.0.1:8080/v1/server/readyz
```

so the container is flagged `unhealthy` roughly **37s** after start (25s start
period, then 3 × 4s). A cold PMM Server needs longer than that to answer
`readyz`, and `docker compose up` **aborts** the moment a service it is waiting
on under `condition: service_healthy` turns `unhealthy` — which is what
`pmm-client` in this compose file waits on. So the suite only ever passed when
the runner happened to be fast enough to get under the 37s cliff, which is why
this failure is intermittent (the re-run of the same job on the same head SHA,
[98811534538](https://github.com/Percona-Lab/pmm-submodules/actions/runs/33155754795/job/98811534538), went green).

This is the product-side issue already tracked as **PMM-15361** ("pmm-server
briefly reports unhealthy on cold start, aborting service_healthy dependents",
Bug, *In Review*) — same Dockerfile, same mechanism, and PMM's own
`docker-compose.yml` gates `pmm-client` the same way. No new ticket filed; this
PR is the QA-side hardening so our test stops losing the race in the meantime,
and it stays correct whatever start period the product lands on.

PMM itself is fine. Measured on the repro VM (6 vCPU / 16 GB, idle), a **plain
default** PMM Server from the same FB image — internal ClickHouse, no external
ClickHouse involved at all — goes:

```
33s starting
36s unhealthy      <- image healthcheck gives up here
45s healthy        <- readyz actually returns 200 {}
```

The transition through `unhealthy` on a cold start is normal PMM Server
behaviour, not something this FB build or the external-ClickHouse configuration
introduces. The stable `percona/pmm-server:3` image on the same box reached
healthy at 34s idle and 35s under load — inside the window, but with only one
spare probe.

## The fix

Override the healthcheck for `pmm-server-external-clickhouse` in the QA compose
file — the same probe the image uses, with a window sized for a cold start
(`start_period: 60s`, `retries: 10`, `interval: 5s`) — so compose waits for real
readiness instead of giving up at 37s. Nothing about the test's assertions
changes.

The start period is what prevents the abort: probe failures inside it are
absorbed, so the retries only extend the budget past it, to 60s + 10 × 5s =
**110s**. That covers the slowest cold start on record (~90s on slow hardware,
per PMM-15361) while a genuinely wedged server still reports `unhealthy` in
under two minutes.

## Verification

On a throwaway Linode VM, against `perconalab/pmm-server-fb:PR-4498-700bc38`:

| Run | Compose file | Result |
| --- | --- | --- |
| Cold, images pulled inside `up` | `main` | `EXIT=1` — `container pmm-server-external-clickhouse is unhealthy` (the CI failure, reproduced) |
| Warm | `main` | `EXIT=0` in 41s — won the race, as the CI re-run did |
| Cold, all four images removed first | this branch | `EXIT=0` in 66s, `FailingStreak=0` |
| Under CPU load, forcing a slow start | this branch | `EXIT=0` in 48s — `readyz` probes failed at 15.7s, 20.8s, 25.9s, 31.0s and only succeeded at **36.1s**; with the image's own healthcheck that streak would have flagged the container `unhealthy` and aborted `up`, with the override no failing streak was counted at all |

The last row is the decisive one: it exercises precisely the regime that fails on
CI, with the fix in place.

Those runs used `retries: 40`, cut to 10 on review in 2ba75f6. It does not
affect what they show: every probe failure observed fell inside the 60s start
period, where the retry count plays no part.

Also green in this repo's own CI on `97f141d`: `@docker-configuration` ran
`OK | 14 passed, 2 skipped`, `PMM-T1218` included (two unrelated flakes on the
first attempt are analysed in the comments below).

Not verified here: the four PMM-T2xxx scenarios were not executed on the VM
itself (no Node toolchain on the box) — they are covered by the CI runs above.

`bash .claude/hooks/lint-changed.sh` (yamllint + `docker compose config`) is
clean on the changed file.

## Same latent flake elsewhere — deliberately out of scope

The `client depends_on pmm-server: condition: service_healthy` pattern, with no
healthcheck override, is also in:

- `codeceptjs-e2e/pmm-ssl.yml`
- `codeceptjs-e2e/docker-compose-disconnect.yml`
- `qa-integration/pmm_qa/docker-compose-clients.yaml`
- `cli/test-setup/docker-compose-pmm-client.yaml`
- `cli/test-setup/docker-compose-pmm-admin-remove.yml`
- `qa-integration/pmm_psmdb_diffauth_setup/docker-compose-pmm-psmdb.yml`

All of them can fail the same way. Left alone here to keep this PR to the failure
that actually went red — worth a follow-up sweep, or they become moot once
PMM-15361 lands.