### PR TITLE
Unskip PMM-T506 once its stale expectations are gone

### DIFF
--- a/codeceptjs-e2e/tests/verifyVMDashboards_test.js
+++ b/codeceptjs-e2e/tests/verifyVMDashboards_test.js
@@ -6,8 +6,7 @@ Before(async ({ I }) => {
   await I.Authorize();
 });
 
-// skip-until: 2026-09-29 -- cardinality panels removed by percona/pmm#5822; unskip via pmm-qa#1275, or when the panels return.
-Scenario.skip(
+Scenario(
   'PMM-T506 - Verify metrics on VictoriaMetrics dashboard @nightly  @dashboards @gssapi-nightly',
   async ({ I, dashboardPage }) => {
     I.amOnPage(dashboardPage.victoriaMetricsDashboard.url);


### PR DESCRIPTION
## Failures fixed (investigator)

- source: nightly CI run https://github.com/percona/pmm-qa/actions/runs/33222594797 — the same PMM-T506 failure #1288 muted
- blocked-on: #1275 — **DO NOT MERGE** until that PR lands. On its own this un-mutes a test whose expectations are still stale, and the nightly goes red again exactly as before.
- tests:
  - `codeceptjs-e2e/tests/verifyVMDashboards_test.js:9` / `@nightly` — PMM-T506 Verify metrics on VictoriaMetrics dashboard

## What this is

The second half of the fix. #1288 muted PMM-T506 while the panel question was open; #1275 (now
approved) settles it by dropping the two expectations. This removes the mute so the test runs again.

```diff
-// skip-until: 2026-09-29 -- cardinality panels removed by percona/pmm#5822; unskip via pmm-qa#1275, or when the panels return.
-Scenario.skip(
+Scenario(
```

## Why this is a separate PR, and why it is needed at all

**#1275 alone no longer fixes the nightly.** Its branch forked from `0b9d4d9`, before #1288 landed,
so its copy of `verifyVMDashboards_test.js` still reads a plain `Scenario(` — nothing to unskip on
that side. In the three-way merge the base and that branch agree on the file while `main` added the
skip, so **merging #1275 keeps `Scenario.skip`**: expectations fixed, test still dark, nightly
unchanged, and the `skip-until: 2026-09-29` tripwire fires on a test nobody needs to look at any more.

The alternative was to merge `main` into #1275's branch and unskip there — one atomic merge. Not done
for two reasons: it would reset the approval #1275 just received, and #1275 was explicitly asked to be
left alone to be merged or rejected on its own. A GitHub App also can't push that merge, since it
would touch `.github/workflows/lint.yml` (moved by #1288) — see the analysis on #1275.

Kept as a **draft** so it cannot merge out of order.

## Merge order

1. **#1275** — drops the stale expectations.
2. **this** — removes the mute; T506 runs against the corrected expectations.

Reversed, step 2 alone reproduces the original failure for a night.

## Verification

- The file is **byte-identical to its pre-mute state** (`git diff --quiet 0b9d4d9 -- <file>` → clean),
  so this is a true revert of #1288's test change, not a rewrite.
- No `skip-until` marker remains anywhere: 0 of 393 tracked `.js`/`.ts` files carry one, so the guard
  #1288 added has nothing dangling to fire on.
- The `skip-until expiry` check still runs clean over all tracked files (`rc=0`).
- T506 now reports `✖` rather than `S` — it executes instead of being skipped (it fails in this
  sandbox only because there is no PMM server to reach).
- That the end state passes is already evidenced: the Linode run recorded on #1275 showed T506
  green with the expectations dropped and the scenario active — which is exactly `main` + #1275 + this.

The guard and weekly lint schedule from #1288 stay in place for future skips; only this skip and its
marker are removed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKRuqWTQVW4p6DDSYcFQEf

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKRuqWTQVW4p6DDSYcFQEf)_