### PR TITLE
PMM-7 Point upgrade alerts check at Grafana fired-alerts for 3.7.1

### DIFF
--- a/e2e_tests/pages/alerts/alertStatus.page.ts
+++ b/e2e_tests/pages/alerts/alertStatus.page.ts
@@ -1,11 +1,14 @@
 import BasePage from '../base.page';
 
 export default class AlertStatusPage extends BasePage {
-  url = 'pmm-ui/alerting/status';
+  // PMM 3.7.1 has no native "Fired alerts" page (pmm-ui/alerting/status renders
+  // an empty "Not found" state). Fired alerts are shown by the Grafana alerting
+  // app, embedded in the Grafana iframe, where the instance state reads "Active".
+  url = 'pmm-ui/graph/alerting/alerts';
   builders = {
     firingAlert: (alertName: string) =>
-      this.page.locator(
-        `//td[text()="${alertName}"]/parent::tr//td[position()="2"]//span[contains(text(), "Firing")]`,
+      this.grafanaIframe().locator(
+        `//tr[td[1][contains(normalize-space(.), "${alertName}")]]/td[2][contains(translate(normalize-space(.), 'ACTIVE', 'active'), "active")]`,
       ),
   };
   buttons = {};


### PR DESCRIPTION
## Summary

Follow-up to #1305. After the folder fix, `PMM-T577` still failed on PMM 3.7.1 — this time on the UI assertion:

```
expect(locator).toBeVisible() failed
Locator: //td[text()="Alerting Upgrade Rule"]/parent::tr//td[position()="2"]//span[contains(text(), "Firing")]
element(s) not found (timeout 120000ms)
```

The rule was firing, but the assertion looked at the wrong page/markup for 3.7.1.

## Root cause (verified on a live server)

On `percona/pmm-server:3.7.1`:

- The page the test opened, **`pmm-ui/alerting/status`**, is a PMM-native "Fired alerts" view that renders an empty **"Not found"** state — it never lists the alert (makes no alerts request at all).
- Fired alerts are actually shown by the **Grafana alerting app**, embedded in the **`#grafana-iframe`**, at **`pmm-ui/graph/alerting/alerts`**. There the alert appears in a table `Triggered by rule | State | Summary | …`, and the instance **State reads "Active"**, not "Firing".

## Fix

`AlertStatusPage` now:
- points `url` at `pmm-ui/graph/alerting/alerts`;
- matches the alert row **inside the Grafana iframe** (`this.grafanaIframe()`), asserting the State cell (column 2) is `Active` (case-insensitive).

## Verification

Ran the real Playwright spec against a live `percona/pmm-server:3.7.1` (Chromium):

```
✓ 1 [chromium] › tests/upgrade/alerts.test.ts:13:10 › PMM-T577 - Verify user is able to
  create and see firing alerts before upgrade @pre-upgrade (6.6s)
1 passed
```

`eslint` clean; `tsc` introduces no new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9tsueFKSWE58LW47S7WWt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9tsueFKSWE58LW47S7WWt)_