### PR TITLE
Wait for PMM Server readiness instead of a fixed 30s sleep

### DIFF
--- a/codeceptjs-e2e/testdata/external-services/external-pgsql-ssl.yml
+++ b/codeceptjs-e2e/testdata/external-services/external-pgsql-ssl.yml
@@ -180,5 +180,5 @@
       shell: docker inspect --format='{{ "{{.State.Health.Status}}" }}' pmm-server-external-postgres-ssl
       register: pmm_server_health
       until: "'healthy' in pmm_server_health.stdout"
-      retries: 5
+      retries: 60
       delay: 5

--- a/codeceptjs-e2e/testdata/external-services/external-pgsql-ssl.yml
+++ b/codeceptjs-e2e/testdata/external-services/external-pgsql-ssl.yml
@@ -180,5 +180,5 @@
       shell: docker inspect --format='{{ "{{.State.Health.Status}}" }}' pmm-server-external-postgres-ssl
       register: pmm_server_health
       until: "'healthy' in pmm_server_health.stdout"
-      retries: 60
+      retries: 24
       delay: 5

--- a/codeceptjs-e2e/testdata/external-services/external-pgsql-ssl.yml
+++ b/codeceptjs-e2e/testdata/external-services/external-pgsql-ssl.yml
@@ -180,5 +180,5 @@
       shell: docker inspect --format='{{ "{{.State.Health.Status}}" }}' pmm-server-external-postgres-ssl
       register: pmm_server_health
       until: "'healthy' in pmm_server_health.stdout"
-      retries: 24
+      retries: 12
       delay: 5

--- a/codeceptjs-e2e/testdata/external-services/external-pgsql.yml
+++ b/codeceptjs-e2e/testdata/external-services/external-pgsql.yml
@@ -95,5 +95,5 @@
       shell: docker inspect --format='{{ "{{.State.Health.Status}}" }}' pmm-server-external-postgres
       register: pmm_server_health
       until: "'healthy' in pmm_server_health.stdout"
-      retries: 24
+      retries: 12
       delay: 5

--- a/codeceptjs-e2e/testdata/external-services/external-pgsql.yml
+++ b/codeceptjs-e2e/testdata/external-services/external-pgsql.yml
@@ -95,5 +95,5 @@
       shell: docker inspect --format='{{ "{{.State.Health.Status}}" }}' pmm-server-external-postgres
       register: pmm_server_health
       until: "'healthy' in pmm_server_health.stdout"
-      retries: 5
+      retries: 60
       delay: 5

--- a/codeceptjs-e2e/testdata/external-services/external-pgsql.yml
+++ b/codeceptjs-e2e/testdata/external-services/external-pgsql.yml
@@ -95,5 +95,5 @@
       shell: docker inspect --format='{{ "{{.State.Health.Status}}" }}' pmm-server-external-postgres
       register: pmm_server_health
       until: "'healthy' in pmm_server_health.stdout"
-      retries: 60
+      retries: 24
       delay: 5

--- a/codeceptjs-e2e/tests/dockerConfiguration/publicAddressVariable_test.js
+++ b/codeceptjs-e2e/tests/dockerConfiguration/publicAddressVariable_test.js
@@ -13,9 +13,15 @@ publicIPs.add(['PMM-T1173', '127.0.0.1:8443']);
 publicIPs.add(['PMM-T1174', 'ec2-18-188-74-98.us-east-2.compute.amazonaws.com']);
 publicIPs.add(['PMM-T1174', 'ec2-18-188-74-98.us-east-2.compute.amazonaws.com:8443']);
 
+// A freshly started PMM Server needs ~26s before it can serve a login, so poll
+// readyz instead of sleeping a fixed amount that a slower CI runner overruns.
+const waitForPmmServerReady = async (I, baseUrl, timeout = 300) => {
+  await I.verifyCommand(`timeout ${timeout} bash -c 'until [ "$(curl -s -o /dev/null -w "%{http_code}" --user admin:admin ${baseUrl}v1/server/readyz)" = "200" ]; do sleep 2; done'`);
+};
+
 const runContainerWithPublicAddressVariable = async (I, publicAddress) => {
   await I.verifyCommand(`docker run -d --restart always -e PERCONA_TEST_PLATFORM_ADDRESS=https://check-dev.percona.com:443 -e PMM_ENABLE_INTERNAL_PG_QAN=1 -e PMM_PUBLIC_ADDRESS=${publicAddress} --publish 8085:8080 --publish 8443:8443 --name ${contanerName} ${dockerVersion}`);
-  await I.wait(30);
+  await waitForPmmServerReady(I, basePmmUrl);
 };
 
 const runContainerWithPublicAddressVariableUpgrade = async (I, publicAddress) => {
@@ -83,7 +89,6 @@ Scenario(
     const basePmmUrl = `http://${serverIP}:8085/`;
 
     await runContainerWithPublicAddressVariable(I, '127.0.0.5');
-    await I.wait(30);
     await I.Authorize('admin', 'admin', basePmmUrl);
     await I.amOnPage(buildUrl(basePmmUrl, pmmSettingsPage.advancedSettingsUrl));
     await I.waitForVisible(pmmSettingsPage.fields.publicAddressInput, 30);

--- a/codeceptjs-e2e/tests/dockerConfiguration/publicAddressVariable_test.js
+++ b/codeceptjs-e2e/tests/dockerConfiguration/publicAddressVariable_test.js
@@ -15,7 +15,7 @@ publicIPs.add(['PMM-T1174', 'ec2-18-188-74-98.us-east-2.compute.amazonaws.com:84
 
 const runContainerWithPublicAddressVariable = async (I, publicAddress) => {
   await I.verifyCommand(`docker run -d --restart always -e PERCONA_TEST_PLATFORM_ADDRESS=https://check-dev.percona.com:443 -e PMM_ENABLE_INTERNAL_PG_QAN=1 -e PMM_PUBLIC_ADDRESS=${publicAddress} --publish 8085:8080 --publish 8443:8443 --name ${contanerName} ${dockerVersion}`);
-  await I.verifyCommand(`timeout 300 bash -c 'until curl -s -D - -o /dev/null -X POST -H "Content-Type: application/json" -d "{\\"user\\":\\"admin\\",\\"password\\":\\"admin\\"}" ${basePmmUrl}graph/login | grep -qi "^set-cookie:"; do sleep 2; done'`);
+  await I.verifyCommand(`timeout 120 bash -c 'until curl -s -D - -o /dev/null -X POST -H "Content-Type: application/json" -d "{\\"user\\":\\"admin\\",\\"password\\":\\"admin\\"}" ${basePmmUrl}graph/login | grep -qi "^set-cookie:"; do sleep 2; done'`);
 };
 
 const runContainerWithPublicAddressVariableUpgrade = async (I, publicAddress) => {

--- a/codeceptjs-e2e/tests/dockerConfiguration/publicAddressVariable_test.js
+++ b/codeceptjs-e2e/tests/dockerConfiguration/publicAddressVariable_test.js
@@ -15,7 +15,7 @@ publicIPs.add(['PMM-T1174', 'ec2-18-188-74-98.us-east-2.compute.amazonaws.com:84
 
 const runContainerWithPublicAddressVariable = async (I, publicAddress) => {
   await I.verifyCommand(`docker run -d --restart always -e PERCONA_TEST_PLATFORM_ADDRESS=https://check-dev.percona.com:443 -e PMM_ENABLE_INTERNAL_PG_QAN=1 -e PMM_PUBLIC_ADDRESS=${publicAddress} --publish 8085:8080 --publish 8443:8443 --name ${contanerName} ${dockerVersion}`);
-  await I.verifyCommand(`timeout 120 bash -c 'until curl -s -D - -o /dev/null -X POST -H "Content-Type: application/json" -d "{\\"user\\":\\"admin\\",\\"password\\":\\"admin\\"}" ${basePmmUrl}graph/login | grep -qi "^set-cookie:"; do sleep 2; done'`);
+  await I.verifyCommand(`timeout 60 bash -c 'until curl -s -D - -o /dev/null -X POST -H "Content-Type: application/json" -d "{\\"user\\":\\"admin\\",\\"password\\":\\"admin\\"}" ${basePmmUrl}graph/login | grep -qi "^set-cookie:"; do sleep 2; done'`);
 };
 
 const runContainerWithPublicAddressVariableUpgrade = async (I, publicAddress) => {

--- a/codeceptjs-e2e/tests/dockerConfiguration/publicAddressVariable_test.js
+++ b/codeceptjs-e2e/tests/dockerConfiguration/publicAddressVariable_test.js
@@ -13,15 +13,9 @@ publicIPs.add(['PMM-T1173', '127.0.0.1:8443']);
 publicIPs.add(['PMM-T1174', 'ec2-18-188-74-98.us-east-2.compute.amazonaws.com']);
 publicIPs.add(['PMM-T1174', 'ec2-18-188-74-98.us-east-2.compute.amazonaws.com:8443']);
 
-// A freshly started PMM Server needs ~26s before it can serve a login, so poll
-// readyz instead of sleeping a fixed amount that a slower CI runner overruns.
-const waitForPmmServerReady = async (I, baseUrl, timeout = 300) => {
-  await I.verifyCommand(`timeout ${timeout} bash -c 'until [ "$(curl -s -o /dev/null -w "%{http_code}" --user admin:admin ${baseUrl}v1/server/readyz)" = "200" ]; do sleep 2; done'`);
-};
-
 const runContainerWithPublicAddressVariable = async (I, publicAddress) => {
   await I.verifyCommand(`docker run -d --restart always -e PERCONA_TEST_PLATFORM_ADDRESS=https://check-dev.percona.com:443 -e PMM_ENABLE_INTERNAL_PG_QAN=1 -e PMM_PUBLIC_ADDRESS=${publicAddress} --publish 8085:8080 --publish 8443:8443 --name ${contanerName} ${dockerVersion}`);
-  await waitForPmmServerReady(I, basePmmUrl);
+  await I.verifyCommand(`timeout 300 bash -c 'until curl -s -D - -o /dev/null -X POST -H "Content-Type: application/json" -d "{\\"user\\":\\"admin\\",\\"password\\":\\"admin\\"}" ${basePmmUrl}graph/login | grep -qi "^set-cookie:"; do sleep 2; done'`);
 };
 
 const runContainerWithPublicAddressVariableUpgrade = async (I, publicAddress) => {


### PR DESCRIPTION
## Failures fixed (investigator)

- source: scheduled CI run https://github.com/percona/pmm-qa/actions/runs/33228638953 (`E2E tests Matrix` on `main`, job `FB E2E tests / Docker configuration tests / e2e tests: @docker-configuration`)
- tests:
  - `codeceptjs-e2e/tests/dockerConfiguration/publicAddressVariable_test.js` / `@docker-configuration` — PMM-T1173 + PMM-T1174, 3 of the 4 data variants
  - `codeceptjs-e2e/tests/dockerConfiguration/externalPostgres_test.js:27` / `@docker-configuration` — PMM-T1678, the `external-pgsql-ssl` variant

## What failed

The only red job of 32. Its `Execute e2e tests` step reported success — the failure surfaced only in `Record launchable test results` (`launchable gate`: `4 actionable failures, 0 quarantined`; `10 passed, 4 failed, 2 skipped`).

```
✖ PMM-T1173 + PMM-T1174 ... {"testCase":"PMM-T1173","publicAddress":"127.0.0.1"}
  Authentication was not successful, verify base url and credentials.
  element ($publicAddress-text-input) still not visible after 30 sec
    - waiting for "http://127.0.0.1:8085/graph/login" navigation to finish...

✖ PMM-T1678 ... {"ansibleName":"external-pgsql-ssl"}
  The "ansible-playbook ... external-pgsql-ssl.yml ..." command was expected to
  run without any errors
```

Both failures are the same shape: the test starts a PMM Server container, gives it a fixed amount of time, then uses it before it is up. In T1173/T1174 the `graph/login` POST returns no `Set-Cookie`, `Authorize` swallows that (`grafana_helper.js:50`) and the test proceeds unauthenticated until the settings input times out.

## Reproduction — it did not reproduce

Fresh Linode VM, `main` @ `0b9d4d9`, the same server image the failing run used (`perconalab/pmm-server@sha256:fe34e198…`, matched against that run's Launchable build id), full `@docker-configuration` tag: **13 passed, 1 failed, 2 skipped**. All four CI-failing tests passed. (The one failure was `PMM-T1642`, from my own repro setup — I skipped the client-install step, so `pmm-admin: command not found`. It is green in CI and unrelated.)

A re-run of the failed job on the original run — same code, CI's own runner — also came back **green**, and run 1713 is now `success` on attempt 2. So the failure is intermittent, not a standing break.

## Root cause — the waits have no margin

Measured on that VM, with the same image, container idle:

| what | measured |
|---|---|
| `docker run` → `/v1/server/readyz` returns 200 | 25–26 s (3 runs) |
| `docker run` → `POST graph/login` returns a cookie | 25–26 s (same second) |
| `docker run` → docker healthcheck reports `healthy` | 30 s (2 runs) |

Against that:

- `publicAddressVariable_test.js` sleeps a fixed **30 s**, then logs in.
- Both `external-pgsql*.yml` playbooks poll for a healthy PMM Server container with `retries: 5, delay: 5` — a budget of roughly **20–25 s**.

So both budgets sit right on top of the boot time. The margin is visible in the timings: every passing run of these scenarios lands at ~31.5 s (2026-08-28 CI, green) and ~31.7 s (this VM) — 30 s of sleep plus ~1.5 s of test. On the shared 2-core GitHub runner, a couple of seconds of extra load is enough to push past it, which is exactly what happened to 3 of the 4 variants. `PMM-T1177`, in the same file, only survives because it sleeps a second 30 s on top.

The server image did move between the last green run and this one (`sha256:16d2f54b…` → `sha256:fe34e198…`), but a server that is usable at 26 s is not a product defect — a test that allots 30 s for it is a fragile test.

## The fix

- `publicAddressVariable_test.js`: instead of sleeping 30 s, poll `POST graph/login` until it returns a `Set-Cookie` — the exact precondition `I.Authorize` needs — and drop the now-redundant second 30 s sleep in PMM-T1177. If the server never comes up the poll times out and `verifyCommand` fails the test.
- `external-pgsql.yml` / `external-pgsql-ssl.yml`: the *PMM Server* health wait goes from `retries: 5` to `retries: 12` (`delay: 5` → 60 s). The postgres-container wait stays at `retries: 5` — it was not implicated.

Both budgets are **60 s** — about 2× the measured startup (26 s to serve a login, 30 s to report `healthy`): headroom for a loaded 2-core runner, tight enough that a regression pushing PMM Server startup into minutes fails the suite instead of being absorbed by the wait.

The number was settled in review. The first revision used 5 min, which is more than the job needs; @peterSirotnak asked for `retries: 6`, which is a ~25–30 s budget and lands on the same boundary that produced this flake (the value that failed was `retries: 5`); 60 s was chosen as the accepted budget. For the record, it is at the low end of this repo's existing waits rather than the middle — `runner-e2e-tests-codeceptjs.yml:212`, the workflow that launches this very suite, allows `timeout 120` for `readyz`, as do the playwright runner and the psmdb-pbm setup scripts; `qa-integration/pmm_qa/external_setup.yml:79` is the one that uses 60. 60 s is a deliberate, accepted choice, not an oversight — if this wait ever trips on a slow runner, 120 s is the value with precedent behind it.

Nothing is loosened: no assertion changed, no check removed. Both waits still fail if PMM Server does not start.

## Verification

**On CI, on `9273a4e`** — [job 99111822827](https://github.com/percona/pmm-qa/actions/runs/33244757665/job/99111822827), the CodeceptJS `@docker-configuration` runner: the same 2-core GitHub runner and the same server image (`sha256:fe34e198…`) as the failing run.

```
| Files found | Tests found | Tests passed | Tests failed | Total duration (min) |
|           1 |          14 |           14 |            0 |                12.93 |
| Status | Quarantined (Ignored) | Actionable Failures |
| PASSED |                     0 |                   0 |
```

All 14 pass, including all four that failed on `main`. Suite time across the states: **14.15 min** before the fix → 13.22 with the first (readyz) poll → **12.93** with the login poll. The later commits only lower the two give-up thresholds (300 s → 120 s in `4b1227e`, then → 60 s in `d29b13d`; `retries: 60` → `24` → `12`), which changes no timing on a passing run — the waits exit as soon as the server answers. `4b1227e` re-ran green on CI at 12.29 min; `d29b13d` is re-running.

**On the repro VM**, on the earlier commit `5c30e4f` (`sync.sh` onto the running box, not patched in place): `publicAddressVariable_test.js` 5 passed / 1 skipped, `externalPostgres_test.js` both variants green, both `CODECEPT_EXIT=0`; per-test T1173 31.7 s → 28.2–28.7 s, T1177 82.5 s → 48.7 s. Review feedback then moved the wait from `readyz` (pmm-managed) to `graph/login` (Grafana) — different services behind the same nginx, and only the latter is the precondition the test needs — so the CI run above supersedes the VM run for that file. Before pushing I verified the emitted command both ways: against a dead port it loops and exits `124`, so `verifyCommand` fails the test loudly; against a server returning `Set-Cookie` it exits `0` immediately — the same curl/grep probe that measured the 25–26 s login time.

What none of this proves: the original failure never reproduced — not on the VM, not on the CI re-run — so no single green run can demonstrate an intermittent failure is gone. It shows the fix is sound and costs nothing; confidence accrues over the next scheduled `E2E tests Matrix` runs.


---
_Generated by [Claude Code](https://claude.ai/code)_