### PR TITLE
Add upgrade test suite and extend Grafana helper with dashboard/folder management

### DIFF
--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -1,0 +1,113 @@
+# PMM Playwright E2E Tests
+
+This folder contains the Playwright end-to-end test suite for PMM.
+It includes tests, shared fixtures, page objects, helpers, API clients, and test data.
+
+## Folder Map
+
+| Path                   | Purpose                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| `tests/`               | Test entrypoints grouped by PMM area.                                          |
+| `fixtures/`            | Shared Playwright fixtures. Tests use `pmmTest` from `@fixtures/pmmTest`.      |
+| `pages/`               | Page objects for PMM pages and Grafana dashboards.                             |
+| `components/`          | Reusable UI components, mostly dashboard panels.                               |
+| `helpers/`             | Shared helpers for API, URL, auth, CLI, metrics, mocks, MongoDB, and timeouts. |
+| `api/`                 | API clients used by UI and API tests.                                          |
+| `interfaces/`          | Shared TypeScript types.                                                       |
+| `testdata/`            | Test data used by specific scenarios.                                          |
+| `playwright.config.ts` | Playwright runtime configuration.                                              |
+
+## Getting Started
+
+- Open the `e2e_tests` folder in terminal.
+- Install Node.js 18+ and make sure `npx` is available.
+- Install dependencies: `npm ci`.
+- Install Playwright browsers: `npx playwright install chromium`.
+- Make sure the target PMM server is available.
+
+Create `e2e_tests/.env` before running tests. These are default values; change them for your PMM environment:
+
+```env
+PMM_UI_URL=http://localhost/
+ADMIN_PASSWORD=admin
+HEADLESS=true
+WORKERS=1
+```
+
+| Variable         | Default             | Purpose                                                |
+| ---------------- | ------------------- | ------------------------------------------------------ |
+| `PMM_UI_URL`     | `http://localhost/` | PMM server base URL.                                   |
+| `ADMIN_PASSWORD` | `admin`             | Password used to authenticate as PMM `admin`.          |
+| `HEADLESS`       | `true`              | Browser visibility; use `false` for a visible browser. |
+| `WORKERS`        | `1`                 | Playwright worker count.                               |
+
+## Running Tests
+
+Run commands from `e2e_tests/`.
+
+| Goal                  | Command                                                |
+| --------------------- | ------------------------------------------------------ |
+| Run all tests         | `npx playwright test`                                  |
+| Run one file          | `npx playwright test tests/<filename>.test.ts`         |
+| Run one folder        | `npx playwright test tests/<folder>`                   |
+| Run by test title     | `npx playwright test --grep "<test-title-or-id>"`      |
+| Run by tag            | `npx playwright test --grep "@<tag>"`                  |
+| Run by multiple tags  | `npx playwright test --grep "@<tag-1>\|@<tag-2>"`      |
+| Run previous failures | `npx playwright test --last-failed`                    |
+| Run headed            | `npx playwright test --headed`                         |
+| Open UI mode          | `npx playwright test --ui`                             |
+| Debug one file        | `npx playwright test tests/<filename>.test.ts --debug` |
+| Record traces         | `npx playwright test --trace on`                       |
+| View a trace          | `npx playwright show-trace <path-to-trace.zip>`        |
+| Open HTML report      | `npx playwright show-report <report-folder>`           |
+
+Runtime defaults:
+
+- Browser project: `chromium`
+- Test directory: `tests/`
+- Test timeout: 10 minutes
+- Global timeout: 30 minutes
+- Fully parallel: `true`
+- Workers: `WORKERS`, or `1`
+- Retries: `2` in CI, `0` locally
+- Viewport: `1920x1080`
+- Headless: `true` unless `HEADLESS=false`
+- Screenshots: only on failure
+- Traces: retained on first failure
+
+Use shared timeout values from `@helpers/timeouts`.
+
+For test, page-object, fixture, and helper conventions, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## Available Tags
+
+<!-- E2E-TAGS-START -->
+
+- `@alerting`
+- `@dashboards`
+- `@docker-configuration`
+- `@downloads`
+- `@ha-settings`
+- `@image-renderer`
+- `@inventory`
+- `@LBAC`
+- `@new-navigation`
+- `@nightly`
+- `@pmm-ps-integration`
+- `@pmm-ps-pxc-haproxy-integration`
+- `@pmm-upgrade`
+- `@pmm-valkey-integration`
+- `@post-release`
+- `@pre-upgrade`
+- `@rta`
+- `@settings`
+- `@standalone`
+
+<!-- E2E-TAGS-END -->
+
+## Related Workspaces
+
+- [CLI Tests](../cli/README.md) - focused `pmm-admin` CLI tests.
+- [CodeceptJS E2E Tests](../codeceptjs-e2e/README.md) - existing CodeceptJS tests.
+- [Package Tests](../package_tests/README.md) - PMM client package install and upgrade validation.
+- [QA Integration](../qa-integration/README.md) - database and PMM integration environment setup.

--- a/e2e_tests/api/alerting.api.ts
+++ b/e2e_tests/api/alerting.api.ts
@@ -1,0 +1,70 @@
+import { APIRequestContext } from '@playwright/test';
+import apiEndpoints from '@helpers/apiEndpoints';
+import GrafanaHelper from '@helpers/grafana.helper';
+
+type Headers = Record<string, string>;
+
+export interface AlertTemplateBody {
+  yaml: string;
+}
+
+export interface CreateRuleBody {
+  for?: string;
+  interval?: string;
+  severity?: string;
+  template_name: string;
+  name?: string;
+  params?: [{ name: string; type: string; float: number }];
+  group?: string;
+  folder_uid?: string;
+  filters?: {
+    label: string;
+    regexp: string;
+    type: 'FILTER_TYPE_MATCH' | 'FILTER_TYPE_MISMATCH';
+  }[];
+}
+
+export interface FoldersResponseBody {
+  id: number;
+  uid: string;
+  title: string;
+  managedBy: string;
+}
+
+export default class AlertingApi {
+  constructor(private request: APIRequestContext) {}
+
+  createRule = async (headers: Headers, data: CreateRuleBody) =>
+    this.request.post(apiEndpoints.alerting.rules, { data, headers });
+
+  createTemplate = async (headers: Headers, yamlBody: AlertTemplateBody) =>
+    this.request.post(apiEndpoints.alerting.templates, { data: yamlBody, headers });
+
+  deleteTemplate = async (headers: Headers, templateName: string) =>
+    this.request.delete(`${apiEndpoints.alerting.templates}/${templateName}`, { headers });
+
+  getFolderByName = async (folderName: string, headers?: Headers): Promise<FoldersResponseBody> => {
+    const folders = await this.listFolders(headers);
+    const folder = folders.find((folder) => folder.title === folderName);
+
+    if (!folder) {
+      throw new Error(`Folder with name: ${folderName} not found`);
+    }
+
+    return folder;
+  };
+
+  listFolders = async (headers?: Headers): Promise<FoldersResponseBody[]> => {
+    const authHeaders = headers ? headers : GrafanaHelper.getAuthHeader();
+
+    return await (await this.request.get(apiEndpoints.alerting.folders, { headers: authHeaders })).json();
+  };
+
+  listTemplates = async (headers: Headers) => this.request.get(apiEndpoints.alerting.templates, { headers });
+
+  updateTemplate = async (headers: Headers, templateName: string, yamlBody: AlertTemplateBody) =>
+    this.request.put(`${apiEndpoints.alerting.templates}/${templateName}`, {
+      data: { name: templateName, ...yamlBody },
+      headers,
+    });
+}

--- a/e2e_tests/api/annotations.api.ts
+++ b/e2e_tests/api/annotations.api.ts
@@ -1,0 +1,28 @@
+import { APIRequestContext, expect } from '@playwright/test';
+import apiEndpoints from '@helpers/apiEndpoints';
+import GrafanaHelper from '@helpers/grafana.helper';
+
+interface SetAnnotation {
+  nodeName: string;
+  serviceNames: string[];
+  tags: string[];
+  text: string;
+}
+
+export default class AnnotationsApi {
+  constructor(private request: APIRequestContext) {}
+
+  setAnnotation = async ({ nodeName, serviceNames, tags, text }: SetAnnotation) => {
+    const response = await this.request.post(apiEndpoints.management.annotations, {
+      data: { node_name: nodeName, service_names: serviceNames, tags, text },
+      headers: GrafanaHelper.getAuthHeader(),
+    });
+
+    expect(
+      response.status(),
+      `Failed to add annotation "${text}". Response: ${await response.text()}`,
+    ).toEqual(200);
+
+    return response;
+  };
+}

--- a/e2e_tests/api/api.ts
+++ b/e2e_tests/api/api.ts
@@ -5,21 +5,34 @@ import GrafanaApi from '@api/grafana.api';
 import RealTimeAnalyticsApi from '@api/realtimeanalytics.api';
 import SettingsApi from '@api/settings.api';
 import AccessControlApi from '@api/accessControl.api';
+import ServerApi from '@api/server.api';
+import AlertingApi from '@api/alerting.api';
+import AnnotationsApi from '@api/annotations.api';
+import RemoteInstanceApi from '@api/remoteInstance.api';
 
 export default class Api {
   readonly accessControlApi: AccessControlApi;
+  readonly alertingApi: AlertingApi;
+  readonly annotationsApi: AnnotationsApi;
   readonly backupsApi: BackupsApi;
   readonly grafanaApi: GrafanaApi;
   readonly inventoryApi: InventoryApi;
   readonly realTimeAnalyticsApi: RealTimeAnalyticsApi;
+  readonly remoteInstanceApi: RemoteInstanceApi;
+  readonly serverApi: ServerApi;
   readonly settingsApi: SettingsApi;
 
   constructor(page: Page, request: APIRequestContext) {
     this.accessControlApi = new AccessControlApi(request);
+    this.alertingApi = new AlertingApi(request);
+    this.annotationsApi = new AnnotationsApi(request);
     this.backupsApi = new BackupsApi(request);
     this.inventoryApi = new InventoryApi(request);
     this.grafanaApi = new GrafanaApi(page, request);
+    this.inventoryApi = new InventoryApi(request);
     this.realTimeAnalyticsApi = new RealTimeAnalyticsApi(request);
+    this.remoteInstanceApi = new RemoteInstanceApi(request);
+    this.serverApi = new ServerApi(request);
     this.settingsApi = new SettingsApi(request);
   }
 }

--- a/e2e_tests/api/inventory.api.ts
+++ b/e2e_tests/api/inventory.api.ts
@@ -6,6 +6,27 @@ import apiEndpoints from '@helpers/apiEndpoints';
 export default class InventoryApi {
   constructor(private request: APIRequestContext) {}
 
+  getAllServiceDetailsByRegex = async (regexString: string): Promise<GetService[]> => {
+    const services = await this.getServices();
+    const regex = new RegExp(regexString);
+    const service = services.services.filter((service: GetService) => regex.test(service.service_name));
+
+    if (!service) throw new Error(`Service matching regex: ${regex} is not present`);
+
+    return service;
+  };
+
+  getAllServicesDetailsByPartialName = async (partialServiceName: string): Promise<GetService[]> => {
+    const services = await this.getServices();
+    const filteredServices = services.services.filter((service: GetService) =>
+      service.service_name.includes(partialServiceName),
+    );
+
+    if (!filteredServices) throw new Error(`Service with name ${partialServiceName} is not present`);
+
+    return filteredServices;
+  };
+
   getServiceDetailsByPartialName = async (partialServiceName: string): Promise<GetService> => {
     const services = await this.getServices();
     const service = services.services.find((service: GetService) =>
@@ -17,15 +38,8 @@ export default class InventoryApi {
     return service;
   };
 
-  getServiceDetailsByRegex = async (regexString: string): Promise<GetService> => {
-    const services = await this.getServices();
-    const regex = new RegExp(regexString);
-    const service = services.services.find((service: GetService) => regex.test(service.service_name));
-
-    if (!service) throw new Error(`Service matching regex: ${regex} is not present`);
-
-    return service;
-  };
+  getServiceDetailsByRegex = async (regexString: string): Promise<GetService> =>
+    (await this.getAllServiceDetailsByRegex(regexString))[0];
 
   getServiceDetailsByRegexAndParameters = async (
     regexString: string,
@@ -81,6 +95,15 @@ export default class InventoryApi {
 
     return service;
   };
+
+  verifyAgentsAreRunning = async (serviceName: string) =>
+    this.getServiceDetailsByPartialName(serviceName)
+      .then((service) =>
+        service.agents
+          .filter((agent) => agent.agent_type !== 'pmm-agent')
+          .every((agent) => agent.status === AgentStatus.running),
+      )
+      .catch(() => false);
 
   verifyServiceAgentsStatus = async (service: GetService, expectedStatus: AgentStatus) => {
     const agents = service.agents.filter((agent) => agent.agent_type !== 'pmm-agent');

--- a/e2e_tests/api/remoteInstance.api.ts
+++ b/e2e_tests/api/remoteInstance.api.ts
@@ -1,0 +1,91 @@
+import { APIRequestContext, expect } from '@playwright/test';
+import apiEndpoints from '../helpers/apiEndpoints';
+import GrafanaHelper from '../helpers/grafana.helper';
+
+type Headers = Record<string, string>;
+
+export interface AddRemoteInstance {
+  mongodb?: RemoteInstanceBody;
+  external?: RemoteInstanceBody;
+  mysql?: RemoteInstanceBody;
+  postgresql?: RemoteInstanceBody;
+}
+
+export interface RemoteUpgradeInstance {
+  connection: {
+    address: string;
+    cluster: string;
+    password: string;
+    port: string;
+    username: string;
+  };
+  metric: string;
+  name: string;
+  serviceType: 'mysql' | 'postgresql' | 'mongodb';
+  upgradeService: string;
+}
+
+interface RemoteInstanceBody {
+  metricsParameters?: string;
+  schema?: 'https' | 'http';
+  pmm_agent_id?: string;
+  port?: string;
+  cluster?: string;
+  group?: string;
+  listen_port?: string;
+  metrics_path?: string;
+  address: string;
+  username?: string;
+  password?: string;
+  skip_connection_check?: boolean;
+  service_name: string;
+  add_node: {
+    node_name: string;
+    node_type: 'NODE_TYPE_REMOTE_NODE';
+  };
+  metrics_mode?: number;
+  tls?: boolean;
+  tls_certificate_file_password?: string;
+  tls_ca?: string;
+  tls_certificate_key?: string;
+  tls_skip_verify?: boolean;
+  authentication_mechanism?: string;
+  engine?: 'DISCOVER_RDS_ENGINE_MYSQL';
+  qan_mysql_perfschema?: boolean;
+  qan_postgresql_pgstatmonitor_agent?: boolean;
+  qan_mongodb_profiler?: boolean;
+}
+
+export default class RemoteInstanceApi {
+  constructor(private request: APIRequestContext) {}
+
+  addRemoteInstance = async (remoteInstance: AddRemoteInstance, headers?: Headers) => {
+    const authHeaders = headers ? headers : GrafanaHelper.getAuthHeader();
+    const response = await this.request.post(apiEndpoints.management.services, {
+      data: remoteInstance,
+      headers: authHeaders,
+    });
+
+    expect(response.status()).toEqual(200);
+  };
+
+  buildRemoteInstanceDataBody = (instance: RemoteUpgradeInstance): AddRemoteInstance => {
+    const body = {
+      add_node: { node_name: instance.name, node_type: 'NODE_TYPE_REMOTE_NODE' as const },
+      pmm_agent_id: 'pmm-server',
+      service_name: instance.name,
+      ...instance.connection,
+    };
+
+    switch (instance.serviceType) {
+      case 'mysql':
+        return { mysql: { ...body, engine: 'DISCOVER_RDS_ENGINE_MYSQL', qan_mysql_perfschema: true } };
+      case 'postgresql':
+        return { postgresql: { ...body, qan_postgresql_pgstatmonitor_agent: true, tls_skip_verify: true } };
+      case 'mongodb':
+        return { mongodb: { ...body, qan_mongodb_profiler: true, tls_skip_verify: true } };
+      default:
+        throw new Error(`Unknown remote instance type: ${instance.serviceType}`);
+    }
+  };
+}

--- a/e2e_tests/api/server.api.ts
+++ b/e2e_tests/api/server.api.ts
@@ -1,0 +1,31 @@
+import { APIRequestContext } from '@playwright/test';
+import { Timeouts } from '@helpers/timeouts';
+import apiEndpoints from '@helpers/apiEndpoints';
+
+export default class ServerApi {
+  constructor(private request: APIRequestContext) {}
+
+  waitForReady = async (overallTimeoutMs: Timeouts = Timeouts.ONE_MINUTE): Promise<void> => {
+    const pollIntervalMs = Timeouts.FIVE_SECONDS;
+    const deadline = Date.now() + overallTimeoutMs;
+    let lastError: unknown;
+
+    while (Date.now() < deadline) {
+      try {
+        const res = await this.request.get(apiEndpoints.server.readyz, { ignoreHTTPSErrors: true });
+
+        if (res.status() === 200) {
+          return;
+        }
+      } catch (err) {
+        lastError = err;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+
+    throw new Error(
+      `PMM Server was not ready in expected timeout: ${overallTimeoutMs}ms (last error: ${lastError})`,
+    );
+  };
+}

--- a/e2e_tests/api/settings.api.ts
+++ b/e2e_tests/api/settings.api.ts
@@ -10,8 +10,37 @@ interface SettingsResponse {
   };
 }
 
+interface SettingsBody {
+  data_retention?: string;
+  pmm_public_address?: string;
+  enable_telemetry?: boolean;
+  enable_updates?: boolean;
+  enable_alerting?: boolean;
+  enable_backup_management?: boolean;
+  enable_internal_pg_qan?: boolean;
+  enable_advisor?: boolean;
+  advisor_run_intervals?: {
+    rare_interval: string;
+    standard_interval: string;
+    frequent_interval: string;
+  };
+  enable_azurediscover?: boolean;
+  enable_access_control?: boolean;
+}
+
 export default class SettingsApi {
   constructor(private request: APIRequestContext) {}
+
+  changeSettings = async (body: SettingsBody) => {
+    const response = await this.request.put(apiEndpoints.server.settings, {
+      data: body,
+      headers: GrafanaHelper.getAuthHeader(),
+    });
+
+    expect(response.status()).toEqual(200);
+
+    return (await response.json()) as SettingsResponse;
+  };
 
   enableAccessControl = async () => {
     const settings = await this.getSettings();

--- a/e2e_tests/components/dashboards/panels/panel.component.ts
+++ b/e2e_tests/components/dashboards/panels/panel.component.ts
@@ -7,16 +7,23 @@ export default class PanelComponent {
 
   grafanaIframe = () => this.page.frameLocator('//*[@id="grafana-iframe"]');
 
-  protected verifyData = async (locator: Locator, panelName: string) => {
+  protected verifyData = async (locator: Locator, panelName: string, verifyTexts = true) => {
     const target = locator.first();
 
     await target.first().waitFor({ state: 'visible', timeout: Timeouts.ONE_MINUTE });
-    await target.scrollIntoViewIfNeeded();
 
-    const barGaugeTexts = await locator.allTextContents();
+    try {
+      await target.scrollIntoViewIfNeeded();
+    } catch {
+      /* ignored */
+    }
 
-    for (const barGaugeText of barGaugeTexts) {
-      expect.soft(barGaugeText.length, `Panel: ${panelName} has empty values!`).toBeGreaterThan(0);
+    if (verifyTexts) {
+      const barGaugeTexts = await locator.allTextContents();
+
+      for (const barGaugeText of barGaugeTexts) {
+        expect.soft(barGaugeText.length, `Panel: ${panelName} has empty values!`).toBeGreaterThan(0);
+      }
     }
   };
 }

--- a/e2e_tests/components/dashboards/panels/table.component.ts
+++ b/e2e_tests/components/dashboards/panels/table.component.ts
@@ -11,6 +11,6 @@ export default class TablePanel extends PanelComponent {
   };
 
   verifyPanelData = async (panelName: string) => {
-    await this.verifyData(this.elements.tablePanelValue(panelName), panelName);
+    await this.verifyData(this.elements.tablePanelValue(panelName), panelName, false);
   };
 }

--- a/e2e_tests/components/snackbar.component.ts
+++ b/e2e_tests/components/snackbar.component.ts
@@ -1,0 +1,15 @@
+import { expect } from '@playwright/test';
+import PanelComponent from '@components/dashboards/panels/panel.component';
+
+export default class SnackbarComponent extends PanelComponent {
+  private snackbarGrafanaLocator = this.grafanaIframe().locator(
+    '//div[contains(@class, "app-notifications-list")]',
+  );
+  private successGrafanaMessageLocator = this.snackbarGrafanaLocator.locator(
+    '//div[@data-testid="data-testid Alert success"]//span',
+  );
+
+  verifySuccessMessage = async (message: string) => {
+    await expect(this.successGrafanaMessageLocator).toHaveText(message);
+  };
+}

--- a/e2e_tests/fixtures/pmmTest.ts
+++ b/e2e_tests/fixtures/pmmTest.ts
@@ -22,9 +22,14 @@ import apiEndpoints from '@helpers/apiEndpoints';
 import SettingsPage from '@pages/ha/settings.page';
 import UpdatesPage from '@pages/updates.page';
 import DownloadsPage from '@pages/downloads.page';
+import AlertStatusPage from '@pages/alerts/alertStatus.page';
+import AdvisorsPage from '@pages/advisors/advisors.page';
+import TestState from '@helpers/upgradeState.helper';
 
 const pmmTest = base.extend<{
+  advisorsPage: AdvisorsPage;
   settingsPage: SettingsPage;
+  alertStatusPage: AlertStatusPage;
   agentsPage: AgentsPage;
   cliHelper: CliHelper;
   credentials: Credentials;
@@ -46,8 +51,11 @@ const pmmTest = base.extend<{
   vacuumDashboardPage: VacuumDashboard;
   updatesPage: UpdatesPage;
   downloadsPage: DownloadsPage;
+  testState: TestState;
 }>({
+  advisorsPage: async ({ page }, use) => await use(new AdvisorsPage(page)),
   agentsPage: async ({ page }, use) => await use(new AgentsPage(page)),
+  alertStatusPage: async ({ page }, use) => await use(new AlertStatusPage(page)),
   api: async ({ page, request }, use) => {
     const inventoryApi = new Api(page, request);
 
@@ -141,6 +149,7 @@ const pmmTest = base.extend<{
   realTimeAnalyticsPage: async ({ page }, use) => await use(new RealTimeAnalyticsPage(page)),
   servicesPage: async ({ page }, use) => await use(new ServicesPage(page)),
   settingsPage: async ({ page }, use) => await use(new SettingsPage(page)),
+  testState: async ({}, use) => await use(new TestState()),
   tour: async ({ page }, use) => {
     const tour = new TourPage(page);
 

--- a/e2e_tests/helpers/apiEndpoints.ts
+++ b/e2e_tests/helpers/apiEndpoints.ts
@@ -3,6 +3,12 @@ const apiEndpoints = {
     roles: '/v1/accesscontrol/roles',
     rolesAssign: '/v1/accesscontrol/roles:assign',
   },
+  alerting: {
+    folders: 'graph/api/folders',
+    listAlerts: 'graph/api/prometheus/grafana/api/v1/rules',
+    rules: '/v1/alerting/rules',
+    templates: '/v1/alerting/templates',
+  },
   backups: {
     artifacts: '/v1/backups/artifacts',
     locations: '/v1/backups/locations',
@@ -16,6 +22,7 @@ const apiEndpoints = {
     services: '/v1/inventory/services',
   },
   management: {
+    annotations: '/v1/management/annotations',
     services: '/v1/management/services',
   },
   platform: {
@@ -27,6 +34,7 @@ const apiEndpoints = {
     sessionsStop: '/v1/realtimeanalytics/sessions:stop',
   },
   server: {
+    readyz: '/v1/server/readyz',
     settings: '/v1/server/settings',
     updates: '**/v1/server/updates?force=**',
   },

--- a/e2e_tests/helpers/grafana.helper.ts
+++ b/e2e_tests/helpers/grafana.helper.ts
@@ -1,5 +1,5 @@
 import { expect, Page } from '@playwright/test';
-import { GrafanaUser, GrafanaUserSearchResponse } from '@interfaces/grafana';
+import { GrafanaFolder, GrafanaUser, GrafanaUserSearchResponse } from '@interfaces/grafana';
 
 export default class GrafanaHelper {
   constructor(private page: Page) {}
@@ -10,9 +10,194 @@ export default class GrafanaHelper {
     await this.page.setExtraHTTPHeaders({ Authorization: `Basic ${authToken}` });
     await this.page.request.post(`${baseUrl}graph/login`, {
       data: { password, user: username },
+      ignoreHTTPSErrors: true,
     });
 
     return this.page;
+  };
+
+  changePassword = async (oldPassword: string, newPassword: string) => {
+    const response = await this.page.request.put('graph/api/user/password', {
+      data: { confirmNew: newPassword, newPassword, oldPassword },
+      headers: { Authorization: `Basic ${GrafanaHelper.getToken('admin', oldPassword)}` },
+      ignoreHTTPSErrors: true,
+    });
+
+    expect(
+      response.status(),
+      `Failed to change user account password! Response message is ${response.statusText()}`,
+    ).toEqual(200);
+  };
+
+  createCustomDashboard = async (
+    name: string,
+    folderId: number,
+    customPanelName: string,
+    tags: string[] = ['pmm-qa'],
+  ) => {
+    const body = {
+      dashboard: {
+        annotations: {
+          list: [
+            {
+              builtIn: 1,
+              datasource: '-- Grafana --',
+              enable: true,
+              hide: true,
+              iconColor: 'rgba(0, 211, 255, 1)',
+              name: 'Annotations & Alerts',
+              type: 'dashboard',
+            },
+          ],
+        },
+        editable: true,
+        panels: [
+          {
+            datasource: 'Metrics',
+            fieldConfig: {
+              defaults: {
+                color: {
+                  fixedColor: 'rgb(31, 120, 193)',
+                  mode: 'fixed',
+                },
+                links: [],
+                mappings: [
+                  {
+                    options: {
+                      match: 'null',
+                      result: {
+                        index: 0,
+                        text: 'N/A',
+                      },
+                    },
+                    type: 'special',
+                  },
+                ],
+                thresholds: {
+                  mode: 'absolute',
+                  steps: [
+                    {
+                      color: '#1F60C4',
+                      value: null,
+                    },
+                    {
+                      color: 'rgba(237, 129, 40, 0.89)',
+                      value: 100,
+                    },
+                    {
+                      color: '#d44a3a',
+                    },
+                  ],
+                },
+                unit: 'none',
+              },
+              overrides: [],
+            },
+            gridPos: {
+              h: 5,
+              w: 12,
+              x: 0,
+              y: 0,
+            },
+            id: 2,
+            links: [],
+            maxDataPoints: 100,
+            options: {
+              colorMode: 'value',
+              graphMode: 'none',
+              justifyMode: 'center',
+              orientation: 'vertical',
+              reduceOptions: {
+                calcs: ['lastNotNull'],
+                fields: '',
+                values: false,
+              },
+              text: {
+                titleSize: 14,
+                valueSize: 24,
+              },
+              textMode: 'auto',
+            },
+            pluginVersion: '9.2.20',
+            targets: [
+              {
+                datasource: 'Metrics',
+                editorMode: 'code',
+                expr: 'count by (service_type) (mysql_global_status_uptime)',
+                format: 'time_series',
+                hide: false,
+                intervalFactor: 1,
+                legendFormat: 'MySQL',
+                range: true,
+                refId: 'A',
+              },
+              {
+                datasource: 'Metrics',
+                editorMode: 'code',
+                expr: 'count by (service_type) (mongodb_up)',
+                hide: false,
+                legendFormat: 'MongoDB',
+                range: true,
+                refId: 'B',
+              },
+              {
+                datasource: 'Metrics',
+                editorMode: 'code',
+                expr: 'count by (service_type)  (group by (service_name, service_type) (pg_up))',
+                hide: false,
+                legendFormat: 'PostgreSQL',
+                range: true,
+                refId: 'C',
+              },
+              {
+                datasource: 'Metrics',
+                editorMode: 'code',
+                expr: 'count by (service_type)  (group by (service_name, service_type) (proxysql_mysql_status_active_transactions))',
+                hide: false,
+                legendFormat: 'ProxySQL',
+                range: true,
+                refId: 'D',
+              },
+            ],
+            title: customPanelName,
+            type: 'stat',
+          },
+        ],
+        schemaVersion: 26,
+        style: 'dark',
+        tags,
+        time: {
+          from: 'now-6h',
+          to: 'now',
+        },
+        title: name,
+        version: 0,
+      },
+      folderId,
+    };
+    const response = await this.page.request.post('graph/api/dashboards/db/', {
+      data: body,
+      headers: GrafanaHelper.getAuthHeader(),
+    });
+
+    expect(response.status()).toEqual(200);
+
+    return response;
+  };
+
+  createFolder = async (folderName: string) => {
+    const authToken = GrafanaHelper.getToken();
+    const response = await this.page.request.post('graph/api/folders', {
+      data: { title: folderName },
+      headers: { Authorization: `Basic ${authToken}` },
+    });
+
+    expect(
+      response.status(),
+      `Failed to create "${folderName}" folder. Response message is ${response.statusText()}`,
+    ).toEqual(200);
+
+    return await response.json();
   };
 
   createUser = async (username: string, password: string) => {
@@ -24,6 +209,17 @@ export default class GrafanaHelper {
         OrgId: 1,
         password: password,
       },
+      headers: { Authorization: `Basic ${authToken}` },
+    });
+
+    expect(response.status(), `Create user ${username}`).toEqual(200);
+
+    return (await response.json()).id as number;
+  };
+
+  deleteUser = async (userId: number) => {
+    const authToken = GrafanaHelper.getToken();
+    const response = await this.page.request.delete(`graph/api/admin/users/${userId}`, {
       headers: { Authorization: `Basic ${authToken}` },
     });
 
@@ -45,6 +241,37 @@ export default class GrafanaHelper {
     Authorization: `Basic ${this.getToken(username, password)}`,
   });
 
+  getDashboard = async (uid: string) => {
+    const response = await this.page.request.get(`graph/api/dashboards/uid/${uid}`, {
+      headers: GrafanaHelper.getAuthHeader(),
+    });
+
+    expect(
+      response.status(),
+      `Get Dashboard api call for dashboard: ${uid} fails with error: ${response.statusText()}`,
+    ).toEqual(200);
+
+    return await response.json();
+  };
+
+  getFolderDetailsByName = async (folderName: string): Promise<GrafanaFolder> => {
+    const response = await this.page.request.get('graph/api/folders', {
+      headers: GrafanaHelper.getAuthHeader(),
+    });
+
+    expect(response.status()).toEqual(200);
+
+    const responseBody = ((await response.json()) as GrafanaFolder[]).find(
+      (folder) => folder.title === folderName,
+    );
+
+    if (!responseBody) {
+      throw new Error(`Failed to get a folder with name ${folderName}`);
+    }
+
+    return responseBody;
+  };
+
   static getToken = (username = 'admin', password = process.env.ADMIN_PASSWORD || 'admin') =>
     Buffer.from(`${username}:${password}`).toString('base64');
 
@@ -56,6 +283,44 @@ export default class GrafanaHelper {
     expect(response.status()).toEqual(200);
 
     return (await response.json()) as GrafanaUserSearchResponse;
+  };
+
+  promoteToEditor = async (userId: number) => {
+    const response = await this.page.request.patch(`graph/api/org/users/${userId}`, {
+      data: { role: 'Editor' },
+      headers: GrafanaHelper.getAuthHeader(),
+    });
+
+    expect(response.status(), 'Promote user to Editor').toEqual(200);
+  };
+
+  setHomeDashboard = async (uid: string) => {
+    const authToken = GrafanaHelper.getToken();
+    const response = await this.page.request.put('graph/api/user/preferences', {
+      data: { homeDashboardUID: uid },
+      headers: { Authorization: `Basic ${authToken}` },
+    });
+
+    expect(
+      response.status(),
+      `Failed to set home dashboard: "${uid}" dashboard. Response message is ${response.statusText()}`,
+    ).toEqual(200);
+
+    return (await response.json()).id as number;
+  };
+
+  starDashboard = async (uid: string) => {
+    const authToken = GrafanaHelper.getToken();
+    const response = await this.page.request.post(`graph/api/user/stars/dashboard/uid/${uid}`, {
+      headers: { Authorization: `Basic ${authToken}` },
+    });
+
+    expect(
+      response.status(),
+      `Failed to star "${uid}" dashboard. Response message is ${response.statusText()}`,
+    ).toEqual(200);
+
+    return (await response.json()).id as number;
   };
 
   unAuthorize = async () => {

--- a/e2e_tests/helpers/upgradeState.helper.ts
+++ b/e2e_tests/helpers/upgradeState.helper.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Persists small pieces of state to disk so they survive between
+ * test runs (which execute as two separate
+ * Playwright processes, with a PMM server upgrade in between).
+ *
+ * {@link CliHelper.execSilent} call spawns its own short-lived child shell, so
+ * nothing set there outlives the call, let alone the whole process.
+ *
+ * The file lives under `output/` (git-ignored) by default. Override the
+ * location with the `UPGRADE_STATE_FILE` env var if `output/` is cleaned
+ * between the two runs in your pipeline.
+ */
+export default class TestState {
+  private readonly file =
+    process.env.UPGRADE_STATE_FILE || path.resolve(__dirname, '..', 'output', 'upgrade-state.json');
+
+  /** Read a single value, throwing a clear error if it was never saved. */
+  get = (key: string): string => {
+    const value = this.readAll()[key];
+
+    if (!value) {
+      throw new Error(
+        `Upgrade state "${key}" not found in ${this.file}. ` +
+          'Did the matching @pre-upgrade test run and save it before the upgrade?',
+      );
+    }
+
+    return value;
+  };
+
+  /** Read the whole state object, or `{}` if nothing has been saved yet. */
+  readAll = (): Record<string, string> => {
+    try {
+      return JSON.parse(fs.readFileSync(this.file, 'utf8'));
+    } catch {
+      return {};
+    }
+  };
+
+  /** Merge the given key/value pairs into the persisted state. */
+  save = (data: Record<string, string>): void => {
+    fs.mkdirSync(path.dirname(this.file), { recursive: true });
+    fs.writeFileSync(this.file, JSON.stringify({ ...this.readAll(), ...data }, null, 2));
+  };
+}

--- a/e2e_tests/interfaces/grafana.ts
+++ b/e2e_tests/interfaces/grafana.ts
@@ -7,3 +7,10 @@ export interface GrafanaUser {
 export interface GrafanaUserSearchResponse {
   users: GrafanaUser[];
 }
+
+export interface GrafanaFolder {
+  id: number;
+  uid: string;
+  title: string;
+  managedBy: string;
+}

--- a/e2e_tests/pages/advisors/advisors.page.ts
+++ b/e2e_tests/pages/advisors/advisors.page.ts
@@ -1,0 +1,27 @@
+import BasePage from '../base.page';
+
+export default class AdvisorsPage extends BasePage {
+  configurationUrl = 'pmm-ui/graph/advisors/configuration';
+  builders = {
+    advisorIntervalValue: (advisorName: string) =>
+      this.grafanaIframe().locator(`//*[text()="${advisorName}"]/parent::tr//td[position()="5"]`),
+    advisorsChangeInterval: (advisorName: string) =>
+      this.grafanaIframe().locator(
+        `//*[text()="${advisorName}"]/parent::tr//td[position()="6"]//button[@title="Change check interval"]`,
+      ),
+    advisorsGroupHeader: (groupName: string) =>
+      this.grafanaIframe().locator(`//*[text()="${groupName}"]/parent::*/parent::*`),
+    changeIntervalValue: (advisorValue: string) =>
+      this.grafanaIframe().locator(`//label[text()="${advisorValue}"]`),
+    disableAdvisor: (advisorName: string) =>
+      this.grafanaIframe().locator(
+        `//*[text()="${advisorName}"]/parent::tr//td[position()="6"]//button[@data-testid="check-table-loader-button"]//span`,
+      ),
+  };
+  buttons = {
+    saveInterval: this.grafanaIframe().locator('//button[@data-testid="change-check-interval-modal-save"]'),
+  };
+  elements = {};
+  inputs = {};
+  messages = {};
+}

--- a/e2e_tests/pages/alerts/alertStatus.page.ts
+++ b/e2e_tests/pages/alerts/alertStatus.page.ts
@@ -1,0 +1,15 @@
+import BasePage from '../base.page';
+
+export default class AlertStatusPage extends BasePage {
+  url = 'pmm-ui/alerting/status';
+  builders = {
+    firingAlert: (alertName: string) =>
+      this.page.locator(
+        `//td[text()="${alertName}"]/parent::tr//td[position()="2"]//span[contains(text(), "Firing")]`,
+      ),
+  };
+  buttons = {};
+  elements = {};
+  inputs = {};
+  messages = {};
+}

--- a/e2e_tests/pages/base.page.ts
+++ b/e2e_tests/pages/base.page.ts
@@ -2,6 +2,7 @@ import { APIRequestContext, expect, Page, Locator } from '@playwright/test';
 import apiEndpoints from '@helpers/apiEndpoints';
 import { Timeouts } from '@helpers/timeouts';
 import GrafanaHelper from '@helpers/grafana.helper';
+import SnackbarComponent from '@components/snackbar.component';
 
 export type DropdownName = 'Service Name' | 'Node Name';
 
@@ -15,13 +16,16 @@ export type NestedLocator = Locator | NestedLocators;
 export type NestedLocatorMap = Record<string, NestedLocator>;
 
 export default abstract class BasePage {
+  snackbar: SnackbarComponent;
   abstract builders: Record<string, (...args: string[]) => Locator>;
   abstract buttons: NestedLocatorMap;
   abstract elements: Record<string, Locator>;
   abstract inputs: Record<string, Locator>;
   abstract messages: Record<string, Locator>;
 
-  constructor(protected page: Page) {}
+  constructor(protected page: Page) {
+    this.snackbar = new SnackbarComponent(this.page);
+  }
 
   duplicateCurrentPage = async (): Promise<Page> => {
     const url = this.page.url();

--- a/e2e_tests/pages/dashboards/dashboards.page.ts
+++ b/e2e_tests/pages/dashboards/dashboards.page.ts
@@ -129,6 +129,7 @@ export default class Dashboards extends BasePage {
   verifyAllPanelsHaveData = async (noDataMetrics: string[], timeout: Timeouts = Timeouts.ONE_MINUTE) => {
     await this.loadAllPanels();
 
+    // eslint-disable-next-line no-useless-assignment -- panels are using in for loop
     let noDataPanels: string[] = [];
     let missingMetrics: string[] = [];
 
@@ -172,8 +173,9 @@ export default class Dashboards extends BasePage {
     await this.loadAllPanels();
 
     for (const panelName of panelNames) {
-      const panel = this.builders.panelByExactName(panelName);
-      const panelText = await panel.innerText();
+      const panelText = await this.grafanaIframe()
+        .getByRole('region', { exact: true, name: panelName })
+        .innerText();
 
       expect(hasKnownNoDataMarker(panelText)).toBeTruthy();
     }
@@ -191,6 +193,9 @@ export default class Dashboards extends BasePage {
           break;
         case 'stat':
           await this.panels().stat.verifyPanelData(panel.name);
+          break;
+        case 'gauge':
+          await this.panels().gauge.verifyPanelData(panel.name);
           break;
         case 'barGauge':
           await this.panels().barGauge.verifyPanelData(panel.name);

--- a/e2e_tests/pages/ha/settings.page.ts
+++ b/e2e_tests/pages/ha/settings.page.ts
@@ -41,11 +41,15 @@ export default class SettingsPage extends BasePage {
     pageTitle: this.page.getByRole('heading', { name: 'Settings' }),
   };
   inputs = {
+    dataRetention: this.page.getByTestId('retention-number-input'),
+    frequentAdvisorInterval: this.page.getByTestId('frequentInterval-number-input'),
     high: this.page.locator('[name="hr"]'),
     low: this.page.locator('[name="lr"]'),
     medium: this.page.locator('[name="mr"]'),
     publicAddress: this.page.getByTestId('text-input-public-address'),
+    rareAdvisorInterval: this.page.getByTestId('rareInterval-number-input'),
     sshKey: this.page.getByTestId('text-input-ssh-key'),
+    standardAdvisorInterval: this.page.getByTestId('standardInterval-number-input'),
   };
   messages = {};
 

--- a/e2e_tests/pages/updates.page.ts
+++ b/e2e_tests/pages/updates.page.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from '@playwright/test';
+import { expect, Locator, Page } from '@playwright/test';
 import BasePage from '@pages/base.page';
 import pmmTest from '@fixtures/pmmTest';
 import GrafanaHelper from '@helpers/grafana.helper';
@@ -16,15 +16,15 @@ export default class UpdatesPage extends BasePage {
   homeUrl = '/pmm-ui/graph/';
   builders = {};
   buttons = {
-    goToUpdates: this.page.getByTestId('update-modal-go-to-updates-button'),
-    releaseNotes: this.page.getByTestId('update-modal-release-notes-link'),
+    checkUpdatesNow: this.page.getByRole('button', { name: 'Check Updates Now' }),
     updateNow: this.page.getByRole('button', { name: 'Update now' }),
+    whatsNew: this.grafanaIframe().getByRole('link', { name: "What's new" }),
   };
   elements = {
     availableSection: this.page.getByRole('heading', { name: /New update available/i }),
-    newVersionLine: this.page.locator('p').filter({ hasText: 'New version:' }),
+    newVersionLine: this.page.getByText('New version:'),
     pageTitle: this.page.getByRole('heading', { exact: true, name: 'Updates' }),
-    updateModalTitle: this.page.getByTestId('modal-title'),
+    updateSuccess: this.page.getByText('PMM Server installation complete!'),
   };
   inputs = {};
   messages = {};
@@ -52,9 +52,22 @@ export default class UpdatesPage extends BasePage {
       await this.elements.pageTitle.waitFor({ state: 'visible' });
     });
 
-  openHomeForUpdateModal = async (): Promise<void> =>
-    await pmmTest.step('Open home page to show update modal', async () => {
+  openHomeForWhatsNew = async (): Promise<void> =>
+    await pmmTest.step('Open home page', async () => {
       await this.page.goto(this.homeUrl);
-      await this.buttons.releaseNotes.waitFor({ state: 'visible', timeout: Timeouts.THIRTY_SECONDS });
+      await expect(this.buttons.whatsNew).toBeVisible({ timeout: Timeouts.THIRTY_SECONDS });
+    });
+
+  upgrade = async (): Promise<void> =>
+    await pmmTest.step('Upgrade PMM server via the Updates page', async () => {
+      await this.open();
+      await this.buttons.updateNow.waitFor({ state: 'visible', timeout: Timeouts.THIRTY_SECONDS });
+
+      if (await this.buttons.checkUpdatesNow.isVisible()) {
+        await this.buttons.checkUpdatesNow.click();
+      }
+
+      await this.buttons.updateNow.click();
+      await expect(this.elements.updateSuccess).toBeVisible({ timeout: Timeouts.FIVE_MINUTES });
     });
 }

--- a/e2e_tests/testdata/externalServices.ts
+++ b/e2e_tests/testdata/externalServices.ts
@@ -1,0 +1,44 @@
+import { RemoteUpgradeInstance } from '@api/remoteInstance.api';
+
+// Shared across the upgrade test files (customPassword + externalService).
+export const services: RemoteUpgradeInstance[] = [
+  {
+    connection: {
+      address: 'ps_pmm_8_4_1',
+      cluster: 'mysql_clstr',
+      password: 'GRgrO9301RuF',
+      port: '3306',
+      username: 'root',
+    },
+    metric: 'mysql_global_status_max_used_connections',
+    name: 'ps_pmm_',
+    serviceType: 'mysql',
+    upgradeService: 'mysql',
+  },
+  {
+    connection: {
+      address: 'pgsql_pgss_pmm_17',
+      cluster: 'pgsql_clstr',
+      password: 'pmm',
+      port: '5432',
+      username: 'pmm',
+    },
+    metric: 'pg_stat_database_xact_rollback',
+    name: 'pgsql_pgss_pmm',
+    serviceType: 'postgresql',
+    upgradeService: 'postgresql',
+  },
+  {
+    connection: {
+      address: 'rs101',
+      cluster: 'mongo_clstr',
+      password: 'pbmpass',
+      port: '27017',
+      username: 'pbm',
+    },
+    metric: 'mongodb_connections',
+    name: 'rs101',
+    serviceType: 'mongodb',
+    upgradeService: 'mongodb',
+  },
+];

--- a/e2e_tests/tests/api/alerting/alertingPermissions.test.ts
+++ b/e2e_tests/tests/api/alerting/alertingPermissions.test.ts
@@ -1,0 +1,92 @@
+import { APIResponse, expect } from '@playwright/test';
+import pmmTest from '@fixtures/pmmTest';
+import GrafanaHelper from '@helpers/grafana.helper';
+import type AlertingApi from '@api/alerting.api';
+import type { AlertTemplateBody } from '@api/alerting.api';
+
+const alertingWriteCases: {
+  label: string;
+  send: (
+    alertingApi: AlertingApi,
+    headers: Record<string, string>,
+    templateName: string,
+    yamlBody: AlertTemplateBody,
+  ) => Promise<APIResponse>;
+}[] = [
+  {
+    label: 'POST templates',
+    send: (alertingApi, headers, _templateName, yamlBody) => alertingApi.createTemplate(headers, yamlBody),
+  },
+  {
+    label: 'PUT template',
+    send: (alertingApi, headers, templateName, yamlBody) =>
+      alertingApi.updateTemplate(headers, templateName, yamlBody),
+  },
+  {
+    label: 'DELETE template',
+    send: (alertingApi, headers, templateName) => alertingApi.deleteTemplate(headers, templateName),
+  },
+  {
+    label: 'POST rule',
+    send: (alertingApi, headers, templateName) =>
+      alertingApi.createRule(headers, { template_name: templateName }),
+  },
+];
+// Set by the test, deleted by the afterEach hook so cleanup runs even on failure.
+let viewerId: number | undefined;
+let editorId: number | undefined;
+const suffix = Date.now();
+const viewer = { login: `viewer-${suffix}`, password: 'Viewer-pw-12345' };
+const editor = { login: `editor-${suffix}`, password: 'Editor-pw-12345' };
+
+// PMM-15138: a Viewer may list alert templates but must not create, update or delete
+// templates, nor create rules. An Editor must be allowed to manage them. The auth layer
+// denies a forbidden write with HTTP 403 / code 7 (PermissionDenied) before the request
+// reaches the backend, so the request body is irrelevant for the Viewer assertions.
+pmmTest.describe('Alerting permissions API tests @alerting', () => {
+  pmmTest.beforeEach(async ({ grafanaHelper }) => {
+    viewerId = await grafanaHelper.createUser(viewer.login, viewer.password);
+    editorId = await grafanaHelper.createUser(editor.login, editor.password);
+    await grafanaHelper.promoteToEditor(editorId);
+  });
+
+  pmmTest.afterEach(async ({ grafanaHelper }) => {
+    if (viewerId) await grafanaHelper.deleteUser(viewerId);
+    if (editorId) await grafanaHelper.deleteUser(editorId);
+  });
+
+  pmmTest('PMM-T2236 - Viewer can list alert templates', async ({ api }) => {
+    const res = await api.alertingApi.listTemplates(
+      GrafanaHelper.getAuthHeader(viewer.login, viewer.password),
+    );
+
+    expect(res.status()).toBe(200);
+  });
+
+  for (const writeCase of alertingWriteCases) {
+    pmmTest(`PMM-T2235 - Viewer cannot ${writeCase.label}; Editor can`, async ({ api }) => {
+      const templateName = `pmm15138_${suffix}`;
+      // Deliberately invalid: the Viewer is rejected by auth first, the Editor by the backend.
+      const yamlBody = { yaml: 'placeholder' };
+      const viewerRes = await writeCase.send(
+        api.alertingApi,
+        GrafanaHelper.getAuthHeader(viewer.login, viewer.password),
+        templateName,
+        yamlBody,
+      );
+
+      expect(viewerRes.status(), `viewer ${writeCase.label}`).toBe(403);
+      // 7 == codes.PermissionDenied
+      expect((await viewerRes.json()).code, `viewer ${writeCase.label} code`).toBe(7);
+
+      const editorRes = await writeCase.send(
+        api.alertingApi,
+        GrafanaHelper.getAuthHeader(editor.login, editor.password),
+        templateName,
+        yamlBody,
+      );
+
+      expect(editorRes.status(), `editor ${writeCase.label}`).not.toBe(403);
+    });
+  }
+});

--- a/e2e_tests/tests/postRelease.test.ts
+++ b/e2e_tests/tests/postRelease.test.ts
@@ -3,7 +3,23 @@ import { expect } from '@playwright/test';
 import apiEndpoints from '@helpers/apiEndpoints';
 import { Timeouts } from '@helpers/timeouts';
 
-const expectedVersion = process.env.PMM_SERVER_LATEST?.trim() as string;
+// Resolved per test rather than at module scope: Playwright imports every spec
+// during collection, so a top-level throw here fails unrelated --grep runs too.
+const getExpectedVersion = () => {
+  const version = process.env.PMM_SERVER_LATEST?.trim();
+
+  if (!version) {
+    throw new Error('PMM_SERVER_LATEST env var is required for @post-release tests');
+  }
+
+  return version;
+};
+
+let expectedVersion: string;
+
+pmmTest.beforeAll(async () => {
+  expectedVersion = getExpectedVersion();
+});
 
 pmmTest.beforeEach(async ({ context, page }) => {
   await page.unroute(apiEndpoints.server.updates);
@@ -42,29 +58,21 @@ pmmTest(
   "PMM-T2201 - Verify What's new link and release notes @post-release",
   async ({ grafanaHelper, updatesPage }) => {
     await grafanaHelper.authorize();
-    await updatesPage.openHomeForUpdateModal();
+    await updatesPage.openHomeForWhatsNew();
 
-    await pmmTest.step('Verify Release Notes link is displayed in the update modal', async () => {
-      await expect(updatesPage.elements.updateModalTitle).toContainText(expectedVersion);
-      await expect(updatesPage.buttons.releaseNotes).toBeVisible({ timeout: Timeouts.THIRTY_SECONDS });
-      await expect(updatesPage.buttons.releaseNotes).toHaveAttribute(
+    await pmmTest.step("Verify What's new link on home page", async () => {
+      await expect(updatesPage.buttons.whatsNew).toBeVisible({ timeout: Timeouts.THIRTY_SECONDS });
+      await expect(updatesPage.buttons.whatsNew).toHaveAttribute(
         'href',
         new RegExp(`per\\.co\\.na/pmm/${expectedVersion.replaceAll('.', '\\.')}`),
       );
     });
 
     await pmmTest.step('Open release notes and verify the released version', async () => {
-      const { href, newTab } = await updatesPage.clickReleaseNotes(updatesPage.buttons.releaseNotes);
+      const { newTab } = await updatesPage.clickReleaseNotes(updatesPage.buttons.whatsNew);
 
-      expect(href, 'Release Notes link should point to the GA release notes URL').toMatch(
-        new RegExp(`per\\.co\\.na/pmm/${expectedVersion.replaceAll('.', '\\.')}`),
-      );
-      await newTab.waitForLoadState();
-      expect(newTab.url(), 'Release notes should open Percona documentation').toMatch(
-        /per\.co\.na|percona\.com|docs\.percona\.com/,
-      );
-      expect(newTab.url(), 'Release notes page should reference the released version').toContain(
-        expectedVersion,
+      await expect(newTab).toHaveURL(
+        `https://docs.percona.com/percona-monitoring-and-management/3/release-notes/${expectedVersion}.html`,
       );
     });
   },

--- a/e2e_tests/tests/qan/storedMetrics/mysql/mysqlQanStoredMetrics.test.ts
+++ b/e2e_tests/tests/qan/storedMetrics/mysql/mysqlQanStoredMetrics.test.ts
@@ -19,10 +19,13 @@ pmmTest.beforeEach(async ({ grafanaHelper }) => {
   await grafanaHelper.authorize();
 });
 
+// Anchored so it cannot also match the source node — see mysqlDashboards.test.ts.
+const replicaServiceRegex = '^ps_pmm_replication_.*_2(_\\d+)?$';
+
 pmmTest(
   'PMM-T2030 - Verify QAN for PS Replica Instance @nightly @pmm-ps-integration',
   async ({ api, page, qanStoredMetrics, urlHelper }) => {
-    const { service_name } = await api.inventoryApi.getServiceDetailsByRegex('ps_pmm_replication_.*_2');
+    const { service_name } = await api.inventoryApi.getServiceDetailsByRegex(replicaServiceRegex);
 
     await page.goto(
       urlHelper.buildUrlWithParameters(qanStoredMetrics.url, {

--- a/e2e_tests/tests/upgrade/advisors.test.ts
+++ b/e2e_tests/tests/upgrade/advisors.test.ts
@@ -1,0 +1,30 @@
+import pmmTest from '@fixtures/pmmTest';
+import { Timeouts } from '@helpers/timeouts';
+import { expect } from '@playwright/test';
+
+pmmTest.describe('PMM Advisors tests for upgrade', () => {
+  const advisorName = 'Check for unsupported PostgreSQL';
+  const groupName = 'Version Configuration';
+  const disabledAdvisorName = 'MongoDB version check';
+
+  pmmTest.beforeEach(async ({ grafanaHelper }) => {
+    await grafanaHelper.authorize();
+  });
+
+  pmmTest('Change advisors intervals before the upgrade @pre-upgrade', async ({ advisorsPage, page }) => {
+    await page.goto(advisorsPage.configurationUrl, { timeout: Timeouts.ONE_MINUTE });
+    await advisorsPage.builders.advisorsGroupHeader(groupName).click({ timeout: Timeouts.ONE_MINUTE });
+    await advisorsPage.builders.advisorsChangeInterval(advisorName).click();
+    await advisorsPage.builders.changeIntervalValue('Frequent').click();
+    await advisorsPage.buttons.saveInterval.click();
+    await advisorsPage.snackbar.verifySuccessMessage('Interval changed for Check for unsupported PostgreSQL');
+    await expect(advisorsPage.builders.advisorIntervalValue(advisorName)).toHaveText('Frequent');
+  });
+
+  pmmTest('Disable advisor before upgrade @pre-upgrade', async ({ advisorsPage, page }) => {
+    await page.goto(advisorsPage.configurationUrl, { timeout: Timeouts.ONE_MINUTE });
+    await advisorsPage.builders.advisorsGroupHeader(groupName).click({ timeout: Timeouts.ONE_MINUTE });
+    await advisorsPage.builders.disableAdvisor(disabledAdvisorName).click();
+    await expect(advisorsPage.builders.disableAdvisor(disabledAdvisorName)).toHaveText('Enable');
+  });
+});

--- a/e2e_tests/tests/upgrade/alerts.test.ts
+++ b/e2e_tests/tests/upgrade/alerts.test.ts
@@ -1,0 +1,35 @@
+import pmmTest from '@fixtures/pmmTest';
+import { Timeouts } from '@helpers/timeouts';
+import { expect } from '@playwright/test';
+import GrafanaHelper from '@helpers/grafana.helper';
+
+pmmTest.describe('PMM Alerts tests for upgrade', () => {
+  const upgradeRuleName = 'Alerting Upgrade Rule';
+
+  pmmTest.beforeEach(async ({ grafanaHelper }) => {
+    await grafanaHelper.authorize();
+  });
+
+  pmmTest(
+    'PMM-T577 - Verify user is able to create and see firing alerts before upgrade @pre-upgrade',
+    async ({ alertStatusPage, api, page }) => {
+      const folder = await api.alertingApi.getFolderByName('PMM Health');
+
+      await api.alertingApi.createRule(GrafanaHelper.getAuthHeader(), {
+        filters: [{ label: 'node_name', regexp: 'pmm-server', type: 'FILTER_TYPE_MATCH' }],
+        folder_uid: folder.uid,
+        for: '30s',
+        group: 'upgrade test group',
+        interval: '10s',
+        name: upgradeRuleName,
+        params: [{ float: 1, name: 'threshold', type: 'PARAM_TYPE_FLOAT' }],
+        template_name: 'pmm_node_high_cpu_load',
+      });
+
+      await page.goto(alertStatusPage.url);
+      await expect(alertStatusPage.builders.firingAlert(upgradeRuleName)).toBeVisible({
+        timeout: Timeouts.TWO_MINUTES,
+      });
+    },
+  );
+});

--- a/e2e_tests/tests/upgrade/annotations.test.ts
+++ b/e2e_tests/tests/upgrade/annotations.test.ts
@@ -1,0 +1,35 @@
+import pmmTest from '@fixtures/pmmTest';
+import { expect } from '@playwright/test';
+
+pmmTest.describe('PMM upgrade tests for annotations', () => {
+  const tag = 'Upgrade-PMM-T878';
+  const services = [
+    { annotationName: 'annotation-for-mysql', name: 'ps_pmm', serviceType: 'mysql' },
+    { annotationName: 'annotation-for-postgres', name: 'pgsql_pgs', serviceType: 'postgresql' },
+    { annotationName: 'annotation-for-mongo', name: 'rs101', serviceType: 'mongodb' },
+  ];
+
+  for (const service of services) {
+    pmmTest(
+      `Adding annotation before upgrade at service Level for ${service.serviceType} @pre-upgrade`,
+      async ({ api }) => {
+        const details = (await api.inventoryApi.getAllServicesDetailsByPartialName(service.name)).find(
+          (found) => !found.service_name.includes('ssl'),
+        );
+
+        if (!details) {
+          throw new Error(`Service with name ${service.name} was not found!`);
+        }
+
+        expect(details, `Service including "${service.name}" (non-ssl) not found`).toBeTruthy();
+
+        await api.annotationsApi.setAnnotation({
+          nodeName: details.node_name,
+          serviceNames: [details.service_name],
+          tags: [tag],
+          text: service.annotationName,
+        });
+      },
+    );
+  }
+});

--- a/e2e_tests/tests/upgrade/cli.test.ts
+++ b/e2e_tests/tests/upgrade/cli.test.ts
@@ -1,0 +1,59 @@
+import pmmTest from '@fixtures/pmmTest';
+import { expect } from '@playwright/test';
+
+pmmTest.describe('PMM cli tests for upgrade', () => {
+  const nonClientContainers = [
+    'ldap-server',
+    'minio',
+    'external_pmm',
+    'nginx',
+    'redis_container',
+    'chunk-churn',
+  ];
+
+  pmmTest('Verify PMM Agents statuses @pre-upgrade', async ({ cliHelper }) => {
+    const containers: string[] = cliHelper
+      .execSilent(`docker ps --format "{{.Names }}"`)
+      .stdout.split('\n')
+      .filter((item) => item && !nonClientContainers.includes(item));
+
+    for (const container of containers) {
+      const pmmAdminStatus: string = cliHelper.execSilent(`docker exec ${container} pmm-admin status`).stdout;
+      const pmmAdminList: string = cliHelper.execSilent(`docker exec ${container} pmm-admin list`).stdout;
+
+      expect(
+        pmmAdminStatus,
+        `Agent status contains wrong status in ${container} container. Error in: ${pmmAdminStatus}`,
+      ).not.toMatch(/Waiting|Done|Unknown|Initialization Error|Stopping/);
+      expect(
+        pmmAdminList,
+        `Agent list contains wrong status in ${container} container. Error in: ${pmmAdminList}`,
+      ).not.toMatch(/Waiting|Done|Unknown|Initialization Error|Stopping/);
+    }
+  });
+
+  pmmTest('Verify PMM client versions before upgrade @pre-upgrade', async ({ cliHelper }) => {
+    const containers: string[] = cliHelper
+      .execSilent(`docker ps --format "{{.Names }}"`)
+      .stdout.split('\n')
+      .filter((item) => item && !nonClientContainers.includes(item));
+
+    for (const container of containers) {
+      const pmmAdminVersion: string = cliHelper.execSilent(
+        `docker exec ${container} sh -lc "pmm-admin status | grep pmm-admin | awk '{print $3}'"`,
+      ).stdout;
+      const pmmAgentVersion: string = cliHelper.execSilent(
+        `docker exec ${container} sh -lc "pmm-admin status | grep pmm-admin | awk '{print $3}'"`,
+      ).stdout;
+
+      expect(
+        pmmAdminVersion,
+        `PMM admin version: ${pmmAdminVersion} does not equal expected PMM client version ${process.env.CLIENT_VERSION} for service ${container},`,
+      ).toContain(process.env.CLIENT_VERSION);
+      expect(
+        pmmAgentVersion,
+        `PMM agent version: ${pmmAdminVersion} does not equal expected PMM client version ${process.env.CLIENT_VERSION} for service ${container},`,
+      ).toContain(process.env.CLIENT_VERSION);
+    }
+  });
+});

--- a/e2e_tests/tests/upgrade/customPassword.test.ts
+++ b/e2e_tests/tests/upgrade/customPassword.test.ts
@@ -1,0 +1,26 @@
+import pmmTest from '@fixtures/pmmTest';
+import { services } from '../../testdata/externalServices';
+
+pmmTest.describe('PMM upgrade tests for custom password', () => {
+  const pgsql = { host: '127.0.0.1', password: 'pmm', port: '5432', username: 'pmm' };
+  const mongo = { host: '127.0.0.1', password: 'pmmpass', port: '27017', username: 'pmm' };
+  const mysql = { host: '127.0.0.1', password: 'GRgrO9301RuF', port: '3306', username: 'root' };
+
+  for (const service of services) {
+    pmmTest(
+      `Adding custom agent password, custom label before upgrade at service Level for ${service.serviceType} @pre-upgrade`,
+      async ({ cliHelper, credentials }) => {
+        const labels = `--agent-password=uitests --custom-labels="testing=upgrade" upgrade-${service.upgradeService}`;
+        const addCommand: Record<string, string> = {
+          mongodb: `pmm-admin add mongodb --username=${mongo.username} --password="${mongo.password}" --port=${mongo.port} --host=${mongo.host} ${labels}`,
+          mysql: `pmm-admin add mysql --password=${credentials.perconaServer.password} --port=${mysql.port} --host=${mysql.host} --query-source=perfschema ${labels}`,
+          postgresql: `pmm-admin add postgresql --username=${pgsql.username} --password=${pgsql.password} --port=${pgsql.port} --host=${pgsql.host} ${labels}`,
+        };
+
+        cliHelper
+          .execSilent(`docker exec ${service.connection.address} ${addCommand[service.serviceType]}`)
+          .assertSuccess();
+      },
+    );
+  }
+});

--- a/e2e_tests/tests/upgrade/dashdoard.test.ts
+++ b/e2e_tests/tests/upgrade/dashdoard.test.ts
@@ -1,0 +1,64 @@
+import pmmTest from '@fixtures/pmmTest';
+import { expect } from '@playwright/test';
+
+pmmTest.describe('PMM settings tests for upgrade', () => {
+  const dashboardName = 'upgrade-dashboard';
+  const panelName = 'Monitored DB';
+
+  pmmTest.beforeEach(async ({ grafanaHelper }) => {
+    await grafanaHelper.authorize();
+  });
+
+  pmmTest(
+    'PMM-T391 - Verify user is able to create and set custom home dashboard @pre-upgrade',
+    async ({ dashboard, grafanaHelper, page }) => {
+      const folder = await grafanaHelper.getFolderDetailsByName('Insight');
+
+      await grafanaHelper.createFolder('upgrade-folder');
+
+      const customDashboard = await grafanaHelper.createCustomDashboard(
+        dashboardName,
+        folder.id,
+        `${panelName}`,
+        ['pmm-qa', 'tag-upgrade'],
+      );
+
+      await grafanaHelper.starDashboard((await customDashboard.json()).uid);
+      await grafanaHelper.setHomeDashboard((await customDashboard.json()).uid);
+
+      await page.goto('pmm-ui/graph/');
+      await dashboard.verifyMetricsPresent([{ name: panelName, type: 'stat' }]);
+      expect(page.url()).toContain(dashboardName);
+      expect(page.url()).toContain((await customDashboard.json()).uid);
+      await page.goto((await grafanaHelper.getDashboard((await customDashboard.json()).uid)).meta.url);
+    },
+  );
+
+  pmmTest(
+    'Verify duplicate dashboard do not break upgrade @pre-upgrade',
+    async ({ grafanaHelper, testState }) => {
+      const insightFolder = await grafanaHelper.getFolderDetailsByName('Insight');
+      const experimentalFolder = await grafanaHelper.getFolderDetailsByName('Experimental');
+      const firstCustomDashboard = await grafanaHelper.createCustomDashboard(
+        'test-dashboard',
+        insightFolder.id,
+        panelName,
+      );
+      const secondCustomDashboard = await grafanaHelper.createCustomDashboard(
+        'test-dashboard',
+        experimentalFolder.id,
+        panelName,
+      );
+      const firstDashboardUid = (await firstCustomDashboard.json()).uid;
+      const secondDashboardUid = (await secondCustomDashboard.json()).uid;
+
+      testState.save({
+        FIRST_DASHBOARD_UID: firstDashboardUid,
+        SECOND_DASHBOARD_UID: secondDashboardUid,
+      });
+
+      expect(firstDashboardUid.length).toBeGreaterThan(0);
+      expect(secondDashboardUid.length).toBeGreaterThan(0);
+    },
+  );
+});

--- a/e2e_tests/tests/upgrade/externalService.test.ts
+++ b/e2e_tests/tests/upgrade/externalService.test.ts
@@ -1,0 +1,39 @@
+import pmmTest from '@fixtures/pmmTest';
+import { services } from '../../testdata/externalServices';
+
+pmmTest.describe('PMM upgrade tests for external services', () => {
+  const redisServiceName = 'pmm-ui-tests-redis-external-remote';
+
+  pmmTest('Adding Redis as external Service before Upgrade @pre-upgrade', async ({ api, cliHelper }) => {
+    await api.remoteInstanceApi.addRemoteInstance({
+      external: {
+        add_node: { node_name: redisServiceName, node_type: 'NODE_TYPE_REMOTE_NODE' },
+        address: 'external_pmm',
+        cluster: 'redis_external_exporter',
+        group: 'redis-remote',
+        listen_port: '42200',
+        metrics_path: '/metrics',
+        schema: 'http',
+        service_name: redisServiceName,
+      },
+    });
+
+    cliHelper
+      .execSilent(
+        `docker exec external_pmm pmm-admin add external --listen-port=42200 --group="redis" --custom-labels="testing=redis" --service-name=${redisServiceName}-2`,
+      )
+      .assertSuccess();
+  });
+
+  for (const service of services) {
+    // eslint-disable-next-line playwright/expect-expect -- Pre upgrade test
+    pmmTest(
+      `PMM-T2074 - Verify user can create Remote Instance ${service.serviceType} before upgrade @pre-upgrade`,
+      async ({ api }) => {
+        const remoteInstance = api.remoteInstanceApi.buildRemoteInstanceDataBody(service);
+
+        await api.remoteInstanceApi.addRemoteInstance(remoteInstance);
+      },
+    );
+  }
+});

--- a/e2e_tests/tests/upgrade/settings.test.ts
+++ b/e2e_tests/tests/upgrade/settings.test.ts
@@ -1,0 +1,25 @@
+import pmmTest from '@fixtures/pmmTest';
+import { expect } from '@playwright/test';
+
+pmmTest.describe('PMM settings tests for upgrade', () => {
+  pmmTest.beforeEach(async ({ grafanaHelper }) => {
+    await grafanaHelper.authorize();
+  });
+
+  pmmTest('Verify user is able to set custom Settings @pre-upgrade', async ({ api }) => {
+    const body = {
+      data_retention: '172800s',
+      metrics_resolutions: {
+        hr: '30s',
+        lr: '60s',
+        mr: '60s',
+      },
+      telemetry_enabled: true,
+    };
+    const response = await api.settingsApi.changeSettings(body);
+
+    expect(response).toBeTruthy();
+
+    await api.serverApi.waitForReady();
+  });
+});

--- a/e2e_tests/tests/upgrade/ssl.test.ts
+++ b/e2e_tests/tests/upgrade/ssl.test.ts
@@ -1,0 +1,48 @@
+import pmmTest from '@fixtures/pmmTest';
+import { Timeouts } from '@helpers/timeouts';
+import { expect } from '@playwright/test';
+
+pmmTest.describe('PMM upgrade tests for SSL', () => {
+  const container = 'psmdb-server';
+  const remoteServiceName = `remote_api_${container}`;
+
+  pmmTest(
+    'PMM-T948 + PMM-T947 - Verify Adding MongoDB SSL service remotely via API before upgrade @pre-upgrade',
+    async ({ api, cliHelper }) => {
+      const clientCert = cliHelper
+        .execSilent(`docker exec ${container} cat /mongodb_certs/client.pem`)
+        .assertSuccess().stdout;
+      const caLocation = cliHelper
+        .execSilent(`find / -name "ca.crt"`)
+        .stdout.split('\n')
+        .find((row: string) => row.includes('pmm_psmdb_diffauth_setup'))
+        ?.trim();
+      const ca = cliHelper.execSilent(`cat ${caLocation}`).assertSuccess().stdout;
+
+      await api.remoteInstanceApi.addRemoteInstance({
+        mongodb: {
+          add_node: { node_name: remoteServiceName, node_type: 'NODE_TYPE_REMOTE_NODE' },
+          address: container,
+          authentication_mechanism: 'MONGODB-X509',
+          cluster: 'mongodb_ssl_remote_cluster',
+          pmm_agent_id: 'pmm-server',
+          port: '27017',
+          qan_mongodb_profiler: true,
+          service_name: remoteServiceName,
+          tls: true,
+          tls_ca: ca,
+          tls_certificate_file_password: '',
+          tls_certificate_key: clientCert,
+          tls_skip_verify: true,
+        },
+      });
+
+      await expect
+        .poll(() => api.inventoryApi.verifyAgentsAreRunning(remoteServiceName), {
+          message: `One or more agents are not running for ${remoteServiceName}`,
+          timeout: Timeouts.TWO_MINUTES,
+        })
+        .toBe(true);
+    },
+  );
+});

--- a/e2e_tests/tests/upgrade/upgradePmm.test.ts
+++ b/e2e_tests/tests/upgrade/upgradePmm.test.ts
@@ -1,0 +1,26 @@
+import pmmTest from '@fixtures/pmmTest';
+import { expect } from '@playwright/test';
+import apiEndpoints from '@helpers/apiEndpoints';
+
+pmmTest.describe('PMM server upgrade tests', () => {
+  pmmTest.beforeEach(async ({ context, grafanaHelper, page }) => {
+    if (!process.env.PMM_SERVER_LATEST?.trim()) {
+      throw new Error('PMM_SERVER_LATEST env var is required for the upgrade version check');
+    }
+
+    // pmmTest mocks the updates endpoint; the real version is needed here.
+    await page.unroute(apiEndpoints.server.updates);
+    await context.unroute(apiEndpoints.server.updates);
+    await grafanaHelper.authorize();
+  });
+
+  pmmTest(
+    'PMM-T3 - Verify user is able to Upgrade PMM version [blocker] @pmm-upgrade',
+    async ({ updatesPage }) => {
+      const info = await updatesPage.getUpdateInfo();
+
+      expect(info.update_available, 'An update should be available before upgrading').toBe(true);
+      await updatesPage.upgrade();
+    },
+  );
+});


### PR DESCRIPTION
## Summary
Adds comprehensive upgrade test coverage for PMM and extends the Grafana helper with new dashboard, folder, and user management capabilities. Introduces new API clients for alerting, annotations, remote instances, and server operations.

## Key Changes

**Test Infrastructure**
- Added upgrade test suite (`tests/upgrade/`) covering dashboards, CLI, SSL, external services, custom passwords, alerts, annotations, advisors, and settings
- Added `README.md` documenting test folder structure, setup, and execution
- Introduced `TestState` helper for persisting state across upgrade test runs (pre/post upgrade)
- Added test data for external services used in upgrade scenarios

**Grafana Helper Extensions**
- `changePassword()` - Change user account password
- `createCustomDashboard()` - Create dashboards with custom panels and tags
- `createFolder()` - Create Grafana folders
- `deleteUser()` - Delete users by ID
- `getDashboard()` - Retrieve dashboard by UID
- `getFolderDetailsByName()` - Look up folders by name
- `promoteToEditor()` - Promote users to Editor role
- `setHomeDashboard()` - Set home dashboard preference
- `starDashboard()` - Star/favorite dashboards
- Updated `createUser()` to return user ID and added proper assertions

**New API Clients**
- `AlertingApi` - Manage alert templates, rules, and folders
- `AnnotationsApi` - Set service-level annotations
- `RemoteInstanceApi` - Add remote database instances (MySQL, PostgreSQL, MongoDB)
- `ServerApi` - Poll server readiness endpoint

**Page Objects & Components**
- `AlertStatusPage` - Alert status dashboard page object
- `AdvisorsPage` - Advisors configuration page object
- `SnackbarComponent` - Notification/snackbar component

**API & Helper Updates**
- Extended `InventoryApi` with regex-based service filtering and batch retrieval methods
- Extended `SettingsApi` with `changeSettings()` method
- Updated `UpdatesPage` to use new "What's new" link and "Check Updates Now" button
- Added `GrafanaFolder` interface for type safety
- Extended `apiEndpoints` with alerting, annotations, and management endpoints

**Test Fixes**
- Fixed `postRelease.test.ts` to resolve `PMM_SERVER_LATEST` per-test rather than at module scope, preventing failures in unrelated `--grep` runs
- Updated panel component verification to support optional text validation

## Notable Implementation Details

- Upgrade tests use `@pre-upgrade` and `@post-upgrade` tags to organize test phases around server upgrade
- `TestState` persists data to `output/upgrade-state.json` (git-ignored), configurable via `UPGRADE_STATE_FILE` env var
- Grafana API calls include `ignoreHTTPSErrors: true` for self-signed certificate environments
- Remote instance API builder supports multiple service types with type-safe configuration
- Alert template and rule creation includes folder management and filter support

https://claude.ai/code/session_01VuxH3QpgJyyGLvsSMnaX4p