### PR TITLE
Add skip-connection-check change agent test

### DIFF
--- a/e2e_tests/tests/cli/mysql/mysqlPerfschemaChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/mysql/mysqlPerfschemaChangeAgent.test.ts
@@ -245,6 +245,28 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
   );
 
   pmmTest(
+    'PMM-T1013 - Verify Change agent skip connection check @ps-integration',
+    async ({ cliHelper, grafanaHelper, page, servicesPage }) => {
+      await cliHelper
+        .execSilent(
+          `docker exec ${containerName} pmm-admin inventory change agent mysqld-exporter ${mysqldExporterId} --password=invalid_skip_check_password --skip-connection-check`,
+        )
+        .assertSuccess()
+        .outContains('MySQL Exporter agent configuration updated.');
+
+      await cliHelper
+        .execSilent(
+          `docker exec ${containerName} pmm-admin inventory change agent mysqld-exporter ${mysqldExporterId} --username=${newUsername} --password=${newPassword}`,
+        )
+        .assertSuccess();
+
+      await grafanaHelper.authorize();
+      await page.goto(servicesPage.url);
+      await servicesPage.waitForServiceStatus(serviceName, 'Up', Timeouts.TWO_MINUTES);
+    },
+  );
+
+  pmmTest(
     'PMM-T1010 - Verify Change agent tls @ps-integration',
     async ({ cliHelper, grafanaHelper, page, servicesPage }) => {
       const confPath = `/etc/mysql/mysql.conf.d/mysqld.cnf`;

--- a/e2e_tests/tests/cli/mysql/mysqlSlowlogChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/mysql/mysqlSlowlogChangeAgent.test.ts
@@ -259,6 +259,28 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
   );
 
   pmmTest(
+    'PMM-T9998 - Verify Change agent skip connection check @ps-slowlog-integration',
+    async ({ cliHelper, grafanaHelper, page, servicesPage }) => {
+      await cliHelper
+        .execSilent(
+          `docker exec ${containerName} pmm-admin inventory change agent mysqld-exporter ${mysqldExporterId} --password=invalid_skip_check_password --skip-connection-check`,
+        )
+        .assertSuccess()
+        .outContains('MySQL Exporter agent configuration updated.');
+
+      await cliHelper
+        .execSilent(
+          `docker exec ${containerName} pmm-admin inventory change agent mysqld-exporter ${mysqldExporterId} --username=${newUsername} --password=${newPassword}`,
+        )
+        .assertSuccess();
+
+      await grafanaHelper.authorize();
+      await page.goto(servicesPage.url);
+      await servicesPage.waitForServiceStatus(serviceName, 'Up', Timeouts.TWO_MINUTES);
+    },
+  );
+
+  pmmTest(
     'PMM-T9994 - Verify Change agent tls @ps-slowlog-integration',
     async ({ cliHelper, grafanaHelper, page, servicesPage }) => {
       const confPath = `/etc/mysql/mysql.conf.d/mysqld.cnf`;


### PR DESCRIPTION
Cover pmm-admin inventory change agent mysqld-exporter --skip-connection-check for both the perfschema and slowlog suites.

The flag is a request-time behavior, not a persisted field, so the test changes the exporter password to an invalid value with --skip-connection-check and asserts the change is accepted (without the flag the connection check rejects it, as the username/password test shows), then restores working credentials and waits for the service to recover.


Claude-Session: https://claude.ai/code/session_01WKdRHb6xgNz5Kzgswvg873