### PR TITLE
Wait for the Explore SQL Editor toggle in PMM-T2020

### DIFF
--- a/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
+++ b/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
@@ -54,15 +54,10 @@ Scenario('PMM-T2020 - Verify external clickhouse as datasource on explore page @
   explorePage.selectDataSource('ClickHouse');
   I.waitForVisible(explorePage.elements.sqlEditorButton, 30);
   I.click(explorePage.elements.sqlEditorButton);
-  // The editor is Monaco, seeded with the datasource's skeleton query: clearField/fillField
-  // race that seeding and leave the skeleton and the typed query interleaved.
-  I.waitForVisible(explorePage.elements.sqlBuilderText, 30);
-  I.click(explorePage.elements.sqlBuilder);
-  I.pressKey(['Control', 'a']);
-  I.pressKey('Delete');
-  I.type('SELECT * FROM pmm.metrics LIMIT 10');
+  I.clearField(explorePage.elements.sqlBuilder);
+  I.fillField(explorePage.elements.sqlBuilder, 'SELECT * FROM pmm.metrics LIMIT 10;');
   I.click(explorePage.elements.runQueryButton);
-  I.waitForVisible(explorePage.elements.resultRow, 30);
+  I.waitForVisible(explorePage.elements.resultRow, 10);
   I.dontSee(explorePage.messages.authError);
 });
 

--- a/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
+++ b/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
@@ -52,7 +52,16 @@ Scenario(
 Scenario('PMM-T2020 - Verify external clickhouse as datasource on explore page @docker-configuration', async ({ I, explorePage }) => {
   I.amOnPage(basePmmUrl + explorePage.url);
   explorePage.selectDataSource('ClickHouse');
-  explorePage.runSqlQuery('SELECT * FROM pmm.metrics LIMIT 10');
+  I.waitForVisible(explorePage.elements.sqlEditorButton, 30);
+  I.click(explorePage.elements.sqlEditorButton);
+  // The editor is Monaco, seeded with the datasource's skeleton query: clearField/fillField
+  // race that seeding and leave the skeleton and the typed query interleaved.
+  I.waitForVisible(explorePage.elements.sqlBuilderText, 30);
+  I.click(explorePage.elements.sqlBuilder);
+  I.pressKey(['Control', 'a']);
+  I.pressKey('Delete');
+  I.type('SELECT * FROM pmm.metrics LIMIT 10');
+  I.click(explorePage.elements.runQueryButton);
   I.waitForVisible(explorePage.elements.resultRow, 30);
   I.dontSee(explorePage.messages.authError);
 });

--- a/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
+++ b/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
@@ -52,7 +52,7 @@ Scenario(
 Scenario('PMM-T2020 - Verify external clickhouse as datasource on explore page @docker-configuration', async ({ I, explorePage }) => {
   I.amOnPage(basePmmUrl + explorePage.url);
   explorePage.selectDataSource('ClickHouse');
-  I.click(explorePage.elements.sqlEditorButton);
+  explorePage.openSqlEditor();
   I.clearField(explorePage.elements.sqlBuilder);
   I.fillField(explorePage.elements.sqlBuilder, 'SELECT * FROM pmm.metrics LIMIT 10;');
   I.click(explorePage.elements.runQueryButton);

--- a/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
+++ b/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
@@ -52,11 +52,8 @@ Scenario(
 Scenario('PMM-T2020 - Verify external clickhouse as datasource on explore page @docker-configuration', async ({ I, explorePage }) => {
   I.amOnPage(basePmmUrl + explorePage.url);
   explorePage.selectDataSource('ClickHouse');
-  explorePage.openSqlEditor();
-  I.clearField(explorePage.elements.sqlBuilder);
-  I.fillField(explorePage.elements.sqlBuilder, 'SELECT * FROM pmm.metrics LIMIT 10;');
-  I.click(explorePage.elements.runQueryButton);
-  I.waitForVisible(explorePage.elements.resultRow, 10);
+  explorePage.runSqlQuery('SELECT * FROM pmm.metrics LIMIT 10');
+  I.waitForVisible(explorePage.elements.resultRow, 30);
   I.dontSee(explorePage.messages.authError);
 });
 

--- a/codeceptjs-e2e/tests/pages/explorePage.js
+++ b/codeceptjs-e2e/tests/pages/explorePage.js
@@ -8,7 +8,6 @@ class ExplorePage {
       dataSourcePicker: locate('//input[@id="data-source-picker"]'),
       sqlEditorButton: locate('//label[text()="SQL Editor"]//parent::*[@data-testid="data-testid radio-button"]'),
       sqlBuilder: locate('//textarea'),
-      sqlBuilderText: locate('//div[contains(@class, "view-line")]//span[normalize-space(text()) != ""]'),
       runQueryButton: locate('//span[text()="Run Query"]//parent::button'),
       resultRow: locate('//div[@role="row"]'),
 

--- a/codeceptjs-e2e/tests/pages/explorePage.js
+++ b/codeceptjs-e2e/tests/pages/explorePage.js
@@ -28,24 +28,6 @@ class ExplorePage {
     I.fillField(this.elements.dataSourcePicker, dataSourceName);
     I.pressKey('Enter');
   }
-
-  // The query editor is mounted only after the picked datasource resolves, so
-  // neither the mode toggle nor the editor exists yet when selectDataSource returns.
-  // It is a Monaco editor seeded with the datasource's skeleton query, and
-  // clearField/fillField race that seeding: clearing an editor Monaco has not
-  // populated yet leaves the skeleton and the typed query interleaved, which
-  // ClickHouse then rejects as a multi-statement. Wait for the skeleton, then
-  // replace it from inside the focused editor.
-  runSqlQuery(query) {
-    I.waitForVisible(this.elements.sqlEditorButton, 30);
-    I.click(this.elements.sqlEditorButton);
-    I.waitForVisible(this.elements.sqlBuilderText, 30);
-    I.click(this.elements.sqlBuilder);
-    I.pressKey(['Control', 'a']);
-    I.pressKey('Delete');
-    I.type(query);
-    I.click(this.elements.runQueryButton);
-  }
 }
 
 module.exports = new ExplorePage();

--- a/codeceptjs-e2e/tests/pages/explorePage.js
+++ b/codeceptjs-e2e/tests/pages/explorePage.js
@@ -8,6 +8,7 @@ class ExplorePage {
       dataSourcePicker: locate('//input[@id="data-source-picker"]'),
       sqlEditorButton: locate('//label[text()="SQL Editor"]//parent::*[@data-testid="data-testid radio-button"]'),
       sqlBuilder: locate('//textarea'),
+      sqlBuilderText: locate('//div[contains(@class, "view-line")]//span[normalize-space(text()) != ""]'),
       runQueryButton: locate('//span[text()="Run Query"]//parent::button'),
       resultRow: locate('//div[@role="row"]'),
 
@@ -30,10 +31,20 @@ class ExplorePage {
 
   // The query editor is mounted only after the picked datasource resolves, so
   // neither the mode toggle nor the editor exists yet when selectDataSource returns.
-  openSqlEditor() {
+  // It is a Monaco editor seeded with the datasource's skeleton query, and
+  // clearField/fillField race that seeding: clearing an editor Monaco has not
+  // populated yet leaves the skeleton and the typed query interleaved, which
+  // ClickHouse then rejects as a multi-statement. Wait for the skeleton, then
+  // replace it from inside the focused editor.
+  runSqlQuery(query) {
     I.waitForVisible(this.elements.sqlEditorButton, 30);
     I.click(this.elements.sqlEditorButton);
-    I.waitForElement(this.elements.sqlBuilder, 30);
+    I.waitForVisible(this.elements.sqlBuilderText, 30);
+    I.click(this.elements.sqlBuilder);
+    I.pressKey(['Control', 'a']);
+    I.pressKey('Delete');
+    I.type(query);
+    I.click(this.elements.runQueryButton);
   }
 }
 

--- a/codeceptjs-e2e/tests/pages/explorePage.js
+++ b/codeceptjs-e2e/tests/pages/explorePage.js
@@ -27,6 +27,14 @@ class ExplorePage {
     I.fillField(this.elements.dataSourcePicker, dataSourceName);
     I.pressKey('Enter');
   }
+
+  // The query editor is mounted only after the picked datasource resolves, so
+  // neither the mode toggle nor the editor exists yet when selectDataSource returns.
+  openSqlEditor() {
+    I.waitForVisible(this.elements.sqlEditorButton, 30);
+    I.click(this.elements.sqlEditorButton);
+    I.waitForElement(this.elements.sqlBuilder, 30);
+  }
 }
 
 module.exports = new ExplorePage();


### PR DESCRIPTION
## Failures fixed (investigator)

- source: scheduled CI run https://github.com/percona/pmm-qa/actions/runs/33829234874 (`E2E tests Matrix` on `main`, job `FB E2E tests / Docker configuration tests / e2e tests: @docker-configuration`)
- tests:
  - `codeceptjs-e2e/tests/QAN/externalClickhouse_test.js:52` / `@docker-configuration` — PMM-T2020 Verify external clickhouse as datasource on explore page

## What failed

The only red job of 34 (Launchable gate: `1 actionable, 0 quarantined`; 13 passed, 1 failed, 2 skipped):

```
Clickable element "//label[text()="SQL Editor"]//parent::*[@data-testid="data-testid radio-button"]"
  was not found by text|CSS|XPath
    at assertElementExists (node_modules/codeceptjs/lib/helper/Playwright.js:4081:11)
    at Playwright.proceedClick (node_modules/codeceptjs/lib/helper/Playwright.js:3835:5)
```

Worth noting for whoever reads the run: the job's own **test step reports success**. It failed
at `Record launchable test results`, where `launchable gate` turns the recorded failure into a
non-zero exit. Reading step conclusions alone hides which test actually failed.

## Root cause — the test, not the product

`I.click` is a single-shot lookup. CodeceptJS's Playwright helper resolves it through
`proceedClick` → `findClickable` → `assertElementExists`, which throws `ElementNotFound` on an
empty match instead of retrying, so the only slack before the click was the config's
`waitForAction: 500` (`pr.codecept.js:28`). The Explore query editor is mounted only after the
picked datasource resolves, so on a loaded runner the toggle simply is not in the DOM 500 ms
after `pressKey('Enter')`.

The element itself is fine on current `main` + `3-dev-latest` — `RadioButton.tsx` on
percona/grafana still renders `data-testid="data-testid radio-button"` on the visible flex
container wrapping the `opacity: 0` input and its `<label>`, and the locator matches it. This is
a race, not a UI change.

## The fix

One line — wait for the toggle before clicking it:

```js
I.waitForVisible(explorePage.elements.sqlEditorButton, 30);
```

## Reproduction and verification

Throwaway Linode VM at `b6073c2` (the commit CI ran), `perconalab/pmm-server:3-dev-latest`,
`docker-compose-clickhouse.yml`, `codeceptjs run --grep 'PMM-T2020'`. To make a race that fires
about once in ten nightlies fire on demand, runs were repeated with 12 busy-loop shell processes
saturating the box's 6 vCPU (one user, one browser, one worker throughout — the load is CPU
contention, not concurrency):

| build | idle | under load |
|---|---|---|
| `main` (b6073c2) | 3 of 3 passed | **2 of 3 failed** — `ElementNotFound` on the toggle |
| this branch | — | **4 of 4 got past the toggle** |

The two `main` failures are byte-identical to CI's, down to the step trace. Re-running the failed
CI job (attempt 2) came back green, which agrees: intermittent and load-dependent.

`npx eslint` clean on the changed file.

What this does **not** prove: that load is a crude proxy — ~200% CPU oversubscription, where a
real runner has 4 vCPU and is contended on disk and network as well. Good enough to provoke the
race and confirm the wait removes it; not a calibrated model of CI. The failure is probabilistic,
so the lasting confirmation is the next few scheduled `E2E tests Matrix` runs staying green here.

## Known latent flake, deliberately not fixed here

Once the toggle wait let the test run further, the same artificial load exposed a second, older
problem: `clearField` can empty the SQL editor before Monaco has seeded its skeleton query, and
`fillField` then types in front of the skeleton that arrives afterwards, leaving:

```
SELECT * FROM pmm.metrics LIMIT 10;LECT FROM LIMIT 1000
error querying the database: code: 62, message: Syntax error (Multi-statements are not allowed)
```

That ordering hazard is real, but it has never fired in CI — the red run died at the click before
reaching it, and the ten scheduled runs before that passed through `clearField`/`fillField`. An
earlier revision of this PR rewrote the step to select-all-and-type; that has been dropped as
scope the failure did not ask for, and because it traded two documented CodeceptJS helpers for a
keyboard sequence plus a dependency on Monaco's internal DOM. Recorded here so the next person to
see it has the diagnosis rather than the mystery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BarjDRLsjTSWrg6pGQg8S9