### PR TITLE
Mute PMM-T506 behind an expiring skip

### DIFF
--- a/.claude/hooks/lint-changed.sh
+++ b/.claude/hooks/lint-changed.sh
@@ -49,6 +49,7 @@ mapfile -t tf_files < <(select_files '\.tf$')
 mapfile -t docker_files < <(select_files '(^|/)Dockerfile[^/]*$')
 mapfile -t compose_files < <(select_files '(^|/)(docker-)?compose[^/]*\.ya?ml$')
 mapfile -t groovy_files < <(select_files '\.groovy$')
+mapfile -t test_files < <(select_files '\.(js|ts)$')
 
 # TypeScript: each Playwright workspace owns its eslint + tsconfig, so lint the
 # whole workspace rather than the individual files.
@@ -121,6 +122,26 @@ if [ ${#groovy_files[@]} -gt 0 ]; then
   echo "==> npm-groovy-lint"
   ensure_npm_groovy_lint || fail "npm-groovy-lint not installed"
   npm-groovy-lint --failon error --files "$(printf '%s,' "${groovy_files[@]}" | sed 's/,$//')" || fail "npm-groovy-lint"
+fi
+
+# A skip parked with `skip-until: YYYY-MM-DD` becomes a lint failure on that
+# date, so a temporary skip cannot quietly become permanent. CI passes every
+# tracked file, so once a date is reached every PR fails here until the skip is
+# revisited or the date is deliberately moved. Only skips that opted in by
+# carrying the marker are checked.
+if [ ${#test_files[@]} -gt 0 ]; then
+  echo "==> skip-until expiry"
+  mapfile -t expired < <(
+    grep -HnoE 'skip-until:[[:space:]]*[0-9]{4}-[0-9]{2}-[0-9]{2}' "${test_files[@]}" 2>/dev/null |
+      awk -v today="$(date -u +%F)" '
+        match($0, /[0-9]{4}-[0-9]{2}-[0-9]{2}/) {
+          d = substr($0, RSTART, RLENGTH)
+          if (d "" <= today "") print $0
+        }'
+  )
+  for hit in "${expired[@]}"; do
+    [ -n "$hit" ] && fail "skip-until date reached -- revisit the skip or move the date: $hit"
+  done
 fi
 
 exit $rc

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches:
       - main
+  # Weekly, so a skip-until date that passes during a quiet week still surfaces
+  # instead of waiting for the next PR.
+  schedule:
+    - cron: '0 7 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/codeceptjs-e2e/tests/verifyVMDashboards_test.js
+++ b/codeceptjs-e2e/tests/verifyVMDashboards_test.js
@@ -6,7 +6,7 @@ Before(async ({ I }) => {
   await I.Authorize();
 });
 
-// Muted: expects the cardinality panels percona/pmm#5822 removed. Unskip with pmm-qa#1275, or when the panels return.
+// skip-until: 2026-09-29 -- cardinality panels removed by percona/pmm#5822; unskip via pmm-qa#1275, or when the panels return.
 Scenario.skip(
   'PMM-T506 - Verify metrics on VictoriaMetrics dashboard @nightly  @dashboards @gssapi-nightly',
   async ({ I, dashboardPage }) => {

--- a/codeceptjs-e2e/tests/verifyVMDashboards_test.js
+++ b/codeceptjs-e2e/tests/verifyVMDashboards_test.js
@@ -6,7 +6,8 @@ Before(async ({ I }) => {
   await I.Authorize();
 });
 
-Scenario(
+// Muted: expects the cardinality panels percona/pmm#5822 removed. Unskip with pmm-qa#1275, or when the panels return.
+Scenario.skip(
   'PMM-T506 - Verify metrics on VictoriaMetrics dashboard @nightly  @dashboards @gssapi-nightly',
   async ({ I, dashboardPage }) => {
     I.amOnPage(dashboardPage.victoriaMetricsDashboard.url);


### PR DESCRIPTION
## Failures fixed (investigator)

- source: nightly CI run https://github.com/percona/pmm-qa/actions/runs/33222594797 (`Nightly E2E tests Matrix (remote PMM Server)`, job `test execution / @nightly`) — also red Aug 30 and Aug 31 on the same test
- tests:
  - `codeceptjs-e2e/tests/verifyVMDashboards_test.js:10` / `@nightly` — PMM-T506 Verify metrics on VictoriaMetrics dashboard

## What this is

A **noise mute that expires by construction** — an alternative to #1275, which is not being merged as it stands.

PMM-T506 expects a `Time Series Information` row with `Top 10 metrics by time series count` and
`Top 10 hosts by time series count`. [percona/pmm#5822](https://github.com/percona/pmm/pull/5822)
removed both deliberately — in the author's words, *"they were literally taking PMM Server down
under high load, i.e. 300+ clients."* So the test fails every night and will keep failing until the
expectation drops (#1275) or the panels come back.

Two parts:

**1. The mute** (`verifyVMDashboards_test.js`)

```diff
+// skip-until: 2026-09-29 -- cardinality panels removed by percona/pmm#5822; unskip via pmm-qa#1275, or when the panels return.
-Scenario(
+Scenario.skip(
```

**2. A guard that makes the date real** (`lint-changed.sh`, `lint.yml`)

A skip parked with `skip-until: YYYY-MM-DD` becomes a lint failure on that date.

## Why the guard, and not just a TODO

This repo carries **69 skipped scenarios across 32 files**, and the convention already in use is
exactly a TODO with a ticket link — `// TODO: unskip after …PMM-13544`, `…PMM-12956` (twice),
`PMM-14002`, `PMM-13750`. Two of those references are already **dead**: one points at
`jira.percona.com`, the Jira instance the project migrated off, and one at a `grafana-dashboards`
PR for a repo since folded into the monorepo. Dead links guarding dormant tests.

So a comment and a ticket is the mechanism with a demonstrated 69× failure rate here. A date the
build enforces does not depend on anyone remembering.

**Where the teeth are:** `lint.yml` runs `git ls-files | xargs lint-changed.sh`, i.e. **every
tracked file on every PR**. Once `2026-09-29` arrives, every PR in the repo fails lint until the
skip is revisited or the date is deliberately moved. A weekly `schedule` was added so it also
surfaces during a quiet week with no PR traffic.

The check lives in `lint-changed.sh` rather than as a workflow step because that script already
owns the linter mapping for both CI and the local PreToolUse commit gate — its own header warns
that re-listing linters in the workflow is how the two drift apart.

**Opt-in by design:** only skips that carry the marker are checked, so the existing 69 are
untouched and CI stays green today. Adopting it for them can be a deliberate, separate pass.

## Relationship to #1275 — please don't merge both

They are alternatives and touch different files, so nothing stops both landing and leaving the test
skipped *and* the expectations dropped — the skip would then mask a test already made correct.

- Merge **this** → nightly quiet, no VictoriaMetrics dashboard coverage, forced review on 2026-09-29.
- Merge **#1275** → nightly quiet, coverage kept. Then close this PR, or revert it if it landed first.

## What the mute costs — worth being explicit

`Scenario.skip` disables the **whole** scenario, not just the two stale expectations: the ~40 other
panel titles it checks, and `verifyThereAreNoGraphsWithoutData(1)`. Until it is unskipped, nothing
catches a genuinely broken or empty VictoriaMetrics dashboard. That is the reason for the expiry
rather than an open-ended skip.

I checked whether the test could leave the nightly but stay alive elsewhere — it cannot. Its other
two tags are dead: **no workflow references `@dashboards` or `@gssapi-nightly`**, and `@nightly`
appears in exactly one place (`nightly-e2e-tests-matrix.yml:140`). Skipping and untagging cost
identical coverage, and `Scenario.skip` at least shows as `S` in the run output rather than leaving
a test nothing silently runs.

Given that cost, #1275 remains the better outcome if its objection can be resolved.

## Verification

Skip behaviour:

```
$ npx codeceptjs run -c pr.codecept.js --grep 'PMM-T506'
  S PMM-T506 - Verify metrics on VictoriaMetrics dashboard @nightly  @dashboards @gssapi-nightly
  OK  | 0 passed, 1 skipped   // 12ms
```

No server contact, and PMM-T507 in the same file is untouched and still runs.

Guard, both directions:

| case | result |
|---|---|
| date in the future (`2026-09-29`, today `2026-09-01`) | `==> skip-until expiry`, `rc=0` |
| date in the past (`2026-08-15`) | `FAIL: skip-until date reached … :9:skip-until: 2026-08-15`, `rc=1` |
| date is today (`2026-09-01`) — boundary | `rc=1` (the date means *review on it*, not after) |
| all 393 tracked `.js`/`.ts` files | exactly one marker — the 69 existing skips do not trip it |

Repo linters on the changed files (`yamllint`, `actionlint`, `shellcheck`, plus the new check) — all
clean, `rc=0`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKRuqWTQVW4p6DDSYcFQEf