### PR TITLE
relay+router: on-roster mentions run the router; name the routine to set up

### DIFF
--- a/.claude/agents/router.md
+++ b/.claude/agents/router.md
@@ -32,6 +32,17 @@ If the message is genuinely ambiguous between two agents, ask a short clarifying
 3. If it didn't match anything actionable: answer directly, in your own voice, no hand-off.
 4. Reply in-thread via the relay's `/reply` endpoint (see the Slack README) with whatever the matched agent produced, or your own direct answer.
 
+## When the caller lacks the routine
+
+The fire payload lists the caller's **available routines**. Two cases when they're missing what the request needs:
+
+- **A plain question that needs no routine** (e.g. "why is nightly red?", "is this expected?") → just answer directly. No routine required.
+- **The request maps to an agent whose routine the caller doesn't have** (a `test-runner` / `investigator` / `fb-reporter` job, but that name isn't in their available list) → do **not** hand off; there's nothing to run it on. Reply naming the exact routine to set up, e.g.:
+
+  > That needs your **test-runner** routine, which isn't set up on your account yet. Create it (a Routine on your Claude account → **Add an API trigger**) and send its trigger id + token to the QA team so it runs as you.
+
+  Only name a routine that actually exists (`test-runner`, `investigator`, `fb-reporter`) — never invent one.
+
 ## Never
 
 - Guess a Jira ticket key, PR number, or test name that wasn't actually present in the mention — ask instead

--- a/.claude/integrations/slack/relay/relay.js
+++ b/.claude/integrations/slack/relay/relay.js
@@ -293,20 +293,24 @@ app?.event("app_mention", async ({ event, body, client }) => {
   if (!(await markSeen(client, event.channel, event.ts, body.event_id))) return;
 
   const threadTs = event.thread_ts || event.ts;
-  // ALLOW_FALLBACK gates BOTH entry points the same way: true lets an
-  // unregistered person run on the central owner's routines; false blocks.
-  // A person with no routines yet (IDs pre-loaded, token not added) counts as
-  // unregistered here too — same zero-cost reply as the Jira path, so their
-  // mention never fires the central router by accident.
+  // ALLOW_FALLBACK gates BOTH entry points the same way: true lets a person with
+  // no usable routines run on the central owner's routines; false blocks. A
+  // person with no routines yet (IDs pre-loaded, token not added) still can't
+  // fire the central router by accident — but when blocked, the reason is split
+  // so they know what to do: no people file at all -> not registered; file
+  // present but routines:{} -> on the roster, routine just isn't set up yet.
   const mapped = (p) => p && Object.keys(p.routines || {}).length > 0;
   let person = bySlack[event.user];
   if (!mapped(person) && ALLOW_FALLBACK && byName[CENTRAL_OWNER])
     person = { ...byName[CENTRAL_OWNER], name: `${CENTRAL_OWNER} (fallback for ${event.user})` };
   if (!mapped(person)) {
+    const onRoster = !!bySlack[event.user];
     await client.chat.postMessage({
       channel: event.channel,
       thread_ts: threadTs,
-      text: `:lock: <@${event.user}> you're not registered with PMM AI yet — ask the QA team to add you to the relay map.`,
+      text: onRoster
+        ? `:hourglass_flowing_sand: <@${event.user}> you're on the PMM AI roster, but your personal routine isn't set up yet — create a routine (e.g. Test Runner) and hand its API token to the QA team so jobs run on your account.`
+        : `:lock: <@${event.user}> you're not registered with PMM AI yet — ask the QA team to add you to the relay map.`,
     });
     return;
   }

--- a/.claude/integrations/slack/relay/relay.js
+++ b/.claude/integrations/slack/relay/relay.js
@@ -293,24 +293,20 @@ app?.event("app_mention", async ({ event, body, client }) => {
   if (!(await markSeen(client, event.channel, event.ts, body.event_id))) return;
 
   const threadTs = event.thread_ts || event.ts;
-  // ALLOW_FALLBACK gates BOTH entry points the same way: true lets a person with
-  // no usable routines run on the central owner's routines; false blocks. A
-  // person with no routines yet (IDs pre-loaded, token not added) still can't
-  // fire the central router by accident — but when blocked, the reason is split
-  // so they know what to do: no people file at all -> not registered; file
-  // present but routines:{} -> on the roster, routine just isn't set up yet.
-  const mapped = (p) => p && Object.keys(p.routines || {}).length > 0;
+  // Fire the central router for anyone on the roster (a people/ file exists),
+  // even with routines:{}. The router answers general questions on the central
+  // account and, for a request that needs a routine the caller lacks, names the
+  // one they must set up (see router.md) rather than blocking silently. Only a
+  // stranger with no file is turned away; ALLOW_FALLBACK still lets one run on
+  // the central owner's routines.
   let person = bySlack[event.user];
-  if (!mapped(person) && ALLOW_FALLBACK && byName[CENTRAL_OWNER])
+  if (!person && ALLOW_FALLBACK && byName[CENTRAL_OWNER])
     person = { ...byName[CENTRAL_OWNER], name: `${CENTRAL_OWNER} (fallback for ${event.user})` };
-  if (!mapped(person)) {
-    const onRoster = !!bySlack[event.user];
+  if (!person) {
     await client.chat.postMessage({
       channel: event.channel,
       thread_ts: threadTs,
-      text: onRoster
-        ? `:hourglass_flowing_sand: <@${event.user}> you're on the PMM AI roster, but your personal routine isn't set up yet — create a routine (e.g. Test Runner) and hand its API token to the QA team so jobs run on your account.`
-        : `:lock: <@${event.user}> you're not registered with PMM AI yet — ask the QA team to add you to the relay map.`,
+      text: `:lock: <@${event.user}> you're not registered with PMM AI yet — ask the QA team to add you to the relay map.`,
     });
     return;
   }
@@ -329,8 +325,8 @@ app?.event("app_mention", async ({ event, body, client }) => {
     `{"user":"${event.user}","channel":"${event.channel}","thread_ts":"${threadTs}",` +
     `"agent":"<one of the available routines>","instruction":"<self-contained task for that agent>",` +
     `"cap":"${routeCap}","exp":${exp}} — the work then runs on the caller's own account.\n` +
-    `If the request is off-topic, or no suitable routine is available, do NOT hand off; ` +
-    `reply briefly instead. ${replyInstructions(event.channel, threadTs)}`;
+    `If the request needs a routine the caller doesn't have, or is off-topic, do NOT hand off; ` +
+    `follow router.md to reply — answer a general question, or name the exact routine they must set up and send to QA. ${replyInstructions(event.channel, threadTs)}`;
 
   try {
     console.log(`router-fire for ${person.name}: ${await fire(ROUTER, payload)}`);

--- a/.claude/integrations/slack/relay/relay.js
+++ b/.claude/integrations/slack/relay/relay.js
@@ -315,7 +315,12 @@ app?.event("app_mention", async ({ event, body, client }) => {
   const history = event.thread_ts ? await fetchThreadHistory(client, event.channel, event.thread_ts) : "";
   const exp = Date.now() + CAP_TTL_MS;
   const routeCap = sign("route", [event.user, event.channel, threadTs], exp);
-  const agents = Object.keys(person.routines || {});
+  // Only a routine with BOTH id and token is usable — /route -> fire needs the
+  // token. A half-configured entry (id, no token) is not "available", so the
+  // router nudges them to finish it rather than trying to fire an unusable one.
+  const agents = Object.entries(person.routines || {})
+    .filter(([, r]) => r && r.id && r.token)
+    .map(([name]) => name);
 
   const payload =
     `Slack mention from ${person.name} (${event.user}) in channel ${event.channel} (thread ${threadTs}):\n` +


### PR DESCRIPTION
## What

A person **on the roster** (a `people/` file exists) whose `routines: {}` is empty now gets a useful reply instead of a blanket "not registered", by letting the **central router actually run** for them:

- **A plain question** (needs no routine) → the router just answers.
- **A request that maps to `test-runner` / `investigator` / `fb-reporter` they don't have** → the router names that routine and tells them to create it and send the trigger id + token to QA, so it runs on their account.
- **Someone with no `people/` file at all** → still `:lock: not registered` (ask QA to add you).

## Why

Vasyl and Nailya are in `people/` (identity pre-filled) but never added a routine token. The old gate blocked anyone without a routine with a single, misleading message ("ask QA to add you to the relay map" — but they're already on the map). This makes PMM AI answer their questions and give the exact onboarding step for job requests.

## Changes

- **`relay.js`** — mention gate now fires the central router for anyone with a `people/` file (only a no-file stranger is turned away; `ALLOW_FALLBACK` still routes an unknown user to the central owner). The fire payload's fallback instruction points the router at router.md's "name the routine to set up" behavior.
- **`relay.js`** — `agents` (the caller's available routines) now counts only entries with **both `id` and `token`**, so a half-configured routine isn't offered or routed to (would fail in `fire`). *(CodeRabbit finding.)*
- **`router.md`** — new "When the caller lacks the routine" section: answer plain questions; for a job that needs a routine they don't have, name that routine and the create-and-send-to-QA step.

Supersedes the earlier static two-message split.

## Follow-up (separate PR)

The **Jira button** (`/jira`) still returns `404 not_registered` for both no-file and no-routine. Fixing that needs a distinct status (`409 no_routine`) **and** a paired change to the Jira Automation rule (external), so it's tracked as its own PR — see the open review thread.

## Delivery

`relay.js` runs on the `pmm-ai-relay` Linode — **merging doesn't deploy it**. Redeploy on the box: `git -C /opt/pmm-qa pull` → `cp /opt/pmm-qa/.claude/integrations/slack/relay/relay.js /opt/pmm-ai-relay/relay.js` → `systemctl restart pmm-ai-relay`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBhvZuEUQU8ym347Xat4Yy