### PR TITLE
Automate PMM-T2131 HA nodes API and PMM-T2124 five-pod scaling

### DIFF
--- a/.claude/skills/linode-ha-provisioning/SKILL.md
+++ b/.claude/skills/linode-ha-provisioning/SKILL.md
@@ -81,6 +81,13 @@ then work locally against `$KUBECONFIG`. Defaults (all
 overridable in the POST body): `region=us-east`, `node_type=g6-standard-4`,
 `node_count=3` (Raft quorum, tolerates one node down); `k8s_version` defaults to the latest LKE offers (versions roll — a retired pin 400s).
 
+**Running the `@pmm-ha` suite? Ask for `"node_count":4`.** The default 3 sizes the
+cluster for exactly what the chart installs — each PMM pod requests 2 CPU and the
+stack leaves ~1.3 free per node — so PMM-T2124, which scales `pmm-ha` to five pods,
+leaves the new pods `Pending` forever. The fourth node takes both of them (the
+chart's pod anti-affinity is preferred-only and its selector does not even match
+these pods). Same reason `pmm3-ha-rosa` runs four workers.
+
 **Keep-alive:** add `"ttl_hours":<N>` to the POST body **and**
 `touch "$RUN_DIR/keep-alive"` — the marker keeps the SessionEnd hook from tearing
 it down; the cluster's `expires-<epoch>` tag (now + N h) still lets the reaper reap it.

--- a/e2e_tests/api/ha.api.ts
+++ b/e2e_tests/api/ha.api.ts
@@ -49,7 +49,7 @@ export default class HaApi {
 
   /** Sorted to compare with {@link getNodeNames}. */
   getNodesFromMetrics = async (): Promise<string[]> => {
-    const samples = await this.prometheusApi.instantQuery(HaApi.leaderStatusMetric);
+    const samples = await this.prometheusApi.instantQuery(`last_over_time(${HaApi.leaderStatusMetric}[1m])`);
 
     return samples
       .map((sample) => sample.metric.node_id)

--- a/e2e_tests/helpers/haCluster.helper.ts
+++ b/e2e_tests/helpers/haCluster.helper.ts
@@ -28,14 +28,12 @@ export default class HaClusterHelper {
    * configuration, so a scale-down that evicts the leader leaves the survivors
    * in a configuration they can never reach quorum in again.
    */
-  ensureLeaderAmong = async (podNames: string[], attempts = 8): Promise<string> => {
-    for (let attempt = 0; ; attempt++) {
+  ensureLeaderAmong = async (podNames: string[]): Promise<string> => {
+    // Each failover is a coin flip between the followers, so allow plenty.
+    for (let attempt = 0; attempt < 8; attempt++) {
       const leader = this.leaderFromPods();
 
       if (podNames.includes(leader)) return leader;
-
-      // Each failover is a coin flip between the followers, so allow plenty.
-      expect(attempt, `Leadership never landed on one of: ${podNames.join(', ')}`).toBeLessThan(attempts);
 
       const replicas = this.podNames().length;
 
@@ -43,6 +41,8 @@ export default class HaClusterHelper {
       await this.waitForLeaderChange(leader);
       await this.waitForReadyPods(replicas);
     }
+
+    throw new Error(`Leadership never landed on one of: ${podNames.join(', ')}`);
   };
 
   /**
@@ -110,12 +110,20 @@ export default class HaClusterHelper {
       )
       .assertSuccess()
       .stdout.trim();
+    let parsed: Partial<HaNodesResponse>;
 
     try {
-      return JSON.parse(stdout) as HaNodesResponse;
+      parsed = JSON.parse(stdout) as Partial<HaNodesResponse>;
     } catch {
       throw new Error(`"${podName}" did not answer ${apiEndpoints.ha.nodes} with JSON, got: ${stdout}`);
     }
+
+    // `curl -sk` exits 0 on a 401 or a 500, whose body is valid JSON too.
+    if (!parsed.nodes) {
+      throw new Error(`"${podName}" answered ${apiEndpoints.ha.nodes} without nodes, got: ${stdout}`);
+    }
+
+    return parsed as HaNodesResponse;
   };
 
   podNames = (): string[] => this.k8sHelper.getPodNames(pmmServerPodSelector).sort();

--- a/e2e_tests/helpers/haCluster.helper.ts
+++ b/e2e_tests/helpers/haCluster.helper.ts
@@ -110,17 +110,17 @@ export default class HaClusterHelper {
       )
       .assertSuccess()
       .stdout.trim();
-    let parsed: Partial<HaNodesResponse>;
+    let parsed: Partial<HaNodesResponse> | null;
 
     try {
-      parsed = JSON.parse(stdout) as Partial<HaNodesResponse>;
+      parsed = JSON.parse(stdout) as Partial<HaNodesResponse> | null;
     } catch {
       throw new Error(`"${podName}" did not answer ${apiEndpoints.ha.nodes} with JSON, got: ${stdout}`);
     }
 
     // `curl -sk` exits 0 on a 401 or a 500, whose body is valid JSON too.
-    if (!parsed.nodes) {
-      throw new Error(`"${podName}" answered ${apiEndpoints.ha.nodes} without nodes, got: ${stdout}`);
+    if (!Array.isArray(parsed?.nodes) || typeof parsed.expected_nodes !== 'number') {
+      throw new Error(`"${podName}" answered ${apiEndpoints.ha.nodes} with an invalid body, got: ${stdout}`);
     }
 
     return parsed as HaNodesResponse;

--- a/e2e_tests/helpers/haCluster.helper.ts
+++ b/e2e_tests/helpers/haCluster.helper.ts
@@ -1,8 +1,10 @@
 import K8sHelper from '@helpers/k8s.helper';
+import GrafanaHelper from '@helpers/grafana.helper';
 import { Timeouts } from '@helpers/timeouts';
 // Type-only: keeps this helper free of a runtime dependency on the api layer.
 import type HaApi from '@api/ha.api';
 import apiEndpoints from '@helpers/apiEndpoints';
+import { HaNodesResponse } from '@interfaces/ha';
 import { expect } from '@playwright/test';
 
 const leaderLogLine = 'I am the leader!';
@@ -21,6 +23,29 @@ export default class HaClusterHelper {
   constructor(private k8sHelper: K8sHelper = new K8sHelper()) {}
 
   /**
+   * Moves leadership onto one of `podNames` by restarting whoever leads until it
+   * lands there. Only the leader removes departing members from the Raft
+   * configuration, so a scale-down that evicts the leader leaves the survivors
+   * in a configuration they can never reach quorum in again.
+   */
+  ensureLeaderAmong = async (podNames: string[], attempts = 8): Promise<string> => {
+    for (let attempt = 0; ; attempt++) {
+      const leader = this.leaderFromPods();
+
+      if (podNames.includes(leader)) return leader;
+
+      // Each failover is a coin flip between the followers, so allow plenty.
+      expect(attempt, `Leadership never landed on one of: ${podNames.join(', ')}`).toBeLessThan(attempts);
+
+      const replicas = this.podNames().length;
+
+      this.k8sHelper.deletePod(leader).assertSuccess();
+      await this.waitForLeaderChange(leader);
+      await this.waitForReadyPods(replicas);
+    }
+  };
+
+  /**
    * Brings the cluster back to `replicas` ready and *reachable* nodes. A run
    * killed mid-scale-down never reaches its cleanup, so the next one repairs.
    */
@@ -33,15 +58,7 @@ export default class HaClusterHelper {
       this.k8sHelper.scaleStatefulSet(statefulSet, replicas).assertSuccess();
     }
 
-    // `kubectl wait` fails outright on pods the StatefulSet has not recreated yet.
-    // Scaling 0 -> 3 is the slow path at roughly two minutes, the pods being
-    // OrderedReady, so they come up one at a time.
-    await expect
-      .poll(() => this.k8sHelper.getPods(pmmServerPodSelector).filter((pod) => pod.ready).length, {
-        message: `The HA cluster must have ${replicas} ready pods`,
-        timeout: Timeouts.FIVE_MINUTES,
-      })
-      .toEqual(replicas);
+    await this.waitForReadyPods(replicas);
 
     // Ready pods, and even an elected leader, are not yet reachable: HAProxy has
     // to re-run its health check and re-point first.
@@ -77,6 +94,28 @@ export default class HaClusterHelper {
     }
 
     return leaders[0];
+  };
+
+  /**
+   * `/v1/ha/nodes` asked of one pod directly. Every external request goes
+   * through HAProxy, which only ever routes to the leader, so this is the only
+   * way to see what an individual follower believes about the cluster.
+   */
+  nodesFromPod = (podName: string): HaNodesResponse => {
+    const stdout = this.k8sHelper
+      .execInPod(
+        podName,
+        `curl -sk -H "Authorization: Basic ${GrafanaHelper.getToken()}" https://127.0.0.1:${pmmServerPort}${apiEndpoints.ha.nodes}`,
+        { silent: true },
+      )
+      .assertSuccess()
+      .stdout.trim();
+
+    try {
+      return JSON.parse(stdout) as HaNodesResponse;
+    } catch {
+      throw new Error(`"${podName}" did not answer ${apiEndpoints.ha.nodes} with JSON, got: ${stdout}`);
+    }
   };
 
   podNames = (): string[] => this.k8sHelper.getPodNames(pmmServerPodSelector).sort();
@@ -115,6 +154,20 @@ export default class HaClusterHelper {
     }).toPass({ intervals: [Timeouts.FIVE_SECONDS], timeout });
 
     return leader;
+  };
+
+  /**
+   * `kubectl wait` fails outright on pods the StatefulSet has not recreated yet.
+   * The pods are OrderedReady, so they come up one at a time: 0 -> 3 is the slow
+   * path at roughly two minutes.
+   */
+  waitForReadyPods = async (replicas: number, timeout: Timeouts = Timeouts.FIVE_MINUTES): Promise<void> => {
+    await expect
+      .poll(() => this.k8sHelper.getPods(pmmServerPodSelector).filter((pod) => pod.ready).length, {
+        message: `The HA cluster must have ${replicas} ready pods`,
+        timeout,
+      })
+      .toEqual(replicas);
   };
 
   // Hits the pod directly rather than through HAProxy, which only ever routes

--- a/e2e_tests/tests/ha/clusterScaleUp.test.ts
+++ b/e2e_tests/tests/ha/clusterScaleUp.test.ts
@@ -1,0 +1,87 @@
+import pmmTest from '@fixtures/pmmTest';
+import { expect } from '@playwright/test';
+import { HaNodeRole } from '@interfaces/ha';
+import { Timeouts } from '@helpers/timeouts';
+
+const defaultReplicas = 3;
+const scaledReplicas = 5;
+
+pmmTest.beforeEach(async ({ api, grafanaHelper, haClusterHelper }) => {
+  await grafanaHelper.authorize();
+  await haClusterHelper.ensureServing(api.haApi, defaultReplicas);
+});
+
+pmmTest.afterEach(async ({ api, haClusterHelper }) => {
+  // Only the leader removes departing members from the Raft configuration, so
+  // scaling down while one of the new pods leads leaves the survivors in a
+  // five-member configuration they can never reach quorum in again.
+  await haClusterHelper.ensureLeaderAmong(haClusterHelper.podNames().slice(0, defaultReplicas));
+  await haClusterHelper.ensureServing(api.haApi, defaultReplicas);
+});
+
+pmmTest(
+  `PMM-T2124 Verify the PMM HA cluster can be scaled to ${scaledReplicas} pods @pmm-ha`,
+  async ({ api, haClusterHelper, k8sHelper, nodesPage, page }) => {
+    pmmTest.setTimeout(Timeouts.THIRTY_MINUTES);
+
+    await pmmTest.step('Verify HA mode is enabled', async () => {
+      expect(await api.haApi.getStatus()).toEqual('Enabled');
+    });
+
+    const statefulSet = haClusterHelper.statefulSetName();
+
+    await pmmTest.step(`Scale the cluster to ${scaledReplicas} replicas`, async () => {
+      expect(
+        k8sHelper.getStatefulSetReplicas(statefulSet),
+        `The cluster must start from its ${defaultReplicas} chart replicas`,
+      ).toEqual(defaultReplicas);
+
+      // Each PMM pod requests 2 CPU, so the cluster needs that much headroom per
+      // added replica - otherwise the new pods sit Pending and never go Ready.
+      k8sHelper.scaleStatefulSet(statefulSet, scaledReplicas).assertSuccess();
+      await haClusterHelper.waitForReadyPods(scaledReplicas, Timeouts.TEN_MINUTES);
+    });
+
+    const podNames = haClusterHelper.podNames();
+
+    expect(podNames, `The StatefulSet must run ${scaledReplicas} PMM Server pods`).toHaveLength(
+      scaledReplicas,
+    );
+
+    await pmmTest.step('Verify the new pods joined the HA cluster', async () => {
+      // The joining pods are added to the memberlist by gossip and to Raft by
+      // the leader, so both trail the pods being Ready.
+      await expect(async () => {
+        const nodes = await api.haApi.getNodes();
+
+        expect(
+          nodes.map((node) => node.node_name).sort(),
+          `All ${scaledReplicas} pods must be listed as HA nodes`,
+        ).toEqual(podNames);
+
+        expect(
+          nodes.map((node) => node.status),
+          'Every HA node must be alive',
+        ).toEqual(Array(scaledReplicas).fill('alive'));
+
+        expect(
+          nodes.filter((node) => node.role === HaNodeRole.leader),
+          'The scaled-up cluster must still have exactly one leader',
+        ).toHaveLength(1);
+      }).toPass({ intervals: [Timeouts.FIVE_SECONDS], timeout: Timeouts.FIVE_MINUTES });
+
+      await api.haApi.waitForLeaderStatusSum(1);
+    });
+
+    await pmmTest.step(`Verify the Inventory Nodes page lists all ${scaledReplicas} nodes`, async () => {
+      await page.goto(nodesPage.url, { timeout: Timeouts.TWO_MINUTES });
+
+      for (const podName of podNames) {
+        await expect(
+          nodesPage.builders.nodeStatusCell(podName),
+          `HA node "${podName}" is running, so the Nodes page must show it Up`,
+        ).toHaveText('Up', { timeout: Timeouts.TWO_MINUTES });
+      }
+    });
+  },
+);

--- a/e2e_tests/tests/ha/clusterScaleUp.test.ts
+++ b/e2e_tests/tests/ha/clusterScaleUp.test.ts
@@ -12,9 +12,6 @@ pmmTest.beforeEach(async ({ api, grafanaHelper, haClusterHelper }) => {
 });
 
 pmmTest.afterEach(async ({ api, haClusterHelper }) => {
-  // Only the leader removes departing members from the Raft configuration, so
-  // scaling down while one of the new pods leads leaves the survivors in a
-  // five-member configuration they can never reach quorum in again.
   await haClusterHelper.ensureLeaderAmong(haClusterHelper.podNames().slice(0, defaultReplicas));
   await haClusterHelper.ensureServing(api.haApi, defaultReplicas);
 });
@@ -36,8 +33,6 @@ pmmTest(
         `The cluster must start from its ${defaultReplicas} chart replicas`,
       ).toEqual(defaultReplicas);
 
-      // Each PMM pod requests 2 CPU, so the cluster needs that much headroom per
-      // added replica - otherwise the new pods sit Pending and never go Ready.
       k8sHelper.scaleStatefulSet(statefulSet, scaledReplicas).assertSuccess();
       await haClusterHelper.waitForReadyPods(scaledReplicas, Timeouts.TEN_MINUTES);
     });

--- a/e2e_tests/tests/ha/haNodesApi.test.ts
+++ b/e2e_tests/tests/ha/haNodesApi.test.ts
@@ -21,8 +21,7 @@ pmmTest(
 
     await pmmTest.step('Verify every pod lists the whole cluster alive under one leader', async () => {
       // Asked of each pod in turn inside one poll: a pod that joined or left
-      // recently is in the others' memberlist only after the next gossip round,
-      // and comparing responses read minutes apart would prove nothing anyway.
+      // recently is in the others' memberlist only after the next gossip round.
       await expect(async () => {
         const leader = haClusterHelper.leaderFromPods(podNames);
 

--- a/e2e_tests/tests/ha/haNodesApi.test.ts
+++ b/e2e_tests/tests/ha/haNodesApi.test.ts
@@ -1,0 +1,56 @@
+import pmmTest from '@fixtures/pmmTest';
+import { expect } from '@playwright/test';
+import { HaNodeRole } from '@interfaces/ha';
+import { Timeouts } from '@helpers/timeouts';
+
+pmmTest.beforeEach(async ({ api, grafanaHelper, haClusterHelper }) => {
+  await grafanaHelper.authorize();
+  await haClusterHelper.ensureServing(api.haApi);
+});
+
+pmmTest(
+  'PMM-T2131 Verify every PMM HA node reports the same cluster status @pmm-ha',
+  async ({ api, haClusterHelper }) => {
+    await pmmTest.step('Verify HA mode is enabled', async () => {
+      expect(await api.haApi.getStatus()).toEqual('Enabled');
+    });
+
+    const podNames = haClusterHelper.podNames();
+
+    expect(podNames.length, 'HA runs more than one PMM Server pod').toBeGreaterThan(1);
+
+    await pmmTest.step('Verify every pod lists the whole cluster alive under one leader', async () => {
+      // Asked of each pod in turn inside one poll: a pod that joined or left
+      // recently is in the others' memberlist only after the next gossip round,
+      // and comparing responses read minutes apart would prove nothing anyway.
+      await expect(async () => {
+        const leader = haClusterHelper.leaderFromPods(podNames);
+
+        for (const podName of podNames) {
+          const { expected_nodes, nodes } = haClusterHelper.nodesFromPod(podName);
+
+          expect(
+            nodes.map((node) => node.node_name).sort(),
+            `"${podName}" must list every PMM Server pod`,
+          ).toEqual(podNames);
+
+          expect(
+            nodes.map((node) => node.status),
+            `"${podName}" must see every node alive`,
+          ).toEqual(Array(podNames.length).fill('alive'));
+
+          expect(
+            nodes.filter((node) => node.role === HaNodeRole.leader).map((node) => node.node_name),
+            `"${podName}" must name "${leader}" as the only leader`,
+          ).toEqual([leader]);
+
+          // Static, from PMM_HA_PEERS - it is the size the chart was installed
+          // with, not a count of who is currently up.
+          expect(expected_nodes, `"${podName}" must expect ${podNames.length} nodes`).toEqual(
+            podNames.length,
+          );
+        }
+      }).toPass({ intervals: [Timeouts.FIVE_SECONDS], timeout: Timeouts.TWO_MINUTES });
+    });
+  },
+);


### PR DESCRIPTION
## What

Two new `@pmm-ha` Playwright tests, plus the helpers they need.

| File | Case |
|---|---|
| `e2e_tests/tests/ha/haNodesApi.test.ts` | **PMM-T2131** — every HA node reports the same cluster status |
| `e2e_tests/tests/ha/clusterScaleUp.test.ts` | **PMM-T2124** — the cluster can be scaled to five pods |
| `e2e_tests/helpers/haCluster.helper.ts` | `nodesFromPod()`, `ensureLeaderAmong()`, `waitForReadyPods()` |
| `.claude/skills/linode-ha-provisioning/SKILL.md` | the `node_count` the suite needs |

**PMM-T2131** asks every PMM Server pod for `/v1/ha/nodes` **directly**. Through HAProxy every request lands on the leader, so the aggregated call cannot show whether the followers agree. It asserts all pods report the same node list, every node `alive`, exactly one `NODE_ROLE_LEADER`, and `expected_nodes` equal to the cluster size.

The manual case reads the leader from `pmm-managed.log`; the test does not. A pod killed while leading never logs a demotion, `/srv` is a PVC so old promotions outlive restarts, and per-pod clocks are not comparable — so the oracle is `/v1/server/leaderHealthCheck` per pod (`leaderFromPods()`), the same contract HAProxy routes on.

**PMM-T2124** scales the StatefulSet to five replicas, waits for five Ready pods, asserts they all joined (`/v1/ha/nodes` alive, one leader, `sum(pmm_ha_leader_status)` = 1) and show **Up** on Inventory → Nodes, then restores three. The cleanup moves leadership onto a surviving pod first: only the leader removes departing members from the Raft configuration, so a scale-down that evicts the leader leaves the survivors in a five-member configuration they can never reach quorum in again.

It scales with `kubectl scale` rather than `helm upgrade --set replicas=5`. The workload change is the same; the difference is that `PMM_HA_PEERS` (and so `expected_nodes`) keeps its installed value, so the test does not assert `expected_nodes` after scaling.

## Testing

**Linode LKE, `PMM-HA-GA` chart** (`pmm-ha` 1.6.0, image `percona/pmm-server:3.9.1`) — the chart branch `pmm3-ha-tests` defaults to:

| | |
|---|---|
| PMM-T2131 | PASS 8s |
| PMM-T2124 | PASS 1.4 min |
| whole `@pmm-ha` suite | **7/7 PASS**, 8.9 min |

The suite was run in full because `haCluster.helper.ts` is shared by all five existing tests.

Both new tests were mutation-checked, then reverted and re-run green:

- PMM-T2131 pointed at a non-leader pod → fails with the expected leader diff, not a timeout;
- PMM-T2124 with the Inventory assertion flipped to `Down` → `Expected: "Down" / Received: "Up"`.

**ROSA / OpenShift** — [`pmm3-ha-tests` #29](https://pmm.cd.percona.com/job/pmm3-ha-tests/29/) on this branch, `TAGS_FOR_TESTS=@pmm-ha`, `HELM_CHART_BRANCH=PMM-HA-GA`: **6 passed, 1 failed**. PMM-T2131 and all five pre-existing tests are green there. PMM-T2124 fails on the nightly cluster for capacity, not for a test defect:

```
Warning  FailedScheduling  default-scheduler
  0/3 nodes are available: 3 Insufficient cpu.
```

Three `m7i.2xlarge` workers are already at 80–83% of requested CPU (~1.3 free per node) while a PMM pod requests 2, so a fourth replica cannot be scheduled. Fixed by [Percona-Lab/jenkins-pipelines#4385](https://github.com/Percona-Lab/jenkins-pipelines/pull/4385), which asks `pmm3-ha-rosa` for a fourth worker. **That PR should land before this one, or the nightly stays red on PMM-T2124.**

## Jira / Zephyr

[PMM-15374](https://perconadev.atlassian.net/browse/PMM-15374). Both Zephyr cases are now `Automated`.

Filed along the way: [PMM-15400](https://perconadev.atlassian.net/browse/PMM-15400) — the `pmm-ha` chart never sets `GF_SECURITY_ADMIN_PASSWORD` when the secret is pre-created, which CrashLoops `pmm-ha-pmm-token-init` and trips Grafana's brute-force lockout. Not blocking these tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YoGfUzkm1mheSiWtwg6nH

---
_Generated by [Claude Code](https://claude.ai/code/session_013YoGfUzkm1mheSiWtwg6nH)_

[PMM-15374]: https://perconadev.atlassian.net/browse/PMM-15374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ