### PR TITLE
Refactor dashboard panel collection to use scroll helper

### DIFF
--- a/e2e_tests/pages/dashboards/dashboards.page.ts
+++ b/e2e_tests/pages/dashboards/dashboards.page.ts
@@ -308,14 +308,7 @@ export default class Dashboards extends BasePage {
 
     await this.elements.panelName.first().waitFor({ state: 'visible' });
 
-    for (let i = 0; i < (await this.elements.gridItems.count()); i++) {
-      const item = this.elements.gridItems.nth(i);
-
-      await item.scrollIntoViewIfNeeded();
-    }
-
-    // eslint-disable-next-line playwright/prefer-web-first-assertions -- the order might be different
-    const availableMetrics = await this.elements.panelName.allTextContents();
+    const availableMetrics = await this.collectTextsAcrossScroll(this.elements.panelName);
 
     expect
       .soft(

--- a/e2e_tests/pages/dashboards/mongo/mongodbReplSetSummary.ts
+++ b/e2e_tests/pages/dashboards/mongo/mongodbReplSetSummary.ts
@@ -115,6 +115,10 @@ export default class MongodbReplSetSummary implements DashboardInterface {
   noDataMetricsForRow = (rowName: string, serviceNames: string[]): string[] => {
     const noDataMetrics: string[] = [
       {
+        metrics: [{ name: 'Top Hottest Collections by Write', type: 'barGauge' }],
+        rowName: 'Details',
+      },
+      {
         metrics: [
           ...serviceNames.map((serviceName): GrafanaPanel => ({
             name: `Oplog GB/Hour - ${serviceName}`,


### PR DESCRIPTION
Simplifies the logic for collecting panel names across scrollable dashboard content by extracting the scroll iteration pattern into a reusable helper method.

**Changes:**
- Replace manual scroll loop in `dashboards.page.ts` with call to `collectTextsAcrossScroll()` helper method
- Add missing metric configuration for "Top Hottest Collections by Write" panel in MongoDB replica set summary test data

**Details:**
The refactoring reduces code duplication by using an existing helper method instead of manually iterating through grid items and scrolling. This maintains the same behavior while improving maintainability.

https://claude.ai/code/session_01MctUftEcG6kYTSW9EFcdhB