### PR TITLE
PMM-7 Fix alerts upgrade test for PMM 3.8.1

### DIFF
--- a/e2e_tests/pages/alerts/alertStatus.page.ts
+++ b/e2e_tests/pages/alerts/alertStatus.page.ts
@@ -1,11 +1,13 @@
 import BasePage from '../base.page';
 
 export default class AlertStatusPage extends BasePage {
-  url = 'pmm-ui/alerting/status';
+  // PMM 3.8.1 renders fired alerts on the Grafana-based "Fired alerts" page (inside the
+  // #grafana-iframe), not on the pmm-ui/alerting/status page introduced in later versions.
+  url = 'graph/alerting/alerts';
   builders = {
     firingAlert: (alertName: string) =>
-      this.page.locator(
-        `//td[text()="${alertName}"]/parent::tr//td[position()="2"]//span[contains(text(), "Firing")]`,
+      this.grafanaIframe().locator(
+        `//td[contains(., "${alertName}")]/parent::tr//td[position()="2"]//span[contains(text(), "active")]`,
       ),
   };
   buttons = {};


### PR DESCRIPTION
## Summary

Fixes the pre-upgrade alerts test (`PMM-T577`) so it passes on **PMM Server 3.8.1**. The test previously failed with `expect(locator).toBeVisible()` / "element(s) not found" because the alert page differs from later PMM versions.

## Root cause

`AlertStatusPage` targeted `pmm-ui/alerting/status` — a "Fired alerts" page that **does not exist in PMM 3.8.1** (the route renders "Not found"). In 3.8.1, fired alerts are shown on the Grafana-based **Fired alerts** page (`graph/alerting/alerts`), which:

- renders inside the `#grafana-iframe` (so top-frame `page.locator` never matches),
- shows the rule name as a link in the first cell (so `td[text()="…"]` never matches — needs `contains(.)`),
- shows the state as **`active`** (lowercase in the DOM; CSS capitalizes it), not "Firing".

## Fix

`e2e_tests/pages/alerts/alertStatus.page.ts`:
- Point `url` at `graph/alerting/alerts`.
- Resolve the row inside the Grafana iframe via the existing `grafanaIframe()` helper.
- Match the rule name with `contains(., "…")` and assert the `active` state cell.

## Verification

Ran the test end-to-end against a live `percona/pmm-server:3.8.1` container, from a clean state — it creates the alert rule, waits for it to fire, and sees it on the page:

```
✓  tests/upgrade/alerts.test.ts › PMM-T577 - Verify user is able to create and see firing alerts before upgrade @pre-upgrade (36.7s)
1 passed
```

ESLint clean; TypeScript typecheck introduces no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuxH3QpgJyyGLvsSMnaX4p

---
_Generated by [Claude Code](https://claude.ai/code/session_01VuxH3QpgJyyGLvsSMnaX4p)_