### PR TITLE
Refresh the T1883 dashboard so its wait can see data arrive

### DIFF
--- a/codeceptjs-e2e/tests/administration/serviceAccounts_test.js
+++ b/codeceptjs-e2e/tests/administration/serviceAccounts_test.js
@@ -60,9 +60,14 @@ Scenario('PMM-T1883 - Configuring pmm-agent to use service account @service-acco
   // them 0/0 and they render as "No data". Keep committing while the dashboard is polled.
   await I.verifyCommand(`sudo docker exec -d ${psContainerName} timeout 420 bash -c 'while true; do mysql ${mysqlCredentials} -e "INSERT INTO ${loadDatabase}.write_load (value) VALUES (UUID())"; sleep 1; done'`);
 
+  // The write load alone is not enough. The dashboard ships with refresh disabled, so without a
+  // refresh param the panels are queried once, over a window that still predates the first commit,
+  // and waitForGraphsToHaveData then re-counts that same static render for its whole timeout.
+  // Auto-refresh is what lets the wait actually observe the data arriving.
   const url = I.buildUrlWithParams(dashboardPage.mySQLInstanceOverview.clearUrl, {
     from: 'now-1m',
     to: 'now',
+    refresh: '10s',
     service_name: newServiceName,
   });
 

--- a/codeceptjs-e2e/tests/administration/serviceAccounts_test.js
+++ b/codeceptjs-e2e/tests/administration/serviceAccounts_test.js
@@ -60,10 +60,8 @@ Scenario('PMM-T1883 - Configuring pmm-agent to use service account @service-acco
   // them 0/0 and they render as "No data". Keep committing while the dashboard is polled.
   await I.verifyCommand(`sudo docker exec -d ${psContainerName} timeout 420 bash -c 'while true; do mysql ${mysqlCredentials} -e "INSERT INTO ${loadDatabase}.write_load (value) VALUES (UUID())"; sleep 1; done'`);
 
-  // The write load alone is not enough. The dashboard ships with refresh disabled, so without a
-  // refresh param the panels are queried once, over a window that still predates the first commit,
-  // and waitForGraphsToHaveData then re-counts that same static render for its whole timeout.
-  // Auto-refresh is what lets the wait actually observe the data arriving.
+  // This dashboard ships with refresh disabled, so without an explicit refresh param Grafana
+  // queries the panels once and waitForGraphsToHaveData just re-counts that static render.
   const url = I.buildUrlWithParams(dashboardPage.mySQLInstanceOverview.clearUrl, {
     from: 'now-1m',
     to: 'now',


### PR DESCRIPTION
## Failures fixed (investigator)

- source: pmm-submodules PR #4478 — FB Tests run https://github.com/Percona-Lab/pmm-submodules/actions/runs/33154828980
- tests:
  - `codeceptjs-e2e/tests/administration/serviceAccounts_test.js` / `@service-account` — PMM-T1883 Configuring pmm-agent to use service account

## What failed

The only red check of 48 (Launchable: 1 actionable failure, 0 quarantined):

```
PMM-T1883 - Configuring pmm-agent to use service account @service-account:
  Expected 1 Elements without data but found 3 on Dashboard
  .../mysql-instance-overview?from=now-1m&to=now&var-service_name=mysql_service_service_token1
  Report Names are Top InnoDB I/O Data Reads,Top InnoDB I/O Data Writes,Top Data Fsyncs
  at Object.printFailedReportNames (tests/pages/dashboardPage.js:1359:12)
  at Object.waitForGraphsToHaveData (tests/pages/dashboardPage.js:1325:16)
```

## Root cause — the wait, not the load, and not the product

The last step starts a write loop and then polls the dashboard:

```js
await I.verifyCommand(`... timeout 420 bash -c 'while true; do mysql -e "INSERT ..."; sleep 1; done'`);
const url = I.buildUrlWithParams(dashboardPage.mySQLInstanceOverview.clearUrl, {
  from: 'now-1m', to: 'now', service_name: newServiceName,
});
await I.amOnPage(url);
await I.wait(5);
await dashboardPage.waitForGraphsToHaveData(1, 300);
```

`MySQL_Instances_Overview.json` ships `"refresh": false`, and this URL — built from
`clearUrl` — carries no `refresh` param. So Grafana queries the panels **exactly once**, over a
`from=now-1m` window snapshotted ~5 s after the load starts (i.e. a window that predates the first
commit), and `waitForGraphsToHaveData` then spends its whole 300 s re-counting that same static
render. `grabNumberOfVisibleElements` re-reads the DOM; nothing re-reads the datasource.

This is the outlier: **every** other dashboard URL in `dashboardPage.js` carries `refresh=1m`,
including this page object's own `mySQLInstanceOverview.url` (`from=now-2m&to=now&refresh=1m`), and
`buildUrlWithParams` has supported a `refresh` key all along.

The write load added in #1194 was the right diagnosis of the *previous* failure and it works.
Measured on the repro VM **while the unfixed test sat in its poll loop showing empty panels**:

- the panel's own PromQL returned **0.41**
- `innodb_data_writes` / `innodb_data_fsyncs` were advancing in **25 of 30** consecutive 5 s scrape
  intervals; the denominator `rate(reads)+rate(writes)+rate(fsyncs)` was non-zero in **27 of 30**

The data was there. Nothing was going to re-read it.

Also worth recording, since it explains why the panel set differs between runs: with
`$interval` resolving to 1 s on a 1-minute range (`auto_min: 1s`, `auto_count: 200`) the
`rate(...[$interval])` term is always empty, so these three panels resolve entirely through their
`or irate(...[5m])` fallback — which reaches five minutes back, *outside* the dashboard's own
window. In my repro the three InnoDB ratio panels therefore had data while nine plain gauge panels
(Min/Max MySQL Uptime, Buffer Pool Size, Used Connections, Threads Cached, Queries), which are
confined to the 1-minute window, came back empty. Same defect, different panels losing the race.

Not a product bug: `mysql_global_status_innodb_data_{reads,writes,fsyncs}` are all present and
correct in VictoriaMetrics, and no assertion is loosened here — the tolerated-empty count stays 1.

## Fix

Add `refresh: '10s'` to the URL, so the 300 s wait can actually observe data arriving.
(Grafana's `min_refresh_interval` is `5s` in PMM's config, so 10 s is honored.)

## Verification

Linode VM at the exact FB build under test, `3.10.0-PMM-14109-improve-advisor-ux-b42a0448d`
(server + client from the PR-4478 FB images), brought up the way
`runner-e2e-tests-codeceptjs.yml` does it: `codeceptjs-e2e/docker-compose.yml` →
`db_setup.sh` → `pmm3-client-setup.sh` → `pmm-framework --parallel --database ps=8.0`.

| | first attempt | outcome |
|---|---|---|
| before (`main`, `0b9d4d9`) | **failed** — `Expected 1 ... but found 9`, after burning the full 300 s poll | passed on `.retry(1)` |
| after (this branch) | **passed 3/3**, ~3 min each | — |

Full `@service-account` tag on the fixed branch: `OK | 3 passed // 5m` — PMM-T1883 (211 s),
PMM-T1884 (31 s), PMM-T1900 (71 s). CI's run of the same suite was 2 passed, 1 failed.

Honest about the limits: the bug is a race, so "before" is n=1 first-attempt failure locally
(CI failed it on both attempts today, and this test was green on this same PR two days ago).
The mechanism, not the run count, is what the fix rests on — the measurement above shows a frozen
render sitting on top of live data, and `refresh` is what unfreezes it.

**Confirmed on a real CI runner**, which is the timing question the paragraph above left open —
this PR's own `FB E2E tests / Service Accounts tests / e2e tests: @service-account` passed on a
freshly-provisioned GitHub-hosted runner, on both heads:

- `ba80ca7` (the fix alone) — [job](https://github.com/percona/pmm-qa/actions/runs/33162349558/job/98819572157), 36/36 checks green
- `109100c` (after the review comment trim) — [job](https://github.com/percona/pmm-qa/actions/runs/33169595505/job/98843196312), 33 success + 2 skipped (the `claude` review workflows), 0 failures

One caveat on environment fidelity: `cdn.playwright.dev` 403s the Linode host, so Playwright's
pinned Chromium 151 could not be downloaded and the local runs used Chrome 152 via `CHROMIUM_PATH`
(which `pr.codecept.js` already supports) — one major version above CI's 151, on an
assertion about data presence rather than rendering. CI's own runs above used the pinned 151.