### PR TITLE
Make PMM-T1087's postgres-db drop deterministic

### DIFF
--- a/codeceptjs-e2e/docker-compose-nomad.yml
+++ b/codeceptjs-e2e/docker-compose-nomad.yml
@@ -112,8 +112,9 @@ services:
   # it needs for deleting postgres db for test T1087
   postgresremovedefaultdb:
     image: ${POSTGRES_IMAGE:-perconalab/percona-distribution-postgresql:15}
-    command: >
-      psql -Utest -hpostgresnodb -dnot_default_db -c 'DROP DATABASE postgres WITH (FORCE);'
+    entrypoint: ["bash", "/scripts/drop_default_db.sh"]
+    volumes:
+      - ./testdata/docker-db-setup-scripts/drop_default_db.sh:/scripts/drop_default_db.sh:ro
     depends_on:
       postgresnodb:
         condition: service_healthy

--- a/codeceptjs-e2e/docker-compose.yml
+++ b/codeceptjs-e2e/docker-compose.yml
@@ -129,8 +129,9 @@ services:
   # it needs for deleting postgres db for test T1087
   postgresremovedefaultdb:
     image: ${POSTGRES_IMAGE:-perconalab/percona-distribution-postgresql:15}
-    command: >
-      psql -Utest -hpostgresnodb -dnot_default_db -c 'DROP DATABASE postgres WITH (FORCE);'
+    entrypoint: ["bash", "/scripts/drop_default_db.sh"]
+    volumes:
+      - ./testdata/docker-db-setup-scripts/drop_default_db.sh:/scripts/drop_default_db.sh:ro
     depends_on:
       postgresnodb:
         condition: service_healthy

--- a/codeceptjs-e2e/testdata/db_setup.sh
+++ b/codeceptjs-e2e/testdata/db_setup.sh
@@ -13,7 +13,7 @@ bash -x ${repo_root}/testdata/docker-db-setup-scripts/docker_ps_8_0.sh
 bash -x ${repo_root}/testdata/docker-db-setup-scripts/docker_postgres_13.sh
 
 ### Assert PMM-T1087's precondition: no `postgres` database on postgresnodb
-bash -x ${repo_root}/testdata/docker-db-setup-scripts/verify_no_default_db.sh
+bash -x ${repo_root}/testdata/docker-db-setup-scripts/verify_no_default_db.sh || exit 1
 
 ### SSL instance setup along with slowlog
 ##bash -x ${repo_root}/testdata/docker-db-setup-scripts/docker_mysql_ssl_8_0.sh

--- a/codeceptjs-e2e/testdata/db_setup.sh
+++ b/codeceptjs-e2e/testdata/db_setup.sh
@@ -12,6 +12,9 @@ bash -x ${repo_root}/testdata/docker-db-setup-scripts/docker_ps_8_0.sh
 ### Call Postgres Docker Setup Script
 bash -x ${repo_root}/testdata/docker-db-setup-scripts/docker_postgres_13.sh
 
+### Assert PMM-T1087's precondition: no `postgres` database on postgresnodb
+bash -x ${repo_root}/testdata/docker-db-setup-scripts/verify_no_default_db.sh
+
 ### SSL instance setup along with slowlog
 ##bash -x ${repo_root}/testdata/docker-db-setup-scripts/docker_mysql_ssl_8_0.sh
 

--- a/codeceptjs-e2e/testdata/docker-db-setup-scripts/drop_default_db.sh
+++ b/codeceptjs-e2e/testdata/docker-db-setup-scripts/drop_default_db.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Runs inside the postgres image as the `postgresremovedefaultdb` one-shot.
+# PMM-T1087 needs postgresnodb to have no `postgres` database, so PMM's pre-add
+# connection check rejects the service. Retry until the drop is confirmed: a
+# single psql leaves the database behind on any transient failure, PMM then
+# legitimately accepts the service, and the test fails much later looking like a
+# product bug.
+
+host=${POSTGRES_NO_DB_HOST:-postgresnodb}
+user=${POSTGRES_NO_DB_USER:-test}
+db=${POSTGRES_NO_DB_NAME:-not_default_db}
+attempts=${POSTGRES_NO_DB_ATTEMPTS:-30}
+
+for attempt in $(seq 1 "${attempts}"); do
+  psql -U "${user}" -h "${host}" -d "${db}" -c 'DROP DATABASE IF EXISTS postgres WITH (FORCE);'
+  remaining=$(psql -U "${user}" -h "${host}" -d "${db}" -Atc \
+    "SELECT count(*) FROM pg_database WHERE datname = 'postgres'")
+  if [ "${remaining}" = 0 ]; then
+    echo "postgres database dropped on ${host} (attempt ${attempt})"
+    exit 0
+  fi
+  echo "attempt ${attempt}: postgres database still present on ${host}, retrying"
+  sleep 2
+done
+
+echo "failed to drop the postgres database on ${host} after ${attempts} attempts" >&2
+exit 1

--- a/codeceptjs-e2e/testdata/docker-db-setup-scripts/drop_default_db.sh
+++ b/codeceptjs-e2e/testdata/docker-db-setup-scripts/drop_default_db.sh
@@ -1,28 +1,22 @@
 #!/bin/bash
 
 # Runs inside the postgres image as the `postgresremovedefaultdb` one-shot.
-# PMM-T1087 needs postgresnodb to have no `postgres` database, so PMM's pre-add
-# connection check rejects the service. Retry until the drop is confirmed: a
-# single psql leaves the database behind on any transient failure, PMM then
-# legitimately accepts the service, and the test fails much later looking like a
-# product bug.
+# PMM-T1087 needs postgresnodb to have no `postgres` database; retry until that
+# is confirmed, since a single psql leaves it behind on a transient failure.
 
-host=${POSTGRES_NO_DB_HOST:-postgresnodb}
-user=${POSTGRES_NO_DB_USER:-test}
-db=${POSTGRES_NO_DB_NAME:-not_default_db}
-attempts=${POSTGRES_NO_DB_ATTEMPTS:-30}
+export PGCONNECT_TIMEOUT=5
 
-for attempt in $(seq 1 "${attempts}"); do
-  psql -U "${user}" -h "${host}" -d "${db}" -c 'DROP DATABASE IF EXISTS postgres WITH (FORCE);'
-  remaining=$(psql -U "${user}" -h "${host}" -d "${db}" -Atc \
+for attempt in $(seq 1 30); do
+  psql -w -Utest -hpostgresnodb -dnot_default_db -c 'DROP DATABASE IF EXISTS postgres WITH (FORCE);'
+  remaining=$(psql -w -Utest -hpostgresnodb -dnot_default_db -Atc \
     "SELECT count(*) FROM pg_database WHERE datname = 'postgres'")
   if [ "${remaining}" = 0 ]; then
-    echo "postgres database dropped on ${host} (attempt ${attempt})"
+    echo "postgres database dropped on postgresnodb (attempt ${attempt})"
     exit 0
   fi
-  echo "attempt ${attempt}: postgres database still present on ${host}, retrying"
+  echo "attempt ${attempt}: postgres database still present on postgresnodb, retrying"
   sleep 2
 done
 
-echo "failed to drop the postgres database on ${host} after ${attempts} attempts" >&2
+echo "failed to drop the postgres database on postgresnodb after 30 attempts" >&2
 exit 1

--- a/codeceptjs-e2e/testdata/docker-db-setup-scripts/verify_no_default_db.sh
+++ b/codeceptjs-e2e/testdata/docker-db-setup-scripts/verify_no_default_db.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Runs on the host from db_setup.sh. `docker compose up -d` never checks the
+# exit code of the drop one-shot, so assert the state PMM-T1087 depends on here,
+# where a failure fails the setup step instead of a test 10 minutes later.
+
+compose_file=${DOCKER_COMPOSE_FILE:-docker-compose.yml}
+service=${POSTGRES_NO_DB_SERVICE:-postgresnodb}
+drop_service=${POSTGRES_NO_DB_DROP_SERVICE:-postgresremovedefaultdb}
+user=${POSTGRES_NO_DB_USER:-test}
+db=${POSTGRES_NO_DB_NAME:-not_default_db}
+
+drop_container=$(docker compose -f "${compose_file}" ps -aq "${drop_service}")
+if [ -n "${drop_container}" ]; then
+  drop_status=$(docker wait "${drop_container}")
+  if [ "${drop_status}" != 0 ]; then
+    echo "${drop_service} exited with ${drop_status}:" >&2
+    docker logs "${drop_container}" >&2
+  fi
+fi
+
+remaining=$(docker compose -f "${compose_file}" exec -T "${service}" \
+  psql -U "${user}" -d "${db}" -Atc \
+  "SELECT count(*) FROM pg_database WHERE datname = 'postgres'")
+
+if [ "${remaining}" != 0 ]; then
+  echo "${service} still has a postgres database — PMM-T1087 expects its connection check to fail" >&2
+  exit 1
+fi
+
+echo "${service} has no postgres database, as PMM-T1087 expects"

--- a/codeceptjs-e2e/testdata/docker-db-setup-scripts/verify_no_default_db.sh
+++ b/codeceptjs-e2e/testdata/docker-db-setup-scripts/verify_no_default_db.sh
@@ -1,31 +1,33 @@
 #!/bin/bash
 
-# Runs on the host from db_setup.sh. `docker compose up -d` never checks the
-# exit code of the drop one-shot, so assert the state PMM-T1087 depends on here,
-# where a failure fails the setup step instead of a test 10 minutes later.
+# Runs on the host from db_setup.sh, asserting the state PMM-T1087 depends on.
 
 compose_file=${DOCKER_COMPOSE_FILE:-docker-compose.yml}
-service=${POSTGRES_NO_DB_SERVICE:-postgresnodb}
-drop_service=${POSTGRES_NO_DB_DROP_SERVICE:-postgresremovedefaultdb}
-user=${POSTGRES_NO_DB_USER:-test}
-db=${POSTGRES_NO_DB_NAME:-not_default_db}
 
-drop_container=$(docker compose -f "${compose_file}" ps -aq "${drop_service}")
+drop_container=$(docker compose -f "${compose_file}" ps -aq postgresremovedefaultdb)
 if [ -n "${drop_container}" ]; then
-  drop_status=$(docker wait "${drop_container}")
+  drop_status=$(timeout 120 docker wait "${drop_container}") || drop_status=timeout
   if [ "${drop_status}" != 0 ]; then
-    echo "${drop_service} exited with ${drop_status}:" >&2
+    echo "postgresremovedefaultdb exited with ${drop_status}:" >&2
     docker logs "${drop_container}" >&2
   fi
 fi
 
-remaining=$(docker compose -f "${compose_file}" exec -T "${service}" \
-  psql -U "${user}" -d "${db}" -Atc \
+remaining=$(timeout 60 docker compose -f "${compose_file}" exec -T \
+  -e PGCONNECT_TIMEOUT=5 postgresnodb \
+  psql -w -U test -d not_default_db -Atc \
   "SELECT count(*) FROM pg_database WHERE datname = 'postgres'")
 
-if [ "${remaining}" != 0 ]; then
-  echo "${service} still has a postgres database — PMM-T1087 expects its connection check to fail" >&2
-  exit 1
-fi
+case "${remaining}" in
+  0) ;;
+  *[!0-9]*|"")
+    echo "could not read pg_database on postgresnodb (got '${remaining}')" >&2
+    exit 1
+    ;;
+  *)
+    echo "postgresnodb still has a postgres database — PMM-T1087 expects its connection check to fail" >&2
+    exit 1
+    ;;
+esac
 
-echo "${service} has no postgres database, as PMM-T1087 expects"
+echo "postgresnodb has no postgres database, as PMM-T1087 expects"


### PR DESCRIPTION
## Failures fixed (investigator)

- source: Percona-Lab/pmm-submodules PR #4543 — run [33638736972](https://github.com/Percona-Lab/pmm-submodules/actions/runs/33638736972), check `E2E / Instances UI tests / e2e tests: @fb-instances`
- tests:
  - `codeceptjs-e2e/tests/verifyRemoteInstances_test.js:316` / `@fb-instances` — PMM-T1087 Verify adding PostgreSQL remote instance without postgres database

## What failed

The only red job of 30 (Launchable gate: `1 actionable, 0 quarantined`; 31 passed, 1 failed, 15 skipped), and it failed both attempts of `Feature(...).retry(1)`:

```
expected element [role="alert"], [role="status"] to include
  "Connection check failed: pq: database "postgres" does not exist"

      + expected - actual
      -Service “arbustum_service” added to your inventory
       Your PostgreSQL service instance is now ready to be monitored.
```

The test points a remote PostgreSQL service at `postgresnodb` with database `postgres`
and expects PMM's pre-add connection check to reject it. Instead the service was added.

## Root cause — the QA setup, not the product

`postgresnodb` **had** a `postgres` database in that run. From the run's own
`pmm-managed.log`:

```
CheckConnectionRequest: DSN: postgres://...@postgresnodb:5432/postgres?connect_timeout=2&sslmode=disable
CheckConnection response: .
ServiceInfo response: version:"15.19 - Percona Distribution"
  database_list:"postgres" database_list:"not_default_db"
```

The connection check succeeded, `pg_database` listed `postgres`, and the service's
`postgres_exporter` log has no connection errors. PMM did the right thing.

That database is supposed to be removed during setup by the one-shot
`postgresremovedefaultdb` container:

```yaml
command: >
  psql -Utest -hpostgresnodb -dnot_default_db -c 'DROP DATABASE postgres WITH (FORCE);'
```

One attempt, no verification — and `docker compose up -d` never looks at its exit
code, so when that `psql` fails the run continues with the wrong precondition and the
test fails ~12 minutes later with a message that reads like a product regression.

## Reproduced

On a throwaway Linode VM running the FB server image `perconalab/pmm-server-fb:PR-4543-018d0e8`,
`AddService` against the same `postgresnodb` container, same payload the UI sends:

| `postgres` database | Result |
| --- | --- |
| absent (the state T1087 expects) | `HTTP 400` — `Connection check failed: pq: database "postgres" does not exist (3D000).` |
| present (the state the FB run had) | `200` — service created, exactly the toast the test saw |

So the outcome is entirely determined by whether the setup dropped that database;
the product behaves correctly in both cases.

The drop itself succeeded 6/6 on an idle box, so the original `psql` failure was
transient and is not captured in the CI logs. What is reproducible is the failure
*mode* — the old one-shot dies on the first hiccup and says nothing:

```
psql: error: could not translate host name "postgresnodb" to address: Name or service not known
```

## Fix

- `drop_default_db.sh` (run by the one-shot) retries the drop until it is **confirmed
  gone** via `pg_database`, so a transient resolve/connect error self-heals. Verified
  on the VM: with `postgresnodb` down when the one-shot starts, it recovers on attempt 6
  and exits 0 — the old command would have exited non-zero at attempt 1 and left the
  database in place.
- `verify_no_default_db.sh`, called from `db_setup.sh`, asserts the precondition on the
  host (and surfaces the one-shot's exit code and logs). Verified both ways: exit 0 in
  the good state, exit 1 with `postgresnodb still has a postgres database …` after
  re-creating it.
- Both sides are time-bounded (`PGCONNECT_TIMEOUT`, `timeout` around `docker wait` and
  the query), so an unreachable `postgresnodb` fails within a known budget instead of
  hanging the setup step — see the review thread.

The assertion in the test is untouched — the `postgres` database really must be absent
for T1087 to mean anything, so the setup is what had to become reliable.

## CI on this branch

`FB E2E tests / Instances UI tests / e2e tests: @fb-instances` — the suite containing
PMM-T1087 — passed on **both** commits, each time with 35 tests found, 35 passed,
0 failed at `LAUNCHABLE_CONFIDENCE: 100%`, with `Setup PMM Server` (which now runs the
assertion via `db_setup.sh`) green:

- `cdc7d9d` — run [33650775022](https://github.com/percona/pmm-qa/actions/runs/33650775022), job completed 16:27:25 UTC. That run reads `cancelled` overall only because `c6c8ab7` superseded it while three unrelated jobs were still going; the Instances job had already finished green.
- `c6c8ab7` (timeouts, inlined literals, explicit exit propagation) — run [33655528833](https://github.com/percona/pmm-qa/actions/runs/33655528833), **all 30 jobs green**. `@ssl-mongo` was red on the first attempt for an unrelated reason — a publish/mirror-sync race in Percona's `pbm-testing` yum repo broke the `ssl_psmdb` image build — and passed on one re-run; details in the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCsB6xKBJ8gxnjJUKmRVjV