### PR TITLE
PMM-7 Fix upgrade alerts test folder for PMM 3.7.1

### DIFF
--- a/e2e_tests/tests/upgrade/alerts.test.ts
+++ b/e2e_tests/tests/upgrade/alerts.test.ts
@@ -13,7 +13,9 @@ pmmTest.describe('PMM Alerts tests for upgrade', () => {
   pmmTest(
     'PMM-T577 - Verify user is able to create and see firing alerts before upgrade @pre-upgrade',
     async ({ alertStatusPage, api, page }) => {
-      const folder = await api.alertingApi.getFolderByName('PMM Health');
+      // PMM 3.7.1 has no dedicated "PMM Health" alerting folder (added in later
+      // releases), so host the rule in the "Insight" folder, which ships with 3.7.1.
+      const folder = await api.alertingApi.getFolderByName('Insight');
 
       await api.alertingApi.createRule(GrafanaHelper.getAuthHeader(), {
         filters: [{ label: 'node_name', regexp: 'pmm-server', type: 'FILTER_TYPE_MATCH' }],


### PR DESCRIPTION
## Summary

Follow-up fix to the upgrade test suite merged in #1301.

The `PMM-T577` alerts pre-upgrade test failed on PMM 3.7.1:

```
Error: Folder with name: PMM Health not found
  at api/alerting.api.ts:51 (AlertingApi.getFolderByName)
  at tests/upgrade/alerts.test.ts:16
```

PMM 3.7.1 has **no dedicated "PMM Health" alerting folder** — that folder was introduced in a later release. The suite was ported from `pmm-3.9.0-upgrade`, where the folder exists.

## Fix

Host the upgrade alert rule in the **`Insight`** folder, which ships with PMM 3.7.1 (and is already used elsewhere in this suite, e.g. `dashdoard.test.ts`).

## Verification

Reproduced against a live `percona/pmm-server:3.7.1` container:

- `GET graph/api/folders` on 3.7.1 returns `Insight, OS, MySQL, MongoDB, PostgreSQL, Experimental, …` — **no `PMM Health`**.
- Creating the rule with the exact test payload (`template_name: pmm_node_high_cpu_load`, `threshold: 1`, `node_name: pmm-server` filter) into the `Insight` folder returns **HTTP 200**.
- The rule reaches the **`firing`** state within ~20s, satisfying the `firingAlert` assertion.

`eslint` clean; `tsc` introduces no new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9tsueFKSWE58LW47S7WWt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9tsueFKSWE58LW47S7WWt)_