### PR TITLE
PMM-15396 Fix /srv ownership in V2 to V3 helm test

### DIFF
--- a/k8s/helm-test.bats
+++ b/k8s/helm-test.bats
@@ -232,7 +232,7 @@ update_values_yaml() {
     update_values_yaml "repository" "$IMAGE_REPO"
 
     kubectl exec pmm4-0 -- supervisorctl stop all
-    kubectl exec pmm4-0 -- chown -R pmm:pmm /srv
+    kubectl exec pmm4-0 -- chown -R 1000:0 /srv
 
     upgrade_pmm_chart pmm4 -f values.yaml
     sleep 7 # give a chance to update manifest


### PR DESCRIPTION
Follow-up to a review thread on [percona/pmm#5844](https://github.com/percona/pmm/pull/5844#discussion_r3902001603).

The `install last released V2 version, upgrade to V3 and uninstall` test handed `/srv` to `pmm:pmm` before switching to the PMM 3 image. That resolves to `1000:1000` and drops group `root` — PMM 3 runs as UID 1000 / GID 0 and `/srv` is mode `0775`, so group `root` is what grants write access on arbitrary-UID deployments. Changed to the explicit `1000:0`, matching the documented migration path that #5844 corrects.

Only the ownership target changed. The reviewer also suggested running the `chown` as root; that is not needed here — the command executes against the still-running PMM 2 deployment (chart `1.3.0`, `percona/pmm-server:2`), whose `podSecurityContext` is empty, so it already runs as root. `USER 1000` only applies after `upgrade_pmm_chart`.

```diff
-    kubectl exec pmm4-0 -- chown -R pmm:pmm /srv
+    kubectl exec pmm4-0 -- chown -R 1000:0 /srv
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01TozePtnZbcgwYSvM8S9Qja)_