### PR TITLE
linode: make the tagged-StorageClass swap race-safe and non-fatal

### DIFF
--- a/.claude/skills/linode-ha-provisioning/scripts/create-lke-pmm-ha.sh
+++ b/.claude/skills/linode-ha-provisioning/scripts/create-lke-pmm-ha.sh
@@ -134,8 +134,12 @@ kubectl get nodes
 # --- storage class: tag every CSI volume at birth ----------------------------
 # LKE's default SC has no volumeTags and a StorageClass's parameters are immutable,
 # so its volumes are born untagged and prune-lke-orphans.sh can never attribute them.
-kubectl delete storageclass linode-block-storage-retain --ignore-not-found
-kubectl apply -f - <<EOF
+# `replace --force` recreates it in one step (a plain apply would hit "parameters
+# forbidden"); non-fatal with one retry so losing a race with LKE's addon reconciler
+# degrades to an untagged volume (imperative tagging backstop) -- never a failed
+# provision that leaks the already-created cluster.
+_apply_tagged_sc() {
+    kubectl replace --force -f - <<EOF
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -149,6 +153,8 @@ reclaimPolicy: Retain
 volumeBindingMode: Immediate
 allowVolumeExpansion: true
 EOF
+}
+_apply_tagged_sc || { sleep 3; _apply_tagged_sc || log "WARN: tagged StorageClass not applied; volumes fall back to imperative tagging"; }
 
 # --- dependencies (operators) ------------------------------------------------
 kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -


### PR DESCRIPTION
## Problem

Follow-up to #1311, addressing a review finding on the just-merged change.

`create-lke` swapped the tagged StorageClass in with `kubectl delete … ; kubectl apply …`. That is fragile under `set -euo pipefail`: LKE's addon reconciler can recreate the (untagged) default `linode-block-storage-retain` in the window between the two commands. The `apply` then tries to *update* an existing StorageClass, hits `updates to parameters are forbidden` (a StorageClass's `parameters` are immutable — the very premise of #1311), and the script exits non-zero **with the cluster already created and billing**. The EXIT trap only tags/diagnoses, so nothing tears the cluster down until the 24h TTL reaper — a worse outcome than the leak #1311 closes.

## Change

Recreate the StorageClass with **`kubectl replace --force`** (a single delete+create, so immutable `parameters` are replaced rather than rejected), wrapped so it is **non-fatal**: one retry, then a warning. Losing the race with the reconciler now degrades to an *untagged volume* — still covered by the imperative tagging backstop (`tag-lke-resources.sh` at provision and before delete) — instead of a failed provision that orphans the cluster.

## Validation

- `shellcheck -S warning` and `bash -n` clean.
- Behavior reasoning: in the race case, `replace --force`'s create step meets LKE's freshly-recreated SC (`AlreadyExists`) and the retry recreates it; if both attempts lose, a default StorageClass still exists (LKE's untagged one), so the provision proceeds and volumes fall back to imperative tagging — never a dead, billing cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBhvZuEUQU8ym347Xat4Yy

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBhvZuEUQU8ym347Xat4Yy)_