### PR TITLE
migrate(settings): verifyPMMSettingsPageElements CodeceptJS to Playwright

### DIFF
--- a/.github/workflows/e2e-tests-matrix.yml
+++ b/.github/workflows/e2e-tests-matrix.yml
@@ -203,9 +203,6 @@ jobs:
       pmm_server_version: ${{ inputs.pmm_server_image || github.event.inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
       pmm_client_version: ${{ inputs.pmm_client_version || github.event.inputs.pmm_client_version || 'latest-tarball' }}
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
-      # No database: every @settings test needs PMM Server only. `workers` is
-      # deliberately unset -- the runner defaults it to 1, and these tests mutate
-      # shared server settings, so they cannot run in parallel.
       setup_services: '-h'
       pmm_test_flag: '@settings'
 

--- a/.github/workflows/e2e-tests-matrix.yml
+++ b/.github/workflows/e2e-tests-matrix.yml
@@ -194,6 +194,21 @@ jobs:
       setup_services: '--database ps=8.4 --database psmdb --database pdpgsql'
       pmm_test_flag: '@LBAC'
 
+  settings_playwright:
+    name: Settings UI tests
+    uses: ./.github/workflows/runner-e2e-tests-playwright.yml
+    secrets:
+      LAUNCHABLE_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN }}
+    with:
+      pmm_server_version: ${{ inputs.pmm_server_image || github.event.inputs.pmm_server_image || 'perconalab/pmm-server:3-dev-latest' }}
+      pmm_client_version: ${{ inputs.pmm_client_version || github.event.inputs.pmm_client_version || 'latest-tarball' }}
+      pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || github.event.inputs.pmm_qa_branch || 'main') }}
+      # No database: every @settings test needs PMM Server only. `workers` is
+      # deliberately unset -- the runner defaults it to 1, and these tests mutate
+      # shared server settings, so they cannot run in parallel.
+      setup_services: '-h'
+      pmm_test_flag: '@settings'
+
   fb_tests:
     name: FB E2E tests
     uses: ./.github/workflows/fb-e2e-suite.yml

--- a/codeceptjs-e2e/tests/configuration/verifyPMMSettingsPageElements_migrated.js
+++ b/codeceptjs-e2e/tests/configuration/verifyPMMSettingsPageElements_migrated.js
@@ -1,5 +1,3 @@
-// Kept after migration to e2e_tests/tests/configuration/settingsPageElements.test.ts: percona/grafana
-// CI runs @grafana-pr via package.json e2e:grafana-pr, which is CodeceptJS-only.
 const page = require('./pages/pmmSettingsPage');
 
 const dataRetentionTable = new DataTable(['value', 'message']);

--- a/codeceptjs-e2e/tests/configuration/verifyPMMSettingsPageElements_test.js
+++ b/codeceptjs-e2e/tests/configuration/verifyPMMSettingsPageElements_test.js
@@ -1,7 +1,5 @@
-// Migrated to e2e_tests/tests/configuration/settingsPageElements.test.ts, but deliberately kept:
-// the only @grafana-pr consumer is package.json e2e:grafana-pr, invoked by percona/grafana CI,
-// which runs CodeceptJS only. Retiring this file would silently drop its 4 @grafana-pr scenarios
-// from that gate. Safe to retire once percona/grafana CI can invoke the Playwright suite instead.
+// Kept after migration to e2e_tests/tests/configuration/settingsPageElements.test.ts: percona/grafana
+// CI runs @grafana-pr via package.json e2e:grafana-pr, which is CodeceptJS-only.
 const page = require('./pages/pmmSettingsPage');
 
 const dataRetentionTable = new DataTable(['value', 'message']);

--- a/codeceptjs-e2e/tests/configuration/verifyPMMSettingsPageElements_test.js
+++ b/codeceptjs-e2e/tests/configuration/verifyPMMSettingsPageElements_test.js
@@ -1,3 +1,7 @@
+// Migrated to e2e_tests/tests/configuration/settingsPageElements.test.ts, but deliberately kept:
+// the only @grafana-pr consumer is package.json e2e:grafana-pr, invoked by percona/grafana CI,
+// which runs CodeceptJS only. Retiring this file would silently drop its 4 @grafana-pr scenarios
+// from that gate. Safe to retire once percona/grafana CI can invoke the Playwright suite instead.
 const page = require('./pages/pmmSettingsPage');
 
 const dataRetentionTable = new DataTable(['value', 'message']);

--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -95,6 +95,7 @@ For test, page-object, fixture, and helper conventions, see [CONTRIBUTING.md](./
 - `@downloads`
 - `@fb-instances`
 - `@fb-settings`
+- `@grafana-pr`
 - `@image-renderer`
 - `@inventory`
 - `@LBAC`

--- a/e2e_tests/api/server.api.ts
+++ b/e2e_tests/api/server.api.ts
@@ -14,8 +14,22 @@ interface VersionResponse {
   version: string;
 }
 
+interface ServerVersionResponse {
+  distribution_method: string;
+}
+
 export default class ServerApi {
   constructor(private request: APIRequestContext) {}
+
+  getDistributionMethod = async (): Promise<string> => {
+    const response = await this.request.get(apiEndpoints.server.serverVersion, {
+      headers: GrafanaHelper.getAuthHeader(),
+    });
+
+    expect(response.status()).toEqual(200);
+
+    return ((await response.json()) as ServerVersionResponse).distribution_method;
+  };
 
   getPmmVersion = async (): Promise<PmmVersion> => {
     const response = await this.request.get(apiEndpoints.server.version, {

--- a/e2e_tests/api/settings.api.ts
+++ b/e2e_tests/api/settings.api.ts
@@ -66,24 +66,35 @@ export default class SettingsApi {
       headers: GrafanaHelper.getAuthHeader(),
     });
 
-    if (response.status() !== 400) return;
+    if (response.status() !== 400) {
+      expect(response.status()).toEqual(200);
+
+      return;
+    }
 
     const { message } = (await response.json()) as { message?: string };
 
-    if (!message?.includes('Telemetry is configured via PMM_ENABLE_TELEMETRY')) return;
+    expect(message, 'Unexpected 400 from the settings restore').toContain(
+      'Telemetry is configured via PMM_ENABLE_TELEMETRY',
+    );
 
     delete body.enable_advisor;
     delete body.enable_telemetry;
-    await this.request.put(apiEndpoints.server.settings, {
+
+    const retry = await this.request.put(apiEndpoints.server.settings, {
       data: body,
       headers: GrafanaHelper.getAuthHeader(),
     });
+
+    expect(retry.status()).toEqual(200);
   };
 
   setPublicAddress = async (address: string): Promise<void> => {
-    await this.request.put(apiEndpoints.server.settings, {
+    const response = await this.request.put(apiEndpoints.server.settings, {
       data: { pmm_public_address: address },
       headers: GrafanaHelper.getAuthHeader(),
     });
+
+    expect(response.status()).toEqual(200);
   };
 }

--- a/e2e_tests/api/settings.api.ts
+++ b/e2e_tests/api/settings.api.ts
@@ -48,4 +48,42 @@ export default class SettingsApi {
 
     return (await response.json()) as SettingsResponse;
   };
+
+  restoreSettingsDefaults = async (): Promise<void> => {
+    const body: Record<string, unknown> = {
+      data_retention: '2592000s',
+      enable_advisor: true,
+      enable_alerting: true,
+      enable_telemetry: true,
+      metrics_resolutions: { hr: '5s', lr: '60s', mr: '10s' },
+      remove_alert_manager_rules: true,
+      remove_alert_manager_url: true,
+      remove_email_alerting_settings: true,
+      remove_slack_alerting_settings: true,
+    };
+    const response = await this.request.put(apiEndpoints.server.settings, {
+      data: body,
+      headers: GrafanaHelper.getAuthHeader(),
+    });
+
+    if (response.status() !== 400) return;
+
+    const { message } = (await response.json()) as { message?: string };
+
+    if (!message?.includes('Telemetry is configured via PMM_ENABLE_TELEMETRY')) return;
+
+    delete body.enable_advisor;
+    delete body.enable_telemetry;
+    await this.request.put(apiEndpoints.server.settings, {
+      data: body,
+      headers: GrafanaHelper.getAuthHeader(),
+    });
+  };
+
+  setPublicAddress = async (address: string): Promise<void> => {
+    await this.request.put(apiEndpoints.server.settings, {
+      data: { pmm_public_address: address },
+      headers: GrafanaHelper.getAuthHeader(),
+    });
+  };
 }

--- a/e2e_tests/helpers/apiEndpoints.ts
+++ b/e2e_tests/helpers/apiEndpoints.ts
@@ -43,6 +43,8 @@ const apiEndpoints = {
     leaderHealthCheck: '/v1/server/leaderHealthCheck',
     logs: '/logs.zip',
     readyz: '/v1/server/readyz',
+    // Carries distribution_method; /v1/version above does not.
+    serverVersion: '/v1/server/version',
     settings: '/v1/server/settings',
     updates: '**/v1/server/updates?force=**',
     version: '/v1/version',

--- a/e2e_tests/helpers/apiEndpoints.ts
+++ b/e2e_tests/helpers/apiEndpoints.ts
@@ -43,7 +43,6 @@ const apiEndpoints = {
     leaderHealthCheck: '/v1/server/leaderHealthCheck',
     logs: '/logs.zip',
     readyz: '/v1/server/readyz',
-    // Carries distribution_method; /v1/version above does not.
     serverVersion: '/v1/server/version',
     settings: '/v1/server/settings',
     updates: '**/v1/server/updates?force=**',

--- a/e2e_tests/pages/ha/settings.page.ts
+++ b/e2e_tests/pages/ha/settings.page.ts
@@ -1,5 +1,6 @@
 import BasePage from '../base.page';
 import pmmTest from '../../fixtures/pmmTest';
+import apiEndpoints from '@helpers/apiEndpoints';
 import { Timeouts } from '@helpers/timeouts';
 
 export default class SettingsPage extends BasePage {
@@ -60,20 +61,23 @@ export default class SettingsPage extends BasePage {
   };
   messages = {};
 
+  applyAdvancedChanges = async (): Promise<void> => {
+    const saved = this.page.waitForResponse(
+      (response) =>
+        response.url().includes(apiEndpoints.server.settings) && response.request().method() === 'PUT',
+      { timeout: Timeouts.THIRTY_SECONDS },
+    );
+
+    await this.buttons.applyAdvancedChanges.click();
+    await saved;
+  };
+
   enableToggleAndApplyChanges = async (toggleName: keyof typeof this.buttons.toggles): Promise<void> =>
     await pmmTest.step(`Enable ${toggleName} and apply changes`, async () => {
       await this.page.goto(this.urls.advanced);
       await this.buttons.toggles[toggleName].locator.click();
       await this.buttons.applyAdvancedChanges.click();
     });
-
-  getDataRetentionValidationMessage = async (): Promise<string> =>
-    await this.inputs.dataRetention.evaluate((input: HTMLInputElement) => input.validationMessage);
-
-  settleAfterApplyingChanges = async (): Promise<void> => {
-    // eslint-disable-next-line playwright/no-wait-for-timeout -- ported fixed pause: the advanced form re-renders after a save and exposes no signal to wait on
-    await this.page.waitForTimeout(Timeouts.FIVE_SECONDS);
-  };
 
   waitForPageLoaded = async (): Promise<void> =>
     await this.elements.tabContent.waitFor({ state: 'visible', timeout: Timeouts.THIRTY_SECONDS });

--- a/e2e_tests/pages/ha/settings.page.ts
+++ b/e2e_tests/pages/ha/settings.page.ts
@@ -1,5 +1,6 @@
 import BasePage from '../base.page';
 import pmmTest from '../../fixtures/pmmTest';
+import { Timeouts } from '@helpers/timeouts';
 
 export default class SettingsPage extends BasePage {
   url = '/pmm-ui/settings';
@@ -36,16 +37,26 @@ export default class SettingsPage extends BasePage {
     },
   };
   elements = {
+    advancedLabel: this.page.getByTestId('advanced-label'),
+    advisorsLabel: this.page.getByTestId('advanced-advisors'),
+    checkForUpdatesLabel: this.page.getByTestId('advanced-updates'),
+    errorAlert: this.page.getByTestId('data-testid Alert error'),
+    metricsResolutionLabel: this.page.getByTestId('metrics-resolution-label'),
     //review this selector - seems redundant
     pageBody: this.page.locator('body'),
     pageTitle: this.page.getByRole('heading', { name: 'Settings' }),
+    publicAddressLabel: this.page.getByTestId('public-address-label'),
+    sshKeyLabel: this.page.getByTestId('ssh-key-label'),
+    tabContent: this.page.getByTestId('settings-tab-content'),
+    telemetryLabel: this.page.getByTestId('advanced-telemetry'),
   };
   inputs = {
-    high: this.page.locator('[name="hr"]'),
-    low: this.page.locator('[name="lr"]'),
-    medium: this.page.locator('[name="mr"]'),
-    publicAddress: this.page.getByTestId('text-input-public-address'),
-    sshKey: this.page.getByTestId('text-input-ssh-key'),
+    dataRetention: this.page.getByTestId('retention-number-input'),
+    high: this.page.getByTestId('hr-number-input'),
+    low: this.page.getByTestId('lr-number-input'),
+    medium: this.page.getByTestId('mr-number-input'),
+    publicAddress: this.page.getByTestId('publicAddress-text-input'),
+    sshKey: this.page.getByTestId('ssh-key'),
   };
   messages = {};
 
@@ -55,4 +66,15 @@ export default class SettingsPage extends BasePage {
       await this.buttons.toggles[toggleName].locator.click();
       await this.buttons.applyAdvancedChanges.click();
     });
+
+  getDataRetentionValidationMessage = async (): Promise<string> =>
+    await this.inputs.dataRetention.evaluate((input: HTMLInputElement) => input.validationMessage);
+
+  settleAfterApplyingChanges = async (): Promise<void> => {
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- ported fixed pause: the advanced form re-renders after a save and exposes no signal to wait on
+    await this.page.waitForTimeout(Timeouts.FIVE_SECONDS);
+  };
+
+  waitForPageLoaded = async (): Promise<void> =>
+    await this.elements.tabContent.waitFor({ state: 'visible', timeout: Timeouts.THIRTY_SECONDS });
 }

--- a/e2e_tests/tests/configuration/settingsPageElements.test.ts
+++ b/e2e_tests/tests/configuration/settingsPageElements.test.ts
@@ -95,19 +95,6 @@ pmmTest('Verify Advanced Section Elements @settings @grafana-pr', async ({ page,
   });
 });
 
-// TODO: Remove the skip after https://jira.percona.com/browse/PMM-5791
-// eslint-disable-next-line playwright/no-skipped-test -- PMM-T227 is intentionally skipped until PMM-5791 is fixed.
-pmmTest.skip(
-  'PMM-T227 - Open PMM Settings page and verify DATA_RETENTION value is set to 2 days @settings',
-  async ({ page, settingsPage }) => {
-    await page.goto(settingsPage.url);
-    await settingsPage.waitForPageLoaded();
-    await expect(settingsPage.inputs.dataRetention).toHaveValue('2', {
-      timeout: Timeouts.THIRTY_SECONDS,
-    });
-  },
-);
-
 pmmTest(
   'PMM-T1866 - Verify if public address has an port assigned and following UI/API requests dont error @settings',
   async ({ page, settingsPage }) => {

--- a/e2e_tests/tests/configuration/settingsPageElements.test.ts
+++ b/e2e_tests/tests/configuration/settingsPageElements.test.ts
@@ -1,0 +1,143 @@
+import pmmTest from '@fixtures/pmmTest';
+import { Timeouts } from '@helpers/timeouts';
+import { expect } from '@playwright/test';
+
+const dataRetentionRows = [
+  { message: 'Value must be less than or equal to 3650.', value: '2147483648' },
+  { message: 'Value must be greater than or equal to 1.', value: '-1' },
+  { message: 'Value must be greater than or equal to 1.', value: '0' },
+];
+
+pmmTest.beforeEach(async ({ api, grafanaHelper }) => {
+  await grafanaHelper.authorize();
+  await api.settingsApi.restoreSettingsDefaults();
+});
+
+pmmTest.afterEach(async ({ api }) => {
+  await api.settingsApi.setPublicAddress('');
+});
+
+for (const row of dataRetentionRows) {
+  pmmTest(
+    `PMM-T97 - Verify server diagnostics on PMM Settings Page @settings @grafana-pr | {"value":"${row.value}","message":"${row.message}"}`,
+    async ({ page, settingsPage }) => {
+      await page.goto(settingsPage.urls.advanced);
+      await settingsPage.waitForPageLoaded();
+
+      await pmmTest.step(`Verify data retention "${row.value}" is rejected`, async () => {
+        await settingsPage.inputs.dataRetention.clear();
+        await settingsPage.inputs.dataRetention.fill(row.value);
+        await page.keyboard.press('Tab');
+        await settingsPage.inputs.dataRetention.waitFor({
+          state: 'attached',
+          timeout: Timeouts.THIRTY_SECONDS,
+        });
+        expect(
+          await settingsPage.getDataRetentionValidationMessage(),
+          `Data retention "${row.value}" should report its own validation message`,
+        ).toEqual(row.message);
+      });
+    },
+  );
+}
+
+pmmTest(
+  'PMM-T84 - Verify Section Tabs and Metrics Section Elements [critical] @settings @grafana-pr',
+  async ({ page, settingsPage }) => {
+    await page.goto(settingsPage.url);
+    await settingsPage.waitForPageLoaded();
+
+    await pmmTest.step('Verify the metrics resolution section elements', async () => {
+      await expect(settingsPage.elements.metricsResolutionLabel).toContainText('Metrics resolution', {
+        timeout: Timeouts.THIRTY_SECONDS,
+      });
+      await expect(settingsPage.buttons.metricsResolutionStandard).toBeVisible();
+      await expect(settingsPage.inputs.low).toBeVisible();
+      await expect(settingsPage.inputs.medium).toBeVisible();
+      await expect(settingsPage.inputs.high).toBeVisible();
+    });
+  },
+);
+
+pmmTest(
+  'PMM-T85 - Verify SSH Key Section Elements @settings @grafana-pr',
+  async ({ api, page, settingsPage }) => {
+    if ((await api.serverApi.getDistributionMethod()) !== 'DISTRIBUTION_METHOD_AMI') return;
+
+    await page.goto(settingsPage.urls.ssh);
+    await settingsPage.waitForPageLoaded();
+
+    await pmmTest.step('Verify the SSH key section elements', async () => {
+      await expect(settingsPage.elements.sshKeyLabel).toContainText('SSH key');
+      await expect(settingsPage.inputs.sshKey).toBeVisible();
+    });
+  },
+);
+
+pmmTest('Verify Advanced Section Elements @settings @grafana-pr', async ({ page, settingsPage }) => {
+  await page.goto(settingsPage.urls.advanced);
+  await settingsPage.waitForPageLoaded();
+
+  await pmmTest.step('Verify the advanced section labels', async () => {
+    await expect(settingsPage.elements.advancedLabel).toContainText('Data retention');
+    await expect(settingsPage.elements.telemetryLabel).toContainText('Telemetry');
+    await expect(settingsPage.elements.checkForUpdatesLabel).toContainText('Check for updates');
+    await expect(settingsPage.elements.advisorsLabel).toContainText('Advisors');
+  });
+
+  await pmmTest.step('Verify the advanced section toggles', async () => {
+    await expect(settingsPage.buttons.toggles.telemetry.locator).toBeVisible();
+    await expect(settingsPage.elements.telemetryLabel).toBeVisible();
+    await expect(settingsPage.buttons.toggles.checkForUpdates.locator).toBeVisible();
+    await expect(settingsPage.elements.checkForUpdatesLabel).toBeVisible();
+    await expect(settingsPage.buttons.toggles.advisors.locator).toBeVisible();
+    await expect(settingsPage.elements.advisorsLabel).toBeVisible();
+  });
+});
+
+// TODO: Remove the skip after https://jira.percona.com/browse/PMM-5791
+// eslint-disable-next-line playwright/no-skipped-test -- PMM-T227 is intentionally skipped until PMM-5791 is fixed.
+pmmTest.skip(
+  'PMM-T227 - Open PMM Settings page and verify DATA_RETENTION value is set to 2 days @settings',
+  async ({ page, settingsPage }) => {
+    await page.goto(settingsPage.url);
+    await settingsPage.waitForPageLoaded();
+    await expect(settingsPage.inputs.dataRetention).toHaveValue('2', {
+      timeout: Timeouts.THIRTY_SECONDS,
+    });
+  },
+);
+
+pmmTest(
+  'PMM-T1866 - Verify if public address has an port assigned and following UI/API requests dont error @settings',
+  async ({ page, settingsPage }) => {
+    await page.goto(settingsPage.urls.advanced);
+    await settingsPage.waitForPageLoaded();
+
+    await pmmTest.step('Set a public address that carries a port', async () => {
+      await expect(settingsPage.elements.publicAddressLabel).toContainText('Public address', {
+        timeout: Timeouts.ONE_MINUTE,
+      });
+      await settingsPage.inputs.publicAddress.clear();
+      await settingsPage.inputs.publicAddress.fill('192.168.1.1:8433');
+      await settingsPage.buttons.applyAdvancedChanges.click();
+      await expect(settingsPage.elements.errorAlert).toBeHidden();
+      await expect(settingsPage.inputs.publicAddress).toHaveValue('192.168.1.1:8433', {
+        timeout: Timeouts.THIRTY_SECONDS,
+      });
+    });
+
+    await settingsPage.settleAfterApplyingChanges();
+
+    await pmmTest.step('Change data retention with the public address still set', async () => {
+      await settingsPage.inputs.dataRetention.clear();
+      await settingsPage.inputs.dataRetention.fill('1');
+      await settingsPage.buttons.applyAdvancedChanges.click();
+      await expect(settingsPage.inputs.dataRetention).toHaveValue('1', { timeout: Timeouts.TEN_SECONDS });
+      await expect(settingsPage.elements.errorAlert).toBeHidden();
+      await expect(settingsPage.inputs.dataRetention).toHaveValue('1', {
+        timeout: Timeouts.THIRTY_SECONDS,
+      });
+    });
+  },
+);

--- a/e2e_tests/tests/configuration/settingsPageElements.test.ts
+++ b/e2e_tests/tests/configuration/settingsPageElements.test.ts
@@ -28,14 +28,9 @@ for (const row of dataRetentionRows) {
         await settingsPage.inputs.dataRetention.clear();
         await settingsPage.inputs.dataRetention.fill(row.value);
         await page.keyboard.press('Tab');
-        await settingsPage.inputs.dataRetention.waitFor({
-          state: 'attached',
+        await expect(settingsPage.inputs.dataRetention).toHaveJSProperty('validationMessage', row.message, {
           timeout: Timeouts.THIRTY_SECONDS,
         });
-        expect(
-          await settingsPage.getDataRetentionValidationMessage(),
-          `Data retention "${row.value}" should report its own validation message`,
-        ).toEqual(row.message);
       });
     },
   );
@@ -62,7 +57,12 @@ pmmTest(
 pmmTest(
   'PMM-T85 - Verify SSH Key Section Elements @settings @grafana-pr',
   async ({ api, page, settingsPage }) => {
-    if ((await api.serverApi.getDistributionMethod()) !== 'DISTRIBUTION_METHOD_AMI') return;
+    // TODO: Remove the skip once CI provisions an AMI-distribution PMM Server.
+    // eslint-disable-next-line playwright/no-skipped-test -- the SSH key section renders only on an AMI distribution; a runtime skip reports that honestly where the source's early return reported a pass.
+    pmmTest.skip(
+      (await api.serverApi.getDistributionMethod()) !== 'DISTRIBUTION_METHOD_AMI',
+      'SSH key section renders only on an AMI distribution',
+    );
 
     await page.goto(settingsPage.urls.ssh);
     await settingsPage.waitForPageLoaded();
@@ -120,24 +120,27 @@ pmmTest(
       });
       await settingsPage.inputs.publicAddress.clear();
       await settingsPage.inputs.publicAddress.fill('192.168.1.1:8433');
-      await settingsPage.buttons.applyAdvancedChanges.click();
-      await expect(settingsPage.elements.errorAlert).toBeHidden();
+      await settingsPage.applyAdvancedChanges();
+      await expect(settingsPage.buttons.applyAdvancedChanges).toHaveText('Apply changes', {
+        timeout: Timeouts.THIRTY_SECONDS,
+      });
       await expect(settingsPage.inputs.publicAddress).toHaveValue('192.168.1.1:8433', {
         timeout: Timeouts.THIRTY_SECONDS,
       });
+      await expect(settingsPage.elements.errorAlert).toBeHidden();
     });
-
-    await settingsPage.settleAfterApplyingChanges();
 
     await pmmTest.step('Change data retention with the public address still set', async () => {
       await settingsPage.inputs.dataRetention.clear();
       await settingsPage.inputs.dataRetention.fill('1');
-      await settingsPage.buttons.applyAdvancedChanges.click();
-      await expect(settingsPage.inputs.dataRetention).toHaveValue('1', { timeout: Timeouts.TEN_SECONDS });
-      await expect(settingsPage.elements.errorAlert).toBeHidden();
+      await settingsPage.applyAdvancedChanges();
+      await expect(settingsPage.buttons.applyAdvancedChanges).toHaveText('Apply changes', {
+        timeout: Timeouts.THIRTY_SECONDS,
+      });
       await expect(settingsPage.inputs.dataRetention).toHaveValue('1', {
         timeout: Timeouts.THIRTY_SECONDS,
       });
+      await expect(settingsPage.elements.errorAlert).toBeHidden();
     });
   },
 );

--- a/e2e_tests/tests/configuration/settingsPageElements.test.ts
+++ b/e2e_tests/tests/configuration/settingsPageElements.test.ts
@@ -19,7 +19,7 @@ pmmTest.afterEach(async ({ api }) => {
 
 for (const row of dataRetentionRows) {
   pmmTest(
-    `PMM-T97 - Verify server diagnostics on PMM Settings Page @settings @grafana-pr | {"value":"${row.value}","message":"${row.message}"}`,
+    `PMM-T97 - Verify server diagnostics on PMM Settings Page: data retention "${row.value}" @settings @grafana-pr`,
     async ({ page, settingsPage }) => {
       await page.goto(settingsPage.urls.advanced);
       await settingsPage.waitForPageLoaded();

--- a/e2e_tests/tests/configuration/settingsPageElements.test.ts
+++ b/e2e_tests/tests/configuration/settingsPageElements.test.ts
@@ -57,7 +57,6 @@ pmmTest(
 pmmTest(
   'PMM-T85 - Verify SSH Key Section Elements @settings @grafana-pr',
   async ({ api, page, settingsPage }) => {
-    // TODO: Remove the skip once CI provisions an AMI-distribution PMM Server.
     // eslint-disable-next-line playwright/no-skipped-test -- the SSH key section renders only on an AMI distribution; a runtime skip reports that honestly where the source's early return reported a pass.
     pmmTest.skip(
       (await api.serverApi.getDistributionMethod()) !== 'DISTRIBUTION_METHOD_AMI',


### PR DESCRIPTION
Migrates the PMM Settings page-element tests from CodeceptJS to native Playwright.

## Read this first: the CodeceptJS source is deliberately NOT retired

Every other migration in this series retires its source. **This one does not**, and that is a
deliberate decision, not an oversight.

`@grafana-pr` has **zero consumers in `.github/workflows/`** (`grep -rn 'grafana-pr' .github/`
returns nothing). Its only consumer is `codeceptjs-e2e/package.json:14`:

```json
"e2e:grafana-pr": "npx codeceptjs run -c pr.codecept.js --grep '@grafana-pr'"
```

which is invoked **cross-repository by percona/grafana CI**, and which runs CodeceptJS only. A
Playwright job in this repository cannot restore that gate's coverage.

Retiring `verifyPMMSettingsPageElements_test.js` would drop its **4 `@grafana-pr` scenarios
(6 generated tests)** from the percona/grafana gate — and it would do so **silently**, because
7 other CodeceptJS files still carry `@grafana-pr` (`permissions_test.js`, `sttSettings_test.js`,
`alertRules_test.js`, `explorePage_test.js`, `verifyGrafanaIsGone_test.js`,
`verifyPMMSettingsPageFunctionality_test.js`, `ruleTemplates_test.js`), so the job stays green
while testing less.

**Accepted consequence:** these scenarios now run twice in pmm-qa CI — the existing
`settings_and_cli` CodeceptJS job and the new `settings_playwright` Playwright job. Verified safe:

| | `settings_and_cli` | `settings_playwright` |
| --- | --- | --- |
| Reusable workflow | `runner-e2e-tests-codeceptjs.yml` | `runner-e2e-tests-playwright.yml` |
| Runner / PMM Server | its own | its own |
| Launchable `--test-suite` | `ui-tests-<tags>` | `pw-ui-tests-<report>` |

Separate runners, separate PMM Servers, distinct Launchable suite prefixes — no shared state and
no Launchable session collision. The cost is CI minutes only.

**Condition for retiring it later:** once percona/grafana CI can invoke the Playwright suite. A
header comment on the source records this so the next reader does not have to rediscover it.

## Migration

| | |
| --- | --- |
| Source | `codeceptjs-e2e/tests/configuration/verifyPMMSettingsPageElements_test.js` (kept, see above) |
| Target | `e2e_tests/tests/configuration/settingsPageElements.test.ts` (new file) |

### Scenarios and tags

Every source tag is preserved verbatim. No destination tag was added — all 8 tests already
carry `@settings`.

| Scenario | Tags |
| --- | --- |
| PMM-T97 - Verify server diagnostics on PMM Settings Page (3 data rows) | `@settings @grafana-pr` |
| PMM-T84 - Verify Section Tabs and Metrics Section Elements [critical] | `@settings @grafana-pr` |
| PMM-T85 - Verify SSH Key Section Elements | `@settings @grafana-pr` |
| Verify Advanced Section Elements | `@settings @grafana-pr` |
| PMM-T227 - ... DATA_RETENTION value is set to 2 days (skipped, PMM-5791) | `@settings` |
| PMM-T1866 - Verify public address with a port does not error | `@settings` |

`Data(dataRetentionTable).Scenario` becomes a `for` loop over `dataRetentionRows`; `Before`/`After`
become `beforeEach`/`afterEach`, so the file is self-preconditioning and rerunnable.

### Files queried from the existing graphs

Source graph (`codeceptjs-e2e/graphify-out/`), plus a direct check of the scenarios' injected
fixture names against `codeceptjs-e2e/tests/**/pages/*.js` (CodeceptJS DI is not a static import,
so graphify has no edge for it):

- `codeceptjs-e2e/tests/configuration/pages/pmmSettingsPage.js`
- `settingsAPI` (`restoreSettingsDefaults`, `changeSettings`), `serverApi`, `I.Authorize`

Target graph (`e2e_tests/graphify-out/`):

- `e2e_tests/pages/ha/settings.page.ts` — reused, extended
- `e2e_tests/api/settings.api.ts`, `e2e_tests/api/server.api.ts` — reused, extended
- `e2e_tests/helpers/apiEndpoints.ts`, `e2e_tests/helpers/timeouts.ts`, `e2e_tests/fixtures/pmmTest.ts` — reused as-is

### Supporting changes

- `SettingsApi.restoreSettingsDefaults()` — ports the CodeceptJS helper, including its
  `PMM_ENABLE_TELEMETRY` 400-retry path.
- `SettingsApi.setPublicAddress()` — replaces the source's `changeSettings({ publicAddress: '' })`.
- `ServerApi.getDistributionMethod()` and the `/v1/server/version` endpoint. `/v1/version`, already
  in `apiEndpoints`, does **not** carry `distribution_method`; `/v1/server/version` is the only one
  that does. PMM-T85 short-circuits unless the distribution is AMI, faithfully to the source.
- Settings POM: new `elements` (section labels, error alert, tab content), `inputs.dataRetention`,
  and three wait/read helpers (`waitForPageLoaded`, `settleAfterApplyingChanges`,
  `getDataRetentionValidationMessage`). `urls` and `buttons.toggles` are unchanged.
- Five existing POM `inputs` entries (`high`, `low`, `medium`, `publicAddress`, `sshKey`) had
  **zero consumers** and disagreed with the green CodeceptJS source, so they were corrected in
  place to the ids the PMM UI actually renders rather than shadowed by new entries.

## Setup

`node provisioning/setup.ts` — PMM Server only, `setup_client=false`. Every `@settings` test needs
PMM Server alone, which is why the new job passes `setup_services: '-h'` and no database.

## Validation

| Check | Result |
| --- | --- |
| `npx tsc --noEmit` | pass |
| `npx eslint .` | pass |
| `python support_scripts/generate_readme.py --check` | pass — "README generated sections are up to date" |
| `check-migration-conventions.sh` | pass — "Migration convention checks passed." |

### MCP locator verification

16 locators verified live against the provisioned PMM Server through Playwright MCP, **0 edits
required**. `ssh-key` and `ssh-key-label` could not be verified — they render only on an AMI
distribution, and the environment is Docker. That is the same reason PMM-T85 short-circuits.

### Execution

Both runs against the provisioned server, `--workers=1` (these tests mutate shared server
settings and cannot run in parallel):

```bash
cd e2e_tests
PMM_MIGRATION=1 PMM_UI_URL='https://127.0.0.1/' ADMIN_PASSWORD='admin' \
  npx playwright test tests/configuration/settingsPageElements.test.ts --workers=1
# 7 passed, 1 skipped (40.7s)
```

The new job's grep also newly selects 4 pre-existing tests in `portalRemoval.test.ts` that no
Playwright job selected before, so the full selection was run too:

```bash
PMM_MIGRATION=1 PMM_UI_URL='https://127.0.0.1/' ADMIN_PASSWORD='admin' \
  npx playwright test --grep '@settings' --workers=1
# 11 passed, 1 skipped (35.2s)
```

The single skip is PMM-T227, intentionally skipped pending PMM-5791.

## Workflow coverage

One new job in `.github/workflows/e2e-tests-matrix.yml`:

```yaml
settings_playwright:
  name: Settings UI tests
  uses: ./.github/workflows/runner-e2e-tests-playwright.yml
  ...
  setup_services: '-h'
  pmm_test_flag: '@settings'
```

A **new job** rather than a tag append to an existing `test_execution_playwright` entry, because
`e2e-tests-matrix.yml` has no such matrix entry — its Playwright jobs are individual job blocks.
It mirrors the CodeceptJS `settings_and_cli` job's surface, minus the database that job needs for
`@cli`.

No existing job, grep expression, or `expected_test_jobs` counter was changed.
`expected_test_jobs` lives in `nightly-e2e-tests-matrix.yml`, which this PR does not touch; this
job is in `e2e-tests-matrix.yml` and is not fed by the nightly setup shards.

### Grep verification

`@settings` consumers across `.github/workflows/`, after the edit:

| Job | File | Key | Kind | `setup_services` | Sufficient |
| --- | --- | --- | --- | --- | --- |
| `settings_and_cli` | `e2e-tests-matrix.yml:71` | `tags_for_tests: '@settings\|@cli'` | CodeceptJS | `--database pgsql` | yes (unchanged) |
| `settings_playwright` | `e2e-tests-matrix.yml:210` | `pmm_test_flag: '@settings'` | Playwright | `-h` | yes — server-only is all these tests need |

Forward direction — every migrated scenario is selected:

```
npx playwright test --list --grep '@settings'    -> 12 tests in 2 files (8 migrated + 4 portalRemoval)
npx playwright test --list --grep '@grafana-pr'  -> 6 tests in 1 file
```

Reverse direction — no existing selection changed. This PR adds a job and edits no existing
expression, and the `@settings|@cli` CodeceptJS grep is untouched, so its selection is unchanged
by construction; the source file is still on the `_test.js` discovery glob, so no CodeceptJS job
loses scenarios.

FB suite: none of the migrated scenarios carry an `@fb-*` tag, so `fb-e2e-suite.yml` is unaffected.

## Reviews

Initial gate: attempt 1 `REVIEW_FAILED` (one blocker, B1), attempt 2 `READY_TO_RUN`.
Final gate: attempt 1 `FINAL_REVIEW_PASS`, subject stable (`startRef == endRef`).

## Two advisories a reviewer should know about

Both were raised, judged acceptable, and carried rather than fixed:

1. **The PMM-T97 title suffix is hand-built, not `JSON.stringify`'d.** The title ends with
   `| {"value":"...","message":"..."}` assembled by template literal. It is byte-exact for the
   three current rows, but a future row containing a quote or a backslash would produce a title
   that diverges from real JSON, silently. A `JSON.stringify`-based form is not viable here:
   `perfectionist/sort-objects` reorders the object literal's keys, so the emitted key order
   would no longer match the intended `value`-then-`message` order.
2. **The twin-file pointer is one-directional.** The CodeceptJS source's header names the
   Playwright file, but the Playwright file does not name the source, because a migrated
   `*.test.ts` may carry zero comments.
