### PR TITLE
PMM-7 Fix alerts upgrade test for 3.8.0 alert-status page

### DIFF
--- a/e2e_tests/pages/alerts/alertStatus.page.ts
+++ b/e2e_tests/pages/alerts/alertStatus.page.ts
@@ -1,11 +1,11 @@
 import BasePage from '../base.page';
 
 export default class AlertStatusPage extends BasePage {
-  url = 'pmm-ui/alerting/status';
+  url = 'pmm-ui/graph/alerting/alerts';
   builders = {
     firingAlert: (alertName: string) =>
-      this.page.locator(
-        `//td[text()="${alertName}"]/parent::tr//td[position()="2"]//span[contains(text(), "Firing")]`,
+      this.grafanaIframe().locator(
+        `//tr[.//a[normalize-space(text())="${alertName}"]]//td[position()=2]//span[contains(text(), "active")]`,
       ),
   };
   buttons = {};


### PR DESCRIPTION
## What

Fixes the failing `PMM-T577` alerts upgrade test (`e2e_tests/tests/upgrade/alerts.test.ts`) on PMM 3.8.0 by pointing `AlertStatusPage` at the correct 3.8.0 "Fired alerts" page.

## Why

On 3.8.0 the native PMM "Fired alerts" page (`pmm-ui/alerting/status`, used by 3.9.0+) does not exist yet — that route renders "Not found". Alerting is still served through the embedded Grafana UI. The test created the alert rule fine and it fired correctly (verified against a live server), but the assertion looked at a page that isn't present in 3.8.0, so the firing alert was never found.

## Change

`e2e_tests/pages/alerts/alertStatus.page.ts`:
- `url`: `pmm-ui/alerting/status` → `pmm-ui/graph/alerting/alerts` (the 3.8.0 Grafana "Fired alerts" page)
- `firingAlert` builder now matches the firing row inside the Grafana iframe, where in 3.8.0 the rule name is a link and the state cell reads `active` instead of `Firing`.

## Verification

Ran the test against a live `percona/pmm-server:3.8.0` container:
- `POST /v1/alerting/rules` with the test body returns 200; the Grafana rule reaches `firing` and shows `active` in Alertmanager.
- `PMM-T577` passes end to end on a fresh container (create rule → wait for firing → see it on the Fired alerts page), well within the 2-minute timeout.
- `eslint` and `tsc` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbQUoHuD9vSo3qk7qm3V2g

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbQUoHuD9vSo3qk7qm3V2g)_