### PR TITLE
Let an @claude run answer in threads and read a linked PR

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,5 +45,13 @@ jobs:
             actions: read
           # No `prompt`: an empty one is what keeps this workflow answering
           # @claude mentions instead of running unprompted.
+          #
+          # A mention run otherwise gets read-only file tools, the CI tools and its one
+          # sticky comment: nothing that answers inside a review thread or reads a PR in
+          # another repo. A second `--allowedTools` adds to that set instead of replacing
+          # it. A thread reply (`gh api .../comments/{id}/replies`) and a resolve (`gh api
+          # graphql`, `resolveReviewThread`) run on the action's app token, which is scoped
+          # to this repo -- a linked PR elsewhere is only reachable through `WebFetch`.
           claude_args: |
             --model claude-opus-5
+            --allowedTools "WebFetch,Bash(gh api:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
Fixes what the `@claude` run reported in https://github.com/percona/pmm-qa/pull/1330#issuecomment-5542969626, where it was asked to read [Percona-Lab/jenkins-pipelines#4380](https://github.com/Percona-Lab/jenkins-pipelines/pull/4380), then answer inside the existing review threads on #1330 and resolve the ones it had got wrong — and stopped, having produced nothing, because the run had neither capability.

## What was actually missing

Confirmed from that run's own log ([job 101083544509](https://github.com/percona/pmm-qa/actions/runs/33891362220/job/101083544509)), which prints the tool set it was given:

```
"allowedTools": [ Glob, Grep, LS, Read,
                  mcp__github_comment__update_claude_comment,
                  mcp__github_ci__get_ci_status,
                  mcp__github_ci__get_workflow_run_details,
                  mcp__github_ci__download_job_log,
                  Bash(git add:*), Bash(git commit:*), Bash(git-push.sh:*), Bash(git rm:*) ]
...
"permission_denials_count": 13
```

That is the action's stock tag-mode set (`src/modes/tag/index.ts`), and `claude.yml` added nothing to it. So:

- **no cross-repo read** — no `WebFetch`, no `gh`, and the run's app token is scoped to `percona/pmm-qa`, so #4380 was unreachable by every route it tried;
- **no thread reply and no resolve** — neither `POST /pulls/{n}/comments/{id}/replies` nor the `resolveReviewThread` GraphQL mutation has a built-in tool, so the only thing the run could write was its one sticky comment, i.e. exactly the new top-level thread it was told not to open.

## Change

One `--allowedTools` line in `claude_args`. Verified against the deployed `@v1` ref that multiple `--allowedTools` occurrences **accumulate** rather than overwrite (`base-action/src/parse-sdk-options.ts`), so the tag-mode tools above are kept and these are added:

| Tool | Unblocks |
|---|---|
| `Bash(gh api:*)` | thread replies (`.../comments/{id}/replies`) and resolves (`gh api graphql`). `run.ts` sets `GH_TOKEN`/`GITHUB_TOKEN` to the action's app token, so both still post as `claude[bot]`. |
| `Bash(gh pr view/diff/comment:*)` | read the PR under discussion; `gh pr comment --edit-last` updates its own summary instead of stacking another. |
| `WebFetch` | read a linked PR in another repo — the app token cannot, being scoped to this one. |
| `mcp__github_inline_comment__create_inline_comment` | a genuinely new finding lands as a thread on the line, not as another top-level comment. Tag mode merges user-supplied `mcp__github_*` tools into its MCP config, so the server actually starts. |

`claude-code-review.yml` already grants the `gh` subset; this brings the mention workflow in line with it.

## Scope and tradeoffs

- **Cross-repo reads are public-only.** `WebFetch` covers `Percona-Lab/jenkins-pipelines` (public) and any other public Percona repo. A *private* cross-repo read would still need a PAT, which would mean repointing `gh` off the app token and losing `claude[bot]` attribution on every write — not worth it for this, so it is deliberately not done here.
- **`Bash(gh api:*)` is broad**: any API call the run's own token permits (`contents: write`, `pull-requests: write`, `issues: write` on this repo). The run already had `git push` and edit rights over the same repo, and the review workflow already carries this grant, so the blast radius is unchanged in practice.
- **`WebFetch` adds outbound reads** to a job that holds an app token. Tag mode only runs for actors with write permission, which is the mitigation the action itself relies on.

## Verification

`yamllint` and `actionlint` clean on the changed file. The capability itself can only be exercised once merged — `@claude`, on a PR, asking for a thread reply plus a linked-PR read is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014M7oeCBD9NcXCfFoRFGps4

---
_Generated by [Claude Code](https://claude.ai/code/session_014M7oeCBD9NcXCfFoRFGps4)_