### PR TITLE
linode: ephemeral StorageClass uses Delete reclaim, not Retain

### DIFF
--- a/.claude/skills/linode-ha-provisioning/scripts/create-lke-pmm-ha.sh
+++ b/.claude/skills/linode-ha-provisioning/scripts/create-lke-pmm-ha.sh
@@ -134,9 +134,8 @@ kubectl get nodes
 # --- storage class: tag every CSI volume at birth ----------------------------
 # LKE's default SC has no volumeTags and a StorageClass's parameters are immutable,
 # so its volumes are born untagged and prune-lke-orphans.sh can never attribute them.
-# Also flip reclaimPolicy to Delete (the default is Retain): on a throwaway cluster a
-# churned/deleted PVC should free its volume immediately, not leave a Released PV
-# billing until teardown. The name is kept so charts that reference it still resolve.
+# The name stays LKE's `-retain` so charts and existing PVCs still resolve it, even
+# though it now reclaims Delete: a churned PVC must free its volume mid-run.
 kubectl delete storageclass linode-block-storage-retain --ignore-not-found
 kubectl apply -f - <<EOF
 apiVersion: storage.k8s.io/v1

--- a/.claude/skills/linode-ha-provisioning/scripts/create-lke-pmm-ha.sh
+++ b/.claude/skills/linode-ha-provisioning/scripts/create-lke-pmm-ha.sh
@@ -134,6 +134,9 @@ kubectl get nodes
 # --- storage class: tag every CSI volume at birth ----------------------------
 # LKE's default SC has no volumeTags and a StorageClass's parameters are immutable,
 # so its volumes are born untagged and prune-lke-orphans.sh can never attribute them.
+# Also flip reclaimPolicy to Delete (the default is Retain): on a throwaway cluster a
+# churned/deleted PVC should free its volume immediately, not leave a Released PV
+# billing until teardown. The name is kept so charts that reference it still resolve.
 kubectl delete storageclass linode-block-storage-retain --ignore-not-found
 kubectl apply -f - <<EOF
 apiVersion: storage.k8s.io/v1
@@ -145,7 +148,7 @@ metadata:
 provisioner: linodebs.csi.linode.com
 parameters:
   linodebs.csi.linode.com/volumeTags: "pmm-qa-ephemeral,pmm-qa-run:$RUN_ID"
-reclaimPolicy: Retain
+reclaimPolicy: Delete
 volumeBindingMode: Immediate
 allowVolumeExpansion: true
 EOF


### PR DESCRIPTION
## Problem

Follow-up to #1311. The tagged StorageClass that `create-lke` installs kept LKE's default **Retain** reclaim policy. On a live cluster, every churned or deleted PVC (a StatefulSet reschedule, an operator recreating a claim) then leaves its Block Storage volume behind as a **Released** PV that keeps billing until the whole cluster is torn down.

Observed on a live HA cluster (`pmm-ha-PMM-15304-ha`): **35 of 54 PVs Released, 830 GB parked**. These are not a cross-cluster leak — they carry the live cluster's `pmm-qa-run` tag, so the orphan sweep correctly keeps them and will reap them when the cluster dies — but they waste money for the cluster's whole life (up to its 24–48 h TTL).

## Change

One line: the ephemeral StorageClass now uses `reclaimPolicy: Delete` instead of `Retain`. A deleted PVC frees its volume immediately, while the CSI controller is alive — no Released buildup during the cluster's life.

Teardown safety is unchanged: an abrupt `lke cluster-delete` still can't run the CSI controller, but volumes are tagged at birth (`volumeTags`, #1311) so `prune-lke-orphans.sh` reaps whatever survives. `Delete` only removes the *within-life* Released accumulation. The StorageClass name is kept so charts referencing it still resolve.

This is intentionally **not** the race-hardening from the closed #1312 (that concern was judged not worth the change) — only the reclaim-policy flip.

## Validation

- `shellcheck -S warning` and `bash -n` clean.
- Root cause confirmed live: 35/54 Released PVs on a running cluster under the Retain SC; `Delete` is the standard reclaim policy for throwaway storage and removes that buildup at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBhvZuEUQU8ym347Xat4Yy

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBhvZuEUQU8ym347Xat4Yy)_