### PR TITLE
Add API verification to disable collectors tests

### DIFF
--- a/e2e_tests/api/inventory.api.ts
+++ b/e2e_tests/api/inventory.api.ts
@@ -6,6 +6,15 @@ import apiEndpoints from '@helpers/apiEndpoints';
 export default class InventoryApi {
   constructor(private request: APIRequestContext) {}
 
+  getAgentById = async (agentId: string) => {
+    const { services } = await this.getServices();
+    const agent = services.flatMap((service) => service.agents).find((agent) => agent.agent_id === agentId);
+
+    if (!agent) throw new Error(`Agent with id ${agentId} is not present`);
+
+    return agent;
+  };
+
   getServiceDetailsByPartialName = async (partialServiceName: string): Promise<GetService> => {
     const services = await this.getServices();
     const service = services.services.find((service: GetService) =>

--- a/e2e_tests/interfaces/inventory.ts
+++ b/e2e_tests/interfaces/inventory.ts
@@ -54,7 +54,7 @@ export interface GetService {
         additionalProp3: string;
       };
       disabled: true;
-      disabled_collectors: [string];
+      disabled_collectors: string[];
       listen_port: 0;
       log_level: string;
       max_query_length: 0;

--- a/e2e_tests/tests/cli/mysql/mysqlPerfschemaChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/mysql/mysqlPerfschemaChangeAgent.test.ts
@@ -223,14 +223,26 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
       .outContains('Running');
   });
 
-  pmmTest('PMM-T1009 - Verify Change agent disable collectors @ps-integration', async ({ cliHelper }) => {
-    await cliHelper
-      .execSilent(
-        `docker exec ${containerName} pmm-admin inventory change agent mysqld-exporter ${mysqldExporterId} --disable-collectors=stat_statements,locks`,
-      )
-      .assertSuccess()
-      .outContains('- updated disabled collectors: [stat_statements locks]');
-  });
+  pmmTest(
+    'PMM-T1009 - Verify Change agent disable collectors @ps-integration',
+    async ({ api, cliHelper }) => {
+      const collectorsToDisable = ['stat_statements', 'locks'];
+
+      await cliHelper
+        .execSilent(
+          `docker exec ${containerName} pmm-admin inventory change agent mysqld-exporter ${mysqldExporterId} --disable-collectors=${collectorsToDisable.join(',')}`,
+        )
+        .assertSuccess()
+        .outContains(`- updated disabled collectors: [${collectorsToDisable.join(' ')}]`);
+
+      const agent = await api.inventoryApi.getAgentById(mysqldExporterId);
+
+      expect(
+        agent.disabled_collectors,
+        'Disabled collectors were not persisted on the mysqld_exporter agent',
+      ).toEqual(collectorsToDisable);
+    },
+  );
 
   pmmTest(
     'PMM-T1010 - Verify Change agent tls @ps-integration',

--- a/e2e_tests/tests/cli/mysql/mysqlSlowlogChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/mysql/mysqlSlowlogChangeAgent.test.ts
@@ -226,14 +226,26 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
       .outContains('Running');
   });
 
-  pmmTest('PMM-T9993 - Verify Change agent disable collectors @ps-integration', async ({ cliHelper }) => {
-    await cliHelper
-      .execSilent(
-        `docker exec ${containerName} pmm-admin inventory change agent mysqld-exporter ${mysqldExporterId} --disable-collectors=stat_statements,locks`,
-      )
-      .assertSuccess()
-      .outContains('- updated disabled collectors: [stat_statements locks]');
-  });
+  pmmTest(
+    'PMM-T9993 - Verify Change agent disable collectors @ps-integration',
+    async ({ api, cliHelper }) => {
+      const collectorsToDisable = ['stat_statements', 'locks'];
+
+      await cliHelper
+        .execSilent(
+          `docker exec ${containerName} pmm-admin inventory change agent mysqld-exporter ${mysqldExporterId} --disable-collectors=${collectorsToDisable.join(',')}`,
+        )
+        .assertSuccess()
+        .outContains(`- updated disabled collectors: [${collectorsToDisable.join(' ')}]`);
+
+      const agent = await api.inventoryApi.getAgentById(mysqldExporterId);
+
+      expect(
+        agent.disabled_collectors,
+        'Disabled collectors were not persisted on the mysqld_exporter agent',
+      ).toEqual(collectorsToDisable);
+    },
+  );
 
   pmmTest(
     'PMM-T9994 - Verify Change agent tls @ps-slowlog-integration',


### PR DESCRIPTION
Enhance two e2e tests to verify that disabled collectors are persisted in the agent configuration via API, not just reflected in CLI output.

**Changes:**
- Modified `PMM-T1009` and `PMM-T9993` tests to extract collectors into a variable for reusability
- Added API calls to verify disabled collectors are persisted on the mysqld_exporter agent after CLI command execution
- Implemented `getAgentById()` helper method in InventoryApi to retrieve agent details by ID
- Fixed TypeScript type annotation for `disabled_collectors` from tuple `[string]` to array `string[]`

**Details:**
The tests now perform end-to-end validation by confirming that the `pmm-admin inventory change agent` command not only produces the expected CLI output but also correctly persists the configuration changes in the backend. This prevents regressions where CLI output might be correct but the actual agent state is not updated.

https://claude.ai/code/session_01WKdRHb6xgNz5Kzgswvg873