### PR TITLE
Replace partial name lookup with regex-based service queries

### DIFF
--- a/.github/workflows/upgrade-pmm-runner.yml
+++ b/.github/workflows/upgrade-pmm-runner.yml
@@ -272,6 +272,8 @@ jobs:
 
       - name: Post-client-upgrade UI tests
         working-directory: pmm-qa/e2e_tests
+        env:
+          PMM_SERVER_LATEST: ${{ steps.resolve.outputs.PMM_SERVER_LATEST }}
         run: npx playwright test --grep "@post-upgrade|@rta"
 
       - name: Check packages after upgrade

--- a/e2e_tests/tests/inventory/services.test.ts
+++ b/e2e_tests/tests/inventory/services.test.ts
@@ -8,7 +8,7 @@ pmmTest.beforeEach(async ({ grafanaHelper, page, servicesPage }) => {
 pmmTest(
   'PMM-T2159 - Verify MongoDB RTA Agent displayed in Inventory UI @rta',
   async ({ agentsPage, api, servicesPage }) => {
-    const service = await api.inventoryApi.getServiceDetailsByPartialName('rs101');
+    const service = await api.inventoryApi.getServiceDetailsByRegex('^rs101_');
 
     await api.realTimeAnalyticsApi.startRealTimeAnalytics(service.service_id);
     await servicesPage.builders.monitoringStatusByServiceName(service.service_name).click();

--- a/e2e_tests/tests/qan/rta/autoRefresh.test.ts
+++ b/e2e_tests/tests/qan/rta/autoRefresh.test.ts
@@ -5,7 +5,7 @@ import { Timeouts } from '@helpers/timeouts';
 pmmTest.beforeEach(async ({ api, grafanaHelper, page, realTimeAnalyticsPage }) => {
   await grafanaHelper.authorize();
 
-  const service = await api.inventoryApi.getServiceDetailsByPartialName('rs101');
+  const service = await api.inventoryApi.getServiceDetailsByRegex('^rs101_');
 
   await api.realTimeAnalyticsApi.startRealTimeAnalytics(service.service_id);
   await page.goto(realTimeAnalyticsPage.getUrlWithServices([service.service_id]));

--- a/e2e_tests/tests/qan/rta/details.test.ts
+++ b/e2e_tests/tests/qan/rta/details.test.ts
@@ -5,7 +5,7 @@ import { expect } from '@playwright/test';
 pmmTest.beforeEach(async ({ api, grafanaHelper, page, queryAnalytics }) => {
   await grafanaHelper.authorize();
 
-  const service = await api.inventoryApi.getServiceDetailsByPartialName('rs101');
+  const service = await api.inventoryApi.getServiceDetailsByRegex('^rs101_');
 
   await api.realTimeAnalyticsApi.startRealTimeAnalytics(service.service_id);
   await page.goto(queryAnalytics.rta.getUrlWithServices([service.service_id]));

--- a/e2e_tests/tests/qan/rta/general.test.ts
+++ b/e2e_tests/tests/qan/rta/general.test.ts
@@ -5,7 +5,7 @@ import { Timeouts } from '@helpers/timeouts';
 pmmTest.beforeEach(async ({ api, grafanaHelper, page, queryAnalytics }) => {
   await grafanaHelper.authorize();
 
-  const service = await api.inventoryApi.getServiceDetailsByPartialName('rs101');
+  const service = await api.inventoryApi.getServiceDetailsByRegex('^rs101_');
 
   await api.realTimeAnalyticsApi.startRealTimeAnalytics(service.service_id);
   await page.goto(queryAnalytics.rta.getUrlWithServices([service.service_id]));

--- a/e2e_tests/tests/qan/rta/overview.test.ts
+++ b/e2e_tests/tests/qan/rta/overview.test.ts
@@ -8,8 +8,8 @@ let sortedHostNames: string[];
 pmmTest.beforeEach(async ({ api, grafanaHelper, page, queryAnalytics }) => {
   await grafanaHelper.authorize();
 
-  const service1 = await api.inventoryApi.getServiceDetailsByPartialName('rs101');
-  const service2 = await api.inventoryApi.getServiceDetailsByPartialName('rs102');
+  const service1 = await api.inventoryApi.getServiceDetailsByRegex('^rs101_');
+  const service2 = await api.inventoryApi.getServiceDetailsByRegex('^rs102_');
 
   sortedHostNames = [service1.service_name, service2.service_name].sort();
 

--- a/e2e_tests/tests/qan/rta/redirection.test.ts
+++ b/e2e_tests/tests/qan/rta/redirection.test.ts
@@ -10,7 +10,7 @@ pmmTest.beforeEach(async ({ grafanaHelper, page }) => {
 pmmTest(
   'PMM-T2195 Verify user is redirected to Sessions page when sessions are running @rta',
   async ({ api, helpPage, page, queryAnalytics, realTimeAnalyticsPage }) => {
-    const service = await api.inventoryApi.getServiceDetailsByPartialName('rs101');
+    const service = await api.inventoryApi.getServiceDetailsByRegex('^rs101_');
 
     await api.realTimeAnalyticsApi.startRealTimeAnalytics(service.service_id);
 

--- a/e2e_tests/tests/qan/rta/session.test.ts
+++ b/e2e_tests/tests/qan/rta/session.test.ts
@@ -8,8 +8,8 @@ let rs102ServiceId: string;
 pmmTest.beforeEach(async ({ api, grafanaHelper }) => {
   await grafanaHelper.authorize();
 
-  const service1 = await api.inventoryApi.getServiceDetailsByPartialName('rs101');
-  const service2 = await api.inventoryApi.getServiceDetailsByPartialName('rs102');
+  const service1 = await api.inventoryApi.getServiceDetailsByRegex('^rs101_');
+  const service2 = await api.inventoryApi.getServiceDetailsByRegex('^rs102_');
 
   rs101ServiceId = service1.service_id;
   rs102ServiceId = service2.service_id;


### PR DESCRIPTION
Update e2e tests to use regex-based service lookup instead of partial name matching for improved precision when retrieving MongoDB RTA services.

**Changes:**
- Replace `getServiceDetailsByPartialName()` calls with `getServiceDetailsByRegex()` using anchored patterns (`^rs101_`, `^rs102_`) across all RTA and inventory test files
- Add `PMM_SERVER_LATEST` environment variable to post-upgrade UI test step in CI workflow

**Rationale:**
The regex-based approach provides more precise service matching by anchoring patterns to the service name prefix, reducing the risk of matching unintended services when multiple services with similar names exist in the test environment.

https://claude.ai/code/session_01Jfa9TRv3eUmizp4AyqNHDr