### PR TITLE
Harden performance load-test scripts + add teardown

### DIFF
--- a/performance/.gitignore
+++ b/performance/.gitignore
@@ -1,0 +1,3 @@
+# Generated at runtime by prepare_ansible_client_inventory.sh -- carries live
+# client IPs and a local key path, so it must never be committed.
+inventory_client_container2

--- a/performance/README.md
+++ b/performance/README.md
@@ -10,7 +10,7 @@ Root password and SSH keys are read from the environment. Do not hardcode them:
 
 | Variable | Used by | Purpose |
 | --- | --- | --- |
-| `LINODE_ROOT_PASS` | create | root password for provisioned VMs |
+| `LINODE_ROOT_PASS` | create | root password for provisioned VMs (optional; random per run if unset — access is by SSH key) |
 | `PMM_PERF_SSH_PUBKEY` | create | SSH public key authorized on the VMs |
 | `PMM_SERVER_PASSWORD` | create | PMM server admin password |
 | `PMM_PERF_SSH_KEY` | inventory | local private key path (default `~/.ssh/id_rsa`) |

--- a/performance/README.md
+++ b/performance/README.md
@@ -1,8 +1,8 @@
 # PMM client performance / load-test harness
 
 Ad-hoc scripts to spin up many PMM client VMs on Linode, register them against a
-PMM server, build an Ansible inventory of them, and upgrade the PMM client across
-them. Used for scale/load testing; **not** wired into CI.
+PMM server, build an Ansible inventory of one batch, and upgrade the PMM client
+across it. Used for scale/load testing; **not** wired into CI.
 
 ## Secrets — never commit them
 
@@ -17,34 +17,40 @@ Root password and SSH keys are read from the environment. Do not hardcode them:
 
 `linode-cli` must be configured with its own API token (`linode-cli configure`).
 
-## Provision
+## Provision a batch
 
 ```bash
 export LINODE_ROOT_PASS=...          # not in git
 export PMM_PERF_SSH_PUBKEY="ssh-rsa AAAA... you@host"
 export PMM_SERVER_PASSWORD=...
+export PERF_RUN_ID=myrun-01           # optional; defaults to a UTC timestamp
 ./linode_stackScript_load_pmm3.sh <pmm_server_host> <client_version> <instances> <metrics_mode> <dbtype>
 #   dbtype: mysql | postgresql | mongodb
 ```
 
-Every VM is tagged `pmm-qa-ephemeral`, `pmm-qa-perf`, and
-`pmm-qa-perf-run:<PERF_RUN_ID>`.
+Each VM is labelled `sp_fb_<i>_<dbtype>_<metrics_mode>_<PERF_RUN_ID>` and tagged
+`pmm-qa-ephemeral`, `pmm-qa-perf`, and `pmm-qa-perf-run:<PERF_RUN_ID>`. The
+create step prints the exact `PERF_RUN_ID` and the inventory/teardown commands
+for that batch.
 
-## Tear down (do this — the VMs bill until deleted)
-
-```bash
-./teardown_perf_linodes.sh --dry-run   # preview
-./teardown_perf_linodes.sh             # delete every pmm-qa-ephemeral instance
-PMM_PERF_TAG=pmm-qa-perf-run:<id> ./teardown_perf_linodes.sh   # just one batch
-```
-
-## Inventory + upgrade
+## Inventory + upgrade (one batch)
 
 ```bash
-./prepare_ansible_client_inventory.sh          # writes inventory_client_container2 (git-ignored)
-./start_upgrade_v3.sh <version> <install_repo>  # runs upgrade_client.yml
+PERF_RUN_ID=myrun-01 ./prepare_ansible_client_inventory.sh   # selects that batch by tag; writes inventory_client_container2 (git-ignored)
+./start_upgrade_v3.sh <version> <install_repo>               # runs upgrade_client.yml
 ```
 
 `upgrade_client.yml` copies `upgrade_all_v3.sh` to each host and runs it as a
 monitored async job, upgrading the PMM client in every `*client_container*`
 Docker container and failing if the upgrade does not complete.
+
+## Tear down (do this — the VMs bill until deleted)
+
+```bash
+./teardown_perf_linodes.sh --dry-run                                # preview all pmm-qa-perf instances
+PMM_PERF_TAG=pmm-qa-perf-run:myrun-01 ./teardown_perf_linodes.sh    # delete just one batch
+./teardown_perf_linodes.sh                                          # delete every pmm-qa-perf instance
+```
+
+Teardown deletes only instances tagged `pmm-qa-perf` (this harness's own tag),
+never the account-wide `pmm-qa-ephemeral`.

--- a/performance/README.md
+++ b/performance/README.md
@@ -14,6 +14,7 @@ Root password and SSH keys are read from the environment. Do not hardcode them:
 | `PMM_PERF_SSH_PUBKEY` | create | SSH public key authorized on the VMs |
 | `PMM_SERVER_PASSWORD` | create | PMM server admin password |
 | `PMM_PERF_SSH_KEY` | inventory | local private key path (default `~/.ssh/id_rsa`) |
+| `PMM_PERF_TAG` | teardown | tag to delete (default `pmm-qa-perf`); only `pmm-qa-perf` or `pmm-qa-perf-run:<id>` accepted |
 
 `linode-cli` must be configured with its own API token (`linode-cli configure`).
 
@@ -29,9 +30,10 @@ export PERF_RUN_ID=myrun-01           # optional; defaults to a UTC timestamp
 ```
 
 Each VM is labelled `sp_fb_<i>_<dbtype>_<metrics_mode>_<PERF_RUN_ID>` and tagged
-`pmm-qa-ephemeral`, `pmm-qa-perf`, and `pmm-qa-perf-run:<PERF_RUN_ID>`. The
-create step prints the exact `PERF_RUN_ID` and the inventory/teardown commands
-for that batch.
+`pmm-qa-perf` and `pmm-qa-perf-run:<PERF_RUN_ID>`. The create step prints the
+`PERF_RUN_ID` and the inventory/teardown commands up front, and tears the batch
+down automatically if provisioning fails partway (nothing reaps stray instances,
+so a partial batch would otherwise bill).
 
 ## Inventory + upgrade (one batch)
 

--- a/performance/README.md
+++ b/performance/README.md
@@ -44,6 +44,13 @@ PERF_RUN_ID=myrun-01 ./prepare_ansible_client_inventory.sh   # selects that batc
 monitored async job, upgrading the PMM client in every `*client_container*`
 Docker container and failing if the upgrade does not complete.
 
+**Host-key precondition:** the inventory is freshly-provisioned VMs with no
+`known_hosts` entries, and `start_upgrade_v3.sh` keeps `ANSIBLE_HOST_KEY_CHECKING`
+on by default, so Ansible will refuse the first connection. Enroll each host's
+key from a trusted source (e.g. the fingerprint Linode reports for the instance)
+before running the upgrade. For throwaway hosts you already trust you may instead
+run with `ANSIBLE_HOST_KEY_CHECKING=False`, accepting the MITM risk on that run.
+
 ## Tear down (do this — the VMs bill until deleted)
 
 ```bash

--- a/performance/README.md
+++ b/performance/README.md
@@ -1,0 +1,50 @@
+# PMM client performance / load-test harness
+
+Ad-hoc scripts to spin up many PMM client VMs on Linode, register them against a
+PMM server, build an Ansible inventory of them, and upgrade the PMM client across
+them. Used for scale/load testing; **not** wired into CI.
+
+## Secrets — never commit them
+
+Root password and SSH keys are read from the environment. Do not hardcode them:
+
+| Variable | Used by | Purpose |
+| --- | --- | --- |
+| `LINODE_ROOT_PASS` | create | root password for provisioned VMs |
+| `PMM_PERF_SSH_PUBKEY` | create | SSH public key authorized on the VMs |
+| `PMM_SERVER_PASSWORD` | create | PMM server admin password |
+| `PMM_PERF_SSH_KEY` | inventory | local private key path (default `~/.ssh/id_rsa`) |
+
+`linode-cli` must be configured with its own API token (`linode-cli configure`).
+
+## Provision
+
+```bash
+export LINODE_ROOT_PASS=...          # not in git
+export PMM_PERF_SSH_PUBKEY="ssh-rsa AAAA... you@host"
+export PMM_SERVER_PASSWORD=...
+./linode_stackScript_load_pmm3.sh <pmm_server_host> <client_version> <instances> <metrics_mode> <dbtype>
+#   dbtype: mysql | postgresql | mongodb
+```
+
+Every VM is tagged `pmm-qa-ephemeral`, `pmm-qa-perf`, and
+`pmm-qa-perf-run:<PERF_RUN_ID>`.
+
+## Tear down (do this — the VMs bill until deleted)
+
+```bash
+./teardown_perf_linodes.sh --dry-run   # preview
+./teardown_perf_linodes.sh             # delete every pmm-qa-ephemeral instance
+PMM_PERF_TAG=pmm-qa-perf-run:<id> ./teardown_perf_linodes.sh   # just one batch
+```
+
+## Inventory + upgrade
+
+```bash
+./prepare_ansible_client_inventory.sh          # writes inventory_client_container2 (git-ignored)
+./start_upgrade_v3.sh <version> <install_repo>  # runs upgrade_client.yml
+```
+
+`upgrade_client.yml` copies `upgrade_all_v3.sh` to each host and runs it as a
+monitored async job, upgrading the PMM client in every `*client_container*`
+Docker container and failing if the upgrade does not complete.

--- a/performance/linode_stackScript_load_pmm3.sh
+++ b/performance/linode_stackScript_load_pmm3.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 # Provision N Linode PMM client load-test VMs for one DB type via a Percona
-# StackScript. Every instance is tagged pmm-qa-ephemeral so its teardown
-# counterpart (teardown_perf_linodes.sh) can find and delete it -- these VMs bill
-# until removed, so nothing here creates an untagged, unattributable instance.
-#
-# Credentials come from the environment, never from source: the VM root password
-# and the authorized SSH key were previously hardcoded here and must stay out of
-# the repo.
+# StackScript. Each instance is tagged pmm-qa-perf-run:<PERF_RUN_ID> so its batch
+# can be found for inventory and teardown; credentials come from the environment.
 set -Eeuo pipefail
 
 usage() {
@@ -17,12 +12,14 @@ Usage: linode_stackScript_load_pmm3.sh <pmm_server_host> <client_version> <insta
 Required environment:
   LINODE_ROOT_PASS     root password for the provisioned VMs
   PMM_PERF_SSH_PUBKEY  SSH public key to authorize on the provisioned VMs
-  PMM_SERVER_PASSWORD  PMM server admin password (kept off this script's argv)
+  PMM_SERVER_PASSWORD  PMM server admin password (from env; still reaches
+                       linode-cli via --stackscript_data, so visible in ps)
 
 Optional environment:
   LINODE_REGION        default: us-east
   LINODE_TYPE          default: g6-standard-2
-  PERF_RUN_ID          groups this batch under tag pmm-qa-perf-run:<id>; default: UTC timestamp
+  PERF_RUN_ID          batch id, tagged pmm-qa-perf-run:<id> and put in the
+                       label so batches don't collide; default: UTC timestamp
 EOF
   exit 2
 }
@@ -54,8 +51,7 @@ command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
 
 for i in $(seq 1 "$INSTANCES"); do
   hostname="${hostprefix}_${METRICS_MODE}_${i}"
-  label="sp_fb_${i}_${DBTYPE}_${METRICS_MODE}_test"
-  # jq builds the JSON so a value containing a quote or backslash can't break it.
+  label="sp_fb_${i}_${DBTYPE}_${METRICS_MODE}_${PERF_RUN_ID}"
   ssdata="$(jq -nc \
     --arg hostname "$hostname" \
     --arg pmmserver "$PMM_SERVER_HOST" \
@@ -79,5 +75,6 @@ for i in $(seq 1 "$INSTANCES"); do
   sleep 15
 done
 
-echo "created ${INSTANCES} ${DBTYPE} client(s), tagged pmm-qa-ephemeral / pmm-qa-perf-run:${PERF_RUN_ID}"
-echo "tear them down with: ./teardown_perf_linodes.sh    (or --dry-run to preview)"
+echo "created ${INSTANCES} ${DBTYPE} client(s) as batch PERF_RUN_ID=${PERF_RUN_ID}"
+echo "inventory:  PERF_RUN_ID=${PERF_RUN_ID} ./prepare_ansible_client_inventory.sh"
+echo "teardown:   PMM_PERF_TAG=pmm-qa-perf-run:${PERF_RUN_ID} ./teardown_perf_linodes.sh"

--- a/performance/linode_stackScript_load_pmm3.sh
+++ b/performance/linode_stackScript_load_pmm3.sh
@@ -10,12 +10,13 @@ Usage: linode_stackScript_load_pmm3.sh <pmm_server_host> <client_version> <insta
   dbtype: mysql | postgresql | mongodb
 
 Required environment:
-  LINODE_ROOT_PASS     root password for the provisioned VMs
   PMM_PERF_SSH_PUBKEY  SSH public key to authorize on the provisioned VMs
   PMM_SERVER_PASSWORD  PMM server admin password (from env; still reaches
                        linode-cli via --stackscript_data, so visible in ps)
 
 Optional environment:
+  LINODE_ROOT_PASS     root password; random per run when unset (access is by
+                       SSH key, so this stays throwaway)
   LINODE_REGION        default: us-east
   LINODE_TYPE          default: g6-standard-2
   PERF_RUN_ID          batch id, tagged pmm-qa-perf-run:<id> and put in the
@@ -31,7 +32,11 @@ INSTANCES=$3
 METRICS_MODE=$4
 DBTYPE=$5
 
-: "${LINODE_ROOT_PASS:?set LINODE_ROOT_PASS (do not hardcode)}"
+# Access to the VMs is by SSH key, not the console, so the root password is
+# throwaway: generate a random one per run when unset. That also shrinks the
+# CWE-214 exposure -- what lands on linode-cli's argv is then a single-use secret
+# for a VM that gets destroyed, not a reused credential.
+LINODE_ROOT_PASS="${LINODE_ROOT_PASS:-$(openssl rand -base64 24)}"
 : "${PMM_PERF_SSH_PUBKEY:?set PMM_PERF_SSH_PUBKEY (do not hardcode)}"
 : "${PMM_SERVER_PASSWORD:?set PMM_SERVER_PASSWORD}"
 LINODE_REGION=${LINODE_REGION:-us-east}

--- a/performance/linode_stackScript_load_pmm3.sh
+++ b/performance/linode_stackScript_load_pmm3.sh
@@ -49,6 +49,20 @@ esac
 command -v linode-cli >/dev/null || { echo "linode-cli is required" >&2; exit 1; }
 command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
 
+# Print the batch id and its teardown before provisioning, so a failure partway
+# through the loop still leaves the operator the id needed to clean up.
+echo "provisioning batch PERF_RUN_ID=${PERF_RUN_ID} (${INSTANCES} ${DBTYPE} client(s))"
+echo "inventory:  PERF_RUN_ID=${PERF_RUN_ID} ./prepare_ansible_client_inventory.sh"
+echo "teardown:   PMM_PERF_TAG=pmm-qa-perf-run:${PERF_RUN_ID} ./teardown_perf_linodes.sh"
+
+# Nothing reaps stray Linode instances automatically, so a mid-loop failure would
+# leak billing VMs -- tear this batch down on any error instead.
+cleanup_on_err() {
+  echo "provisioning failed -- tearing down batch pmm-qa-perf-run:${PERF_RUN_ID}" >&2
+  PMM_PERF_TAG="pmm-qa-perf-run:${PERF_RUN_ID}" bash "$(dirname "$0")/teardown_perf_linodes.sh" || true
+}
+trap cleanup_on_err ERR
+
 for i in $(seq 1 "$INSTANCES"); do
   hostname="${hostprefix}_${METRICS_MODE}_${i}"
   label="sp_fb_${i}_${DBTYPE}_${METRICS_MODE}_${PERF_RUN_ID}"
@@ -68,13 +82,11 @@ for i in $(seq 1 "$INSTANCES"); do
     --stackscript_data "$ssdata" \
     --root_pass "$LINODE_ROOT_PASS" \
     --region "$LINODE_REGION" \
-    --tags pmm-qa-ephemeral \
     --tags pmm-qa-perf \
     --tags "pmm-qa-perf-run:${PERF_RUN_ID}" \
     --authorized_keys "$PMM_PERF_SSH_PUBKEY"
-  sleep 15
+  sleep 15   # pace Linode API / StackScript provisioning to avoid rate-limit errors
 done
 
+trap - ERR
 echo "created ${INSTANCES} ${DBTYPE} client(s) as batch PERF_RUN_ID=${PERF_RUN_ID}"
-echo "inventory:  PERF_RUN_ID=${PERF_RUN_ID} ./prepare_ansible_client_inventory.sh"
-echo "teardown:   PMM_PERF_TAG=pmm-qa-perf-run:${PERF_RUN_ID} ./teardown_perf_linodes.sh"

--- a/performance/linode_stackScript_load_pmm3.sh
+++ b/performance/linode_stackScript_load_pmm3.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Provision N Linode PMM client load-test VMs for one DB type via a Percona
+# StackScript. Every instance is tagged pmm-qa-ephemeral so its teardown
+# counterpart (teardown_perf_linodes.sh) can find and delete it -- these VMs bill
+# until removed, so nothing here creates an untagged, unattributable instance.
+#
+# Credentials come from the environment, never from source: the VM root password
+# and the authorized SSH key were previously hardcoded here and must stay out of
+# the repo.
+set -Eeuo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: linode_stackScript_load_pmm3.sh <pmm_server_host> <client_version> <instances> <metrics_mode> <dbtype>
+  dbtype: mysql | postgresql | mongodb
+
+Required environment:
+  LINODE_ROOT_PASS     root password for the provisioned VMs
+  PMM_PERF_SSH_PUBKEY  SSH public key to authorize on the provisioned VMs
+  PMM_SERVER_PASSWORD  PMM server admin password (kept off this script's argv)
+
+Optional environment:
+  LINODE_REGION        default: us-east
+  LINODE_TYPE          default: g6-standard-2
+  PERF_RUN_ID          groups this batch under tag pmm-qa-perf-run:<id>; default: UTC timestamp
+EOF
+  exit 2
+}
+
+[ "$#" -eq 5 ] || usage
+PMM_SERVER_HOST=$1
+CLIENT_VERSION=$2
+INSTANCES=$3
+METRICS_MODE=$4
+DBTYPE=$5
+
+: "${LINODE_ROOT_PASS:?set LINODE_ROOT_PASS (do not hardcode)}"
+: "${PMM_PERF_SSH_PUBKEY:?set PMM_PERF_SSH_PUBKEY (do not hardcode)}"
+: "${PMM_SERVER_PASSWORD:?set PMM_SERVER_PASSWORD}"
+LINODE_REGION=${LINODE_REGION:-us-east}
+LINODE_TYPE=${LINODE_TYPE:-g6-standard-2}
+PERF_RUN_ID=${PERF_RUN_ID:-$(date -u +%Y%m%d-%H%M%S)}
+
+[[ "$INSTANCES" =~ ^[1-9][0-9]*$ ]] || { echo "instances must be a positive integer, got: $INSTANCES" >&2; exit 2; }
+case "$DBTYPE" in
+  mysql)      STACKSCRIPT_ID=1611994; hostprefix=li_client_mysql ;;
+  postgresql) STACKSCRIPT_ID=1612038; hostprefix=li_client_pgsql ;;
+  mongodb)    STACKSCRIPT_ID=2046257; hostprefix=li_client_mongodb ;;
+  *) echo "unknown dbtype: $DBTYPE (expected mysql|postgresql|mongodb)" >&2; exit 2 ;;
+esac
+
+command -v linode-cli >/dev/null || { echo "linode-cli is required" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+for i in $(seq 1 "$INSTANCES"); do
+  hostname="${hostprefix}_${METRICS_MODE}_${i}"
+  label="sp_fb_${i}_${DBTYPE}_${METRICS_MODE}_test"
+  # jq builds the JSON so a value containing a quote or backslash can't break it.
+  ssdata="$(jq -nc \
+    --arg hostname "$hostname" \
+    --arg pmmserver "$PMM_SERVER_HOST" \
+    --arg pmmpassword "$PMM_SERVER_PASSWORD" \
+    --arg clientversion "$CLIENT_VERSION" \
+    --arg metricsmode "$METRICS_MODE" \
+    '{hostname:$hostname, pmmserver:$pmmserver, pmmpassword:$pmmpassword, clientversion:$clientversion, metricsmode:$metricsmode}')"
+
+  linode-cli linodes create \
+    --type "$LINODE_TYPE" \
+    --image linode/ubuntu22.04 \
+    --label "$label" \
+    --stackscript_id "$STACKSCRIPT_ID" \
+    --stackscript_data "$ssdata" \
+    --root_pass "$LINODE_ROOT_PASS" \
+    --region "$LINODE_REGION" \
+    --tags pmm-qa-ephemeral \
+    --tags pmm-qa-perf \
+    --tags "pmm-qa-perf-run:${PERF_RUN_ID}" \
+    --authorized_keys "$PMM_PERF_SSH_PUBKEY"
+  sleep 15
+done
+
+echo "created ${INSTANCES} ${DBTYPE} client(s), tagged pmm-qa-ephemeral / pmm-qa-perf-run:${PERF_RUN_ID}"
+echo "tear them down with: ./teardown_perf_linodes.sh    (or --dry-run to preview)"

--- a/performance/linode_stackScript_load_pmm3.sh
+++ b/performance/linode_stackScript_load_pmm3.sh
@@ -55,13 +55,19 @@ echo "provisioning batch PERF_RUN_ID=${PERF_RUN_ID} (${INSTANCES} ${DBTYPE} clie
 echo "inventory:  PERF_RUN_ID=${PERF_RUN_ID} ./prepare_ansible_client_inventory.sh"
 echo "teardown:   PMM_PERF_TAG=pmm-qa-perf-run:${PERF_RUN_ID} ./teardown_perf_linodes.sh"
 
-# Nothing reaps stray Linode instances automatically, so a mid-loop failure would
-# leak billing VMs -- tear this batch down on any error instead.
-cleanup_on_err() {
-  echo "provisioning failed -- tearing down batch pmm-qa-perf-run:${PERF_RUN_ID}" >&2
+# Nothing reaps stray Linode instances automatically, so an interrupted run would
+# leak billing VMs -- tear this batch down on any error. ERR covers a failed
+# command; the signal traps cover a CI cancel/timeout (SIGTERM/SIGINT), which does
+# NOT fire ERR. Best-effort: a hard SIGKILL still can't be trapped, so an
+# out-of-band tag-expiry reaper is the real backstop (see PR discussion).
+cleanup_on_fail() {
+  echo "provisioning interrupted -- tearing down batch pmm-qa-perf-run:${PERF_RUN_ID}" >&2
   PMM_PERF_TAG="pmm-qa-perf-run:${PERF_RUN_ID}" bash "$(dirname "$0")/teardown_perf_linodes.sh" || true
 }
-trap cleanup_on_err ERR
+trap cleanup_on_fail ERR
+trap 'cleanup_on_fail; exit 143' TERM
+trap 'cleanup_on_fail; exit 130' INT
+trap 'cleanup_on_fail; exit 129' HUP
 
 for i in $(seq 1 "$INSTANCES"); do
   hostname="${hostprefix}_${METRICS_MODE}_${i}"
@@ -88,5 +94,5 @@ for i in $(seq 1 "$INSTANCES"); do
   sleep 15   # pace Linode API / StackScript provisioning to avoid rate-limit errors
 done
 
-trap - ERR
+trap - ERR TERM INT HUP
 echo "created ${INSTANCES} ${DBTYPE} client(s) as batch PERF_RUN_ID=${PERF_RUN_ID}"

--- a/performance/prepare_ansible_client_inventory.sh
+++ b/performance/prepare_ansible_client_inventory.sh
@@ -24,13 +24,21 @@ list_all() {
 
 hosts="$(list_all | jq -r --arg tag "$RUN_TAG" 'select(.tags | index($tag)) | .ipv4[0] // empty')"
 
+# Build into a temp file and validate before replacing the inventory, so a
+# no-match run can't destroy a good inventory from another batch.
+tmp="$(mktemp)"
 {
   echo "[linode_clients]"
   printf '%s\n' "$hosts" | sed '/^$/d' | while read -r ip; do
     echo "${ip} ansible_ssh_user=root ansible_ssh_private_key_file=\"${SSH_KEY}\""
   done
-} > "$INVENTORY"
+} > "$tmp"
 
-count=$(($(wc -l < "$INVENTORY") - 1))
+count=$(($(wc -l < "$tmp") - 1))
+if [ "$count" -le 0 ]; then
+  rm -f "$tmp"
+  echo "no instances matched $RUN_TAG (left $INVENTORY untouched)" >&2
+  exit 1
+fi
+mv "$tmp" "$INVENTORY"
 echo "wrote $count host(s) for $RUN_TAG to $INVENTORY"
-[ "$count" -gt 0 ] || { echo "no instances matched $RUN_TAG" >&2; exit 1; }

--- a/performance/prepare_ansible_client_inventory.sh
+++ b/performance/prepare_ansible_client_inventory.sh
@@ -3,7 +3,7 @@
 # pmm-qa-perf-run:<PERF_RUN_ID> tag (not by label, which is account-wide).
 set -Eeuo pipefail
 
-INVENTORY="inventory_client_container2"   # git-ignored; keep the name in sync with .gitignore
+INVENTORY="inventory_client_container2"
 : "${PERF_RUN_ID:?set PERF_RUN_ID to the batch you provisioned}"
 SSH_KEY="${PMM_PERF_SSH_KEY:-$HOME/.ssh/id_rsa}"
 RUN_TAG="pmm-qa-perf-run:${PERF_RUN_ID}"

--- a/performance/prepare_ansible_client_inventory.sh
+++ b/performance/prepare_ansible_client_inventory.sh
@@ -1,26 +1,24 @@
 #!/usr/bin/env bash
-# Build the Ansible inventory of load-test client VMs from the live Linode list.
-# Matches the same label prefix the create step uses (sp_fb_) so the two scripts
-# actually line up; override with PERF_LABEL_MATCH.
+# Build the Ansible inventory for one provisioned batch, selected by its
+# pmm-qa-perf-run:<PERF_RUN_ID> tag (not by label, which is account-wide).
 set -Eeuo pipefail
 
 INVENTORY="${INVENTORY_FILE:-inventory_client_container2}"
-LABEL_MATCH="${PERF_LABEL_MATCH:-sp_fb_}"
+: "${PERF_RUN_ID:?set PERF_RUN_ID to the batch you provisioned}"
 SSH_KEY="${PMM_PERF_SSH_KEY:-$HOME/.ssh/id_rsa}"
+RUN_TAG="pmm-qa-perf-run:${PERF_RUN_ID}"
 command -v linode-cli >/dev/null || { echo "linode-cli is required" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
 
-# Capture the listing first so a linode-cli failure aborts (set -e) instead of
-# silently producing an empty inventory.
-raw="$(linode-cli linodes list --format 'id,ipv4,label' --text --delimiter ';' --no-headers)"
+hosts="$(linode-cli linodes list --json | jq -r --arg tag "$RUN_TAG" '.[] | select(.tags | index($tag)) | .ipv4[0] // empty')"
 
 {
   echo "[linode_clients]"
-  printf '%s\n' "$raw" \
-    | grep -- "$LABEL_MATCH" \
-    | awk -F ';' -v key="$SSH_KEY" '{print $2" ansible_ssh_user=root ansible_ssh_private_key_file="key}' \
-    || true
+  printf '%s\n' "$hosts" | sed '/^$/d' | while read -r ip; do
+    echo "${ip} ansible_ssh_user=root ansible_ssh_private_key_file=${SSH_KEY}"
+  done
 } > "$INVENTORY"
 
 count=$(($(wc -l < "$INVENTORY") - 1))
-echo "wrote $count host(s) matching '$LABEL_MATCH' to $INVENTORY"
-[ "$count" -gt 0 ] || echo "warning: no instances matched '$LABEL_MATCH'" >&2
+echo "wrote $count host(s) for $RUN_TAG to $INVENTORY"
+[ "$count" -gt 0 ] || { echo "no instances matched $RUN_TAG" >&2; exit 1; }

--- a/performance/prepare_ansible_client_inventory.sh
+++ b/performance/prepare_ansible_client_inventory.sh
@@ -10,7 +10,19 @@ RUN_TAG="pmm-qa-perf-run:${PERF_RUN_ID}"
 command -v linode-cli >/dev/null || { echo "linode-cli is required" >&2; exit 1; }
 command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
 
-hosts="$(linode-cli linodes list --json | jq -r --arg tag "$RUN_TAG" '.[] | select(.tags | index($tag)) | .ipv4[0] // empty')"
+# linode-cli lists account-wide and defaults to one 100-row page; walk pages at the
+# 500 max until a short one so a busy account can't silently shorten the batch.
+list_all() {
+  local page=1 got
+  while :; do
+    got="$(linode-cli linodes list --json --page "$page" --page-size 500)"
+    printf '%s' "$got" | jq -c '.[]'
+    [ "$(printf '%s' "$got" | jq 'length')" -lt 500 ] && break
+    page=$((page + 1))
+  done
+}
+
+hosts="$(list_all | jq -r --arg tag "$RUN_TAG" 'select(.tags | index($tag)) | .ipv4[0] // empty')"
 
 {
   echo "[linode_clients]"

--- a/performance/prepare_ansible_client_inventory.sh
+++ b/performance/prepare_ansible_client_inventory.sh
@@ -3,7 +3,7 @@
 # pmm-qa-perf-run:<PERF_RUN_ID> tag (not by label, which is account-wide).
 set -Eeuo pipefail
 
-INVENTORY="${INVENTORY_FILE:-inventory_client_container2}"
+INVENTORY="inventory_client_container2"   # git-ignored; keep the name in sync with .gitignore
 : "${PERF_RUN_ID:?set PERF_RUN_ID to the batch you provisioned}"
 SSH_KEY="${PMM_PERF_SSH_KEY:-$HOME/.ssh/id_rsa}"
 RUN_TAG="pmm-qa-perf-run:${PERF_RUN_ID}"
@@ -15,7 +15,7 @@ hosts="$(linode-cli linodes list --json | jq -r --arg tag "$RUN_TAG" '.[] | sele
 {
   echo "[linode_clients]"
   printf '%s\n' "$hosts" | sed '/^$/d' | while read -r ip; do
-    echo "${ip} ansible_ssh_user=root ansible_ssh_private_key_file=${SSH_KEY}"
+    echo "${ip} ansible_ssh_user=root ansible_ssh_private_key_file=\"${SSH_KEY}\""
   done
 } > "$INVENTORY"
 

--- a/performance/prepare_ansible_client_inventory.sh
+++ b/performance/prepare_ansible_client_inventory.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Build the Ansible inventory of load-test client VMs from the live Linode list.
+# Matches the same label prefix the create step uses (sp_fb_) so the two scripts
+# actually line up; override with PERF_LABEL_MATCH.
+set -Eeuo pipefail
+
+INVENTORY="${INVENTORY_FILE:-inventory_client_container2}"
+LABEL_MATCH="${PERF_LABEL_MATCH:-sp_fb_}"
+SSH_KEY="${PMM_PERF_SSH_KEY:-$HOME/.ssh/id_rsa}"
+command -v linode-cli >/dev/null || { echo "linode-cli is required" >&2; exit 1; }
+
+# Capture the listing first so a linode-cli failure aborts (set -e) instead of
+# silently producing an empty inventory.
+raw="$(linode-cli linodes list --format 'id,ipv4,label' --text --delimiter ';' --no-headers)"
+
+{
+  echo "[linode_clients]"
+  printf '%s\n' "$raw" \
+    | grep -- "$LABEL_MATCH" \
+    | awk -F ';' -v key="$SSH_KEY" '{print $2" ansible_ssh_user=root ansible_ssh_private_key_file="key}' \
+    || true
+} > "$INVENTORY"
+
+count=$(($(wc -l < "$INVENTORY") - 1))
+echo "wrote $count host(s) matching '$LABEL_MATCH' to $INVENTORY"
+[ "$count" -gt 0 ] || echo "warning: no instances matched '$LABEL_MATCH'" >&2

--- a/performance/start_upgrade_v3.sh
+++ b/performance/start_upgrade_v3.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <version> <install_repo>" >&2
+  echo "Example: $0 3.1.0 release" >&2
+  exit 1
+fi
+
+# Host-key verification stays ON by default so a hijacked host can't MITM the
+# root SSH session; override to False only for throwaway hosts you already trust.
+export ANSIBLE_HOST_KEY_CHECKING="${ANSIBLE_HOST_KEY_CHECKING:-True}"
+export version="$1"
+export install_repo="$2"
+INVENTORY="${INVENTORY_FILE:-inventory_client_container2}"
+
+echo "Running upgrade with version=$version repo=$install_repo (host_key_checking=$ANSIBLE_HOST_KEY_CHECKING)"
+ansible-playbook -i "$INVENTORY" upgrade_client.yml

--- a/performance/start_upgrade_v3.sh
+++ b/performance/start_upgrade_v3.sh
@@ -10,7 +10,7 @@ fi
 export ANSIBLE_HOST_KEY_CHECKING="${ANSIBLE_HOST_KEY_CHECKING:-True}"
 export version="$1"
 export install_repo="$2"
-INVENTORY="${INVENTORY_FILE:-inventory_client_container2}"
+INVENTORY="inventory_client_container2"
 
 echo "Running upgrade with version=$version repo=$install_repo (host_key_checking=$ANSIBLE_HOST_KEY_CHECKING)"
 ansible-playbook -i "$INVENTORY" upgrade_client.yml

--- a/performance/start_upgrade_v3.sh
+++ b/performance/start_upgrade_v3.sh
@@ -7,8 +7,6 @@ if [ "$#" -ne 2 ]; then
   exit 1
 fi
 
-# Host-key verification stays ON by default so a hijacked host can't MITM the
-# root SSH session; override to False only for throwaway hosts you already trust.
 export ANSIBLE_HOST_KEY_CHECKING="${ANSIBLE_HOST_KEY_CHECKING:-True}"
 export version="$1"
 export install_repo="$2"

--- a/performance/teardown_perf_linodes.sh
+++ b/performance/teardown_perf_linodes.sh
@@ -1,24 +1,42 @@
 #!/usr/bin/env bash
-# Delete the load-test client VMs from linode_stackScript_load_pmm3.sh. Defaults to
-# this harness's pmm-qa-perf tag, never the account-wide pmm-qa-ephemeral (the
+# Delete the load-test client VMs from linode_stackScript_load_pmm3.sh. Scoped to
+# this harness's own pmm-qa-perf tag, never the account-wide pmm-qa-ephemeral (the
 # Terraform QA runner and LKE clusters carry that too, and linode-cli lists
 # account-wide). See README.md for usage.
 set -Eeuo pipefail
 
-# Strict parse: this is destructive, so anything but a lone --dry-run is a hard error.
 DRY=0
 case "$#" in
   0) ;;
   1) [ "$1" = "--dry-run" ] || { echo "usage: $0 [--dry-run]" >&2; exit 2; }; DRY=1 ;;
   *) echo "usage: $0 [--dry-run]" >&2; exit 2 ;;
 esac
+
 TAG="${PMM_PERF_TAG:-pmm-qa-perf}"
+# Refuse any tag outside this harness's own scope, so PMM_PERF_TAG can never point
+# teardown at a shared tag like pmm-qa-ephemeral.
+case "$TAG" in
+  pmm-qa-perf|pmm-qa-perf-run:?*) ;;
+  *) echo "refusing PMM_PERF_TAG='$TAG': only pmm-qa-perf or pmm-qa-perf-run:<id>" >&2; exit 2 ;;
+esac
 command -v linode-cli >/dev/null || { echo "linode-cli is required" >&2; exit 1; }
 command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
 
+# linode-cli lists account-wide and defaults to one 100-row page; walk pages at the
+# 500 max until a short one, so a busy account can't hide instances from teardown.
+list_all() {
+  local page=1 got
+  while :; do
+    got="$(linode-cli linodes list --json --page "$page" --page-size 500)"
+    printf '%s' "$got" | jq -c '.[]'
+    [ "$(printf '%s' "$got" | jq 'length')" -lt 500 ] && break
+    page=$((page + 1))
+  done
+}
+
 # index() matches the tag as an exact array element, so pmm-qa-perf can't also
-# catch pmm-qa-perf-run:<id>; a linode-cli failure aborts via set -e/pipefail.
-rows="$(linode-cli linodes list --json | jq -r --arg tag "$TAG" '.[] | select(.tags | index($tag)) | [.id, .label] | @tsv')"
+# catch pmm-qa-perf-run:<id>.
+rows="$(list_all | jq -r --arg tag "$TAG" 'select(.tags | index($tag)) | [.id, .label] | @tsv')"
 
 n=0 fail=0
 while IFS=$'\t' read -r id label; do

--- a/performance/teardown_perf_linodes.sh
+++ b/performance/teardown_perf_linodes.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Delete the load-test client VMs that linode_stackScript_load_pmm3.sh creates.
+# Those instances bill until removed, so this is the teardown the create step
+# needs. It deletes ONLY instances carrying the pmm-qa-ephemeral tag the create
+# step stamps -- never anything else. --dry-run lists them and deletes nothing.
+#
+#   ./teardown_perf_linodes.sh --dry-run    # preview
+#   ./teardown_perf_linodes.sh              # delete
+#   PMM_PERF_TAG=pmm-qa-perf-run:20260904-120000 ./teardown_perf_linodes.sh  # one batch
+set -Eeuo pipefail
+
+DRY=0; [ "${1:-}" = "--dry-run" ] && DRY=1
+TAG="${PMM_PERF_TAG:-pmm-qa-ephemeral}"
+command -v linode-cli >/dev/null || { echo "linode-cli is required" >&2; exit 1; }
+
+# List every instance once (linode-cli failure aborts via set -e), then match the
+# tag client-side so this never depends on a server-side tag-filter flag.
+raw="$(linode-cli linodes list --format 'id,label,tags' --text --no-headers --delimiter $'\t')"
+
+n=0 fail=0
+while IFS=$'\t' read -r id label tags; do
+  [ -n "$id" ] || continue
+  printf '%s' "$tags" | grep -qw -- "$TAG" || continue
+  if [ "$DRY" -eq 1 ]; then echo "would delete linode $id ($label)"; n=$((n + 1)); continue; fi
+  if linode-cli linodes delete "$id"; then
+    echo "deleted linode $id ($label)"; n=$((n + 1))
+  else
+    echo "FAILED linode $id ($label)" >&2; fail=$((fail + 1))
+  fi
+done <<< "$raw"
+
+echo "teardown_perf_linodes: instances=$n failed=$fail$([ "$DRY" -eq 1 ] && echo ' (dry-run)') [tag=$TAG]"
+[ "$fail" -eq 0 ]

--- a/performance/teardown_perf_linodes.sh
+++ b/performance/teardown_perf_linodes.sh
@@ -42,7 +42,7 @@ n=0 fail=0
 while IFS=$'\t' read -r id label; do
   [ -n "$id" ] || continue
   if [ "$DRY" -eq 1 ]; then echo "would delete linode $id ($label)"; n=$((n + 1)); continue; fi
-  if linode-cli linodes delete "$id"; then
+  if linode-cli linodes delete "$id" </dev/null; then   # </dev/null: don't let it consume the row here-string
     echo "deleted linode $id ($label)"; n=$((n + 1))
   else
     echo "FAILED linode $id ($label)" >&2; fail=$((fail + 1))

--- a/performance/teardown_perf_linodes.sh
+++ b/performance/teardown_perf_linodes.sh
@@ -1,33 +1,39 @@
 #!/usr/bin/env bash
 # Delete the load-test client VMs that linode_stackScript_load_pmm3.sh creates.
 # Those instances bill until removed, so this is the teardown the create step
-# needs. It deletes ONLY instances carrying the pmm-qa-ephemeral tag the create
-# step stamps -- never anything else. --dry-run lists them and deletes nothing.
+# needs.
+#
+# It defaults to this harness's own pmm-qa-perf tag -- NOT the account-wide
+# pmm-qa-ephemeral tag, which the Terraform QA runner (terraform/linode-runner)
+# and LKE clusters (linode-ha-provisioning) also stamp. `linode-cli linodes list`
+# is account-wide, so defaulting to pmm-qa-ephemeral would delete someone else's
+# live instance mid-test. --dry-run lists matches and deletes nothing.
 #
 #   ./teardown_perf_linodes.sh --dry-run    # preview
-#   ./teardown_perf_linodes.sh              # delete
+#   ./teardown_perf_linodes.sh              # delete every pmm-qa-perf instance
 #   PMM_PERF_TAG=pmm-qa-perf-run:20260904-120000 ./teardown_perf_linodes.sh  # one batch
 set -Eeuo pipefail
 
 DRY=0; [ "${1:-}" = "--dry-run" ] && DRY=1
-TAG="${PMM_PERF_TAG:-pmm-qa-ephemeral}"
+TAG="${PMM_PERF_TAG:-pmm-qa-perf}"
 command -v linode-cli >/dev/null || { echo "linode-cli is required" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
 
-# List every instance once (linode-cli failure aborts via set -e), then match the
-# tag client-side so this never depends on a server-side tag-filter flag.
-raw="$(linode-cli linodes list --format 'id,label,tags' --text --no-headers --delimiter $'\t')"
+# jq matches the tag as an exact array element -- a substring/word match would let
+# pmm-qa-perf also catch pmm-qa-perf-run:<id>. A linode-cli failure aborts via
+# set -e/pipefail rather than yielding an empty list that deletes nothing silently.
+rows="$(linode-cli linodes list --json | jq -r --arg tag "$TAG" '.[] | select(.tags | index($tag)) | [.id, .label] | @tsv')"
 
 n=0 fail=0
-while IFS=$'\t' read -r id label tags; do
+while IFS=$'\t' read -r id label; do
   [ -n "$id" ] || continue
-  printf '%s' "$tags" | grep -qw -- "$TAG" || continue
   if [ "$DRY" -eq 1 ]; then echo "would delete linode $id ($label)"; n=$((n + 1)); continue; fi
   if linode-cli linodes delete "$id"; then
     echo "deleted linode $id ($label)"; n=$((n + 1))
   else
     echo "FAILED linode $id ($label)" >&2; fail=$((fail + 1))
   fi
-done <<< "$raw"
+done <<< "$rows"
 
 echo "teardown_perf_linodes: instances=$n failed=$fail$([ "$DRY" -eq 1 ] && echo ' (dry-run)') [tag=$TAG]"
 [ "$fail" -eq 0 ]

--- a/performance/teardown_perf_linodes.sh
+++ b/performance/teardown_perf_linodes.sh
@@ -1,17 +1,8 @@
 #!/usr/bin/env bash
-# Delete the load-test client VMs that linode_stackScript_load_pmm3.sh creates.
-# Those instances bill until removed, so this is the teardown the create step
-# needs.
-#
-# It defaults to this harness's own pmm-qa-perf tag -- NOT the account-wide
-# pmm-qa-ephemeral tag, which the Terraform QA runner (terraform/linode-runner)
-# and LKE clusters (linode-ha-provisioning) also stamp. `linode-cli linodes list`
-# is account-wide, so defaulting to pmm-qa-ephemeral would delete someone else's
-# live instance mid-test. --dry-run lists matches and deletes nothing.
-#
-#   ./teardown_perf_linodes.sh --dry-run    # preview
-#   ./teardown_perf_linodes.sh              # delete every pmm-qa-perf instance
-#   PMM_PERF_TAG=pmm-qa-perf-run:20260904-120000 ./teardown_perf_linodes.sh  # one batch
+# Delete the load-test client VMs from linode_stackScript_load_pmm3.sh. Defaults to
+# this harness's pmm-qa-perf tag, never the account-wide pmm-qa-ephemeral (the
+# Terraform QA runner and LKE clusters carry that too, and linode-cli lists
+# account-wide). See README.md for usage.
 set -Eeuo pipefail
 
 DRY=0; [ "${1:-}" = "--dry-run" ] && DRY=1
@@ -19,9 +10,8 @@ TAG="${PMM_PERF_TAG:-pmm-qa-perf}"
 command -v linode-cli >/dev/null || { echo "linode-cli is required" >&2; exit 1; }
 command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
 
-# jq matches the tag as an exact array element -- a substring/word match would let
-# pmm-qa-perf also catch pmm-qa-perf-run:<id>. A linode-cli failure aborts via
-# set -e/pipefail rather than yielding an empty list that deletes nothing silently.
+# index() matches the tag as an exact array element, so pmm-qa-perf can't also
+# catch pmm-qa-perf-run:<id>; a linode-cli failure aborts via set -e/pipefail.
 rows="$(linode-cli linodes list --json | jq -r --arg tag "$TAG" '.[] | select(.tags | index($tag)) | [.id, .label] | @tsv')"
 
 n=0 fail=0

--- a/performance/teardown_perf_linodes.sh
+++ b/performance/teardown_perf_linodes.sh
@@ -5,7 +5,13 @@
 # account-wide). See README.md for usage.
 set -Eeuo pipefail
 
-DRY=0; [ "${1:-}" = "--dry-run" ] && DRY=1
+# Strict parse: this is destructive, so anything but a lone --dry-run is a hard error.
+DRY=0
+case "$#" in
+  0) ;;
+  1) [ "$1" = "--dry-run" ] || { echo "usage: $0 [--dry-run]" >&2; exit 2; }; DRY=1 ;;
+  *) echo "usage: $0 [--dry-run]" >&2; exit 2 ;;
+esac
 TAG="${PMM_PERF_TAG:-pmm-qa-perf}"
 command -v linode-cli >/dev/null || { echo "linode-cli is required" >&2; exit 1; }
 command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }

--- a/performance/upgrade_all_v3.sh
+++ b/performance/upgrade_all_v3.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Upgrade the PMM client inside every running *client_container* Docker container
-# to a requested version/repo, then verify each one actually reports that version.
+# to a requested version/repo, then verify each one reports that version.
 set -Eeuo pipefail
 
 version="" repo=""
@@ -24,11 +24,8 @@ for c in "${containers[@]}"; do
   docker exec "$c" apt-get update
   docker exec "$c" sh -c 'cp /usr/local/percona/pmm/config/pmm-agent.yaml /tmp/pmm-agent.yaml.old'
 
-  # Pin the requested version; fall back to latest-in-repo (with a warning) only
-  # if that exact build isn't published.
   if ! docker exec "$c" bash -c "DEBIAN_FRONTEND=noninteractive apt-get install -y 'pmm-client=${version}*'"; then
-    echo "warning: pmm-client=${version}* unavailable on ${c}, installing latest from ${repo}" >&2
-    docker exec "$c" bash -c "DEBIAN_FRONTEND=noninteractive apt-get install -y pmm-client"
+    echo "ERROR: pmm-client=${version}* is not available on ${c}" >&2; exit 1
   fi
 
   docker exec "$c" pkill -f pmm-agent || true

--- a/performance/upgrade_all_v3.sh
+++ b/performance/upgrade_all_v3.sh
@@ -8,7 +8,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --version) version="$2"; shift 2 ;;
     --repo)    repo="$2"; shift 2 ;;
-    *) shift ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done
 version="${version:-3.7.0}"
@@ -24,9 +24,13 @@ for c in "${containers[@]}"; do
   docker exec "$c" apt-get update
   docker exec "$c" sh -c 'cp /usr/local/percona/pmm/config/pmm-agent.yaml /tmp/pmm-agent.yaml.old'
 
-  if ! docker exec --env DEBIAN_FRONTEND=noninteractive "$c" apt-get install -y "pmm-client=${version}*"; then
-    echo "ERROR: pmm-client=${version}* is not available on ${c}" >&2; exit 1
+  # apt's `=<version>` is an exact match (no glob), so resolve the concrete
+  # published build whose version begins with the requested one, newest first.
+  full_ver="$(docker exec "$c" apt-cache madison pmm-client 2>/dev/null | awk -F'|' -v v="$version" '{gsub(/ /,"",$2)} $2 ~ ("^" v) {print $2; exit}')"
+  if [ -z "$full_ver" ]; then
+    echo "ERROR: no pmm-client version matching ${version} in repo ${repo} on ${c}" >&2; exit 1
   fi
+  docker exec --env DEBIAN_FRONTEND=noninteractive "$c" apt-get install -y "pmm-client=${full_ver}"
 
   docker exec "$c" pkill -f pmm-agent || true
   docker exec "$c" sh -c 'cp /tmp/pmm-agent.yaml.old /usr/local/percona/pmm/config/pmm-agent.yaml'

--- a/performance/upgrade_all_v3.sh
+++ b/performance/upgrade_all_v3.sh
@@ -24,7 +24,7 @@ for c in "${containers[@]}"; do
   docker exec "$c" apt-get update
   docker exec "$c" sh -c 'cp /usr/local/percona/pmm/config/pmm-agent.yaml /tmp/pmm-agent.yaml.old'
 
-  if ! docker exec "$c" bash -c "DEBIAN_FRONTEND=noninteractive apt-get install -y 'pmm-client=${version}*'"; then
+  if ! docker exec --env DEBIAN_FRONTEND=noninteractive "$c" apt-get install -y "pmm-client=${version}*"; then
     echo "ERROR: pmm-client=${version}* is not available on ${c}" >&2; exit 1
   fi
 

--- a/performance/upgrade_all_v3.sh
+++ b/performance/upgrade_all_v3.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Upgrade the PMM client inside every running *client_container* Docker container
+# to a requested version/repo, then verify each one actually reports that version.
+set -Eeuo pipefail
+
+version="" repo=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) version="$2"; shift 2 ;;
+    --repo)    repo="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+version="${version:-3.7.0}"
+repo="${repo:-testing}"
+
+mapfile -t containers < <(docker ps --format '{{.Names}}' | grep client_container || true)
+[ "${#containers[@]}" -gt 0 ] || { echo "no running *client_container* containers found" >&2; exit 1; }
+
+rc=0
+for c in "${containers[@]}"; do
+  echo "Upgrading PMM client on container: ${c}"
+  docker exec "$c" percona-release enable pmm3-client "$repo"
+  docker exec "$c" apt-get update
+  docker exec "$c" sh -c 'cp /usr/local/percona/pmm/config/pmm-agent.yaml /tmp/pmm-agent.yaml.old'
+
+  # Pin the requested version; fall back to latest-in-repo (with a warning) only
+  # if that exact build isn't published.
+  if ! docker exec "$c" bash -c "DEBIAN_FRONTEND=noninteractive apt-get install -y 'pmm-client=${version}*'"; then
+    echo "warning: pmm-client=${version}* unavailable on ${c}, installing latest from ${repo}" >&2
+    docker exec "$c" bash -c "DEBIAN_FRONTEND=noninteractive apt-get install -y pmm-client"
+  fi
+
+  docker exec "$c" pkill -f pmm-agent || true
+  docker exec "$c" sh -c 'cp /tmp/pmm-agent.yaml.old /usr/local/percona/pmm/config/pmm-agent.yaml'
+  # setsid detaches the agent from the exec session so it survives docker exec return.
+  docker exec "$c" sh -c 'setsid pmm-agent --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml >/tmp/pmm-agent.log 2>&1 &'
+  sleep 10
+
+  if ! docker exec "$c" pmm-admin status >/dev/null 2>&1; then
+    echo "ERROR: pmm-agent did not come up on ${c}" >&2; rc=1; continue
+  fi
+  node_name="$(docker exec "$c" pmm-admin status | awk -F': ' '/Node name/ {print $2}')"
+  docker exec "$c" pmm-admin annotate "client ${node_name} upgraded to ${version}" || true
+
+  echo "Verifying installation in container: ${c}"
+  if docker exec "$c" pmm-agent --version 2>&1 | grep -q "${version}"; then
+    echo "client upgraded: ${node_name} -> ${version}"
+  else
+    echo "ERROR: ${c} did not report version ${version}" >&2; rc=1
+  fi
+  echo ""
+done
+
+exit "$rc"

--- a/performance/upgrade_all_v3.sh
+++ b/performance/upgrade_all_v3.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Upgrade the PMM client inside every running *client_container* Docker container
-# to a requested version/repo, then verify each one reports that version.
+# to a requested version/repo, then verify each one reports that version. One
+# container's failure is recorded and the loop continues to the rest.
 set -Eeuo pipefail
 
 version="" repo=""
@@ -14,41 +15,45 @@ done
 version="${version:-3.7.0}"
 repo="${repo:-testing}"
 
+# One container's whole upgrade, in a subshell so a failed step fails just this
+# container (the outer loop records it in rc and moves on) instead of aborting
+# the run under set -e.
+upgrade_container() {
+  local c="$1" full_ver node_name
+  (
+    set -Eeuo pipefail
+    docker exec "$c" percona-release enable pmm3-client "$repo"
+    docker exec "$c" apt-get update
+    docker exec "$c" sh -c 'cp /usr/local/percona/pmm/config/pmm-agent.yaml /tmp/pmm-agent.yaml.old'
+    # apt's `=<version>` is an exact match (no glob), so resolve the concrete
+    # published build whose version begins with the requested one (literal
+    # prefix via index(), newest first).
+    full_ver="$(docker exec "$c" apt-cache madison pmm-client 2>/dev/null | awk -F'|' -v v="$version" '{gsub(/ /,"",$2)} index($2, v)==1 {print $2; exit}')"
+    [ -n "$full_ver" ] || { echo "no pmm-client version matching ${version} in repo ${repo}" >&2; exit 1; }
+    docker exec --env DEBIAN_FRONTEND=noninteractive "$c" apt-get install -y "pmm-client=${full_ver}"
+    docker exec "$c" pkill -f pmm-agent || true
+    docker exec "$c" sh -c 'cp /tmp/pmm-agent.yaml.old /usr/local/percona/pmm/config/pmm-agent.yaml'
+    # setsid detaches the agent from the exec session so it survives docker exec return.
+    docker exec "$c" sh -c 'setsid pmm-agent --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml >/tmp/pmm-agent.log 2>&1 &'
+    sleep 10
+    docker exec "$c" pmm-admin status >/dev/null 2>&1 || { echo "pmm-agent did not come up" >&2; exit 1; }
+    node_name="$(docker exec "$c" pmm-admin status | awk -F': ' '/Node name/ {print $2}')"
+    docker exec "$c" pmm-admin annotate "client ${node_name} upgraded to ${version}" || true
+    docker exec "$c" pmm-agent --version 2>&1 | grep -Fq -- "${version}" \
+      || { echo "did not report version ${version}" >&2; exit 1; }
+  )
+}
+
 mapfile -t containers < <(docker ps --format '{{.Names}}' | grep client_container || true)
 [ "${#containers[@]}" -gt 0 ] || { echo "no running *client_container* containers found" >&2; exit 1; }
 
 rc=0
 for c in "${containers[@]}"; do
   echo "Upgrading PMM client on container: ${c}"
-  docker exec "$c" percona-release enable pmm3-client "$repo"
-  docker exec "$c" apt-get update
-  docker exec "$c" sh -c 'cp /usr/local/percona/pmm/config/pmm-agent.yaml /tmp/pmm-agent.yaml.old'
-
-  # apt's `=<version>` is an exact match (no glob), so resolve the concrete
-  # published build whose version begins with the requested one, newest first.
-  full_ver="$(docker exec "$c" apt-cache madison pmm-client 2>/dev/null | awk -F'|' -v v="$version" '{gsub(/ /,"",$2)} $2 ~ ("^" v) {print $2; exit}')"
-  if [ -z "$full_ver" ]; then
-    echo "ERROR: no pmm-client version matching ${version} in repo ${repo} on ${c}" >&2; exit 1
-  fi
-  docker exec --env DEBIAN_FRONTEND=noninteractive "$c" apt-get install -y "pmm-client=${full_ver}"
-
-  docker exec "$c" pkill -f pmm-agent || true
-  docker exec "$c" sh -c 'cp /tmp/pmm-agent.yaml.old /usr/local/percona/pmm/config/pmm-agent.yaml'
-  # setsid detaches the agent from the exec session so it survives docker exec return.
-  docker exec "$c" sh -c 'setsid pmm-agent --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml >/tmp/pmm-agent.log 2>&1 &'
-  sleep 10
-
-  if ! docker exec "$c" pmm-admin status >/dev/null 2>&1; then
-    echo "ERROR: pmm-agent did not come up on ${c}" >&2; rc=1; continue
-  fi
-  node_name="$(docker exec "$c" pmm-admin status | awk -F': ' '/Node name/ {print $2}')"
-  docker exec "$c" pmm-admin annotate "client ${node_name} upgraded to ${version}" || true
-
-  echo "Verifying installation in container: ${c}"
-  if docker exec "$c" pmm-agent --version 2>&1 | grep -q "${version}"; then
-    echo "client upgraded: ${node_name} -> ${version}"
+  if upgrade_container "$c"; then
+    echo "client upgraded: ${c} -> ${version}"
   else
-    echo "ERROR: ${c} did not report version ${version}" >&2; rc=1
+    echo "ERROR: upgrade failed on ${c}" >&2; rc=1
   fi
   echo ""
 done

--- a/performance/upgrade_client.yml
+++ b/performance/upgrade_client.yml
@@ -5,8 +5,8 @@
   remote_user: root
 
   vars:
-    repo: "{{ lookup('vars', 'extra_repo', default=lookup('env', 'install_repo') | default('testing', true)) }}"
-    version: "{{ lookup('vars', 'extra_version', default=lookup('env', 'version') | default('3.7.0', true)) }}"
+    repo: "{{ lookup('env', 'install_repo') | default('testing', true) }}"
+    version: "{{ lookup('env', 'version') | default('3.7.0', true) }}"
 
   tasks:
     - name: Copy upgrade script

--- a/performance/upgrade_client.yml
+++ b/performance/upgrade_client.yml
@@ -1,0 +1,45 @@
+---
+# Copies upgrade_all_v3.sh to each host and runs it as a monitored async job, so
+# the play only succeeds once the upgrade has actually finished (and fails if it
+# exits non-zero). Env overrides: install_repo, version.
+- hosts: all
+  become: true
+  become_method: sudo
+  remote_user: root
+
+  vars:
+    repo: "{{ lookup('vars', 'extra_repo', default=lookup('env', 'install_repo') | default('testing', true)) }}"
+    version: "{{ lookup('vars', 'extra_version', default=lookup('env', 'version') | default('3.7.0', true)) }}"
+
+  tasks:
+    - name: Copy upgrade script
+      ansible.builtin.copy:
+        src: ./upgrade_all_v3.sh
+        dest: /tmp/upgrade_all_v3.sh
+        mode: '0755'
+
+    - name: Remove old log
+      ansible.builtin.file:
+        path: /tmp/update.log
+        state: absent
+
+    - name: Start PMM client upgrade (async)
+      ansible.builtin.shell: >
+        bash /tmp/upgrade_all_v3.sh --repo {{ repo | quote }} --version {{ version | quote }}
+        >> /tmp/update.log 2>&1
+      async: 7200
+      poll: 0
+      register: upgrade_result
+
+    - name: Wait for PMM client upgrade to finish
+      ansible.builtin.async_status:
+        jid: "{{ upgrade_result.ansible_job_id }}"
+      register: job_result
+      until: job_result.finished
+      retries: 240
+      delay: 30
+      failed_when: job_result.finished and (job_result.rc | default(0)) != 0
+
+    - name: Show final status
+      ansible.builtin.debug:
+        var: job_result

--- a/performance/upgrade_client.yml
+++ b/performance/upgrade_client.yml
@@ -1,7 +1,4 @@
 ---
-# Copies upgrade_all_v3.sh to each host and runs it as a monitored async job, so
-# the play only succeeds once the upgrade has actually finished (and fails if it
-# exits non-zero). Env overrides: install_repo, version.
 - hosts: all
   become: true
   become_method: sudo


### PR DESCRIPTION
## What this is

A `performance/` load-test harness for PMM clients on Linode: provision many client VMs from a Percona StackScript, build an Ansible inventory of one batch, and upgrade the PMM client across it. Used for scale/load testing; not wired into CI.

Supersedes #1324 (closed) — same intent, with the security and cost-leak problems fixed. Reopens the change that was previously on #1332 (that PR couldn't be reopened after a branch force-push). cc @shrutipradhan-percona, whose scripts this reworks; her original branch is preserved on her fork.

## What the scripts do

- **`linode_stackScript_load_pmm3.sh`** — creates N client VMs for one DB type (mysql/postgresql/mongodb). Root password and authorized SSH key come from the environment (`LINODE_ROOT_PASS`, `PMM_PERF_SSH_PUBKEY`), never from source; the PMM admin password from `PMM_SERVER_PASSWORD`. `--stackscript_data` built with `jq`. Each VM labelled and tagged with a `PERF_RUN_ID` (`pmm-qa-perf-run:<id>`) so a batch is uniquely identifiable and two runs coexist.
- **`teardown_perf_linodes.sh`** — deletes the VMs (they bill until removed). Scoped to this harness's own `pmm-qa-perf` tag (exact array match), never the account-wide `pmm-qa-ephemeral`; strict arg parse; `--dry-run` previews.
- **`prepare_ansible_client_inventory.sh`** — writes the inventory for one batch, selected by its `pmm-qa-perf-run:<id>` tag; exits non-zero if no host matches. Generated inventory is git-ignored.
- **`start_upgrade_v3.sh` / `upgrade_client.yml` / `upgrade_all_v3.sh`** — upgrade the PMM client in every `*client_container*` Docker container. SSH host-key checking on by default (README documents the `known_hosts` precondition); playbook vars shell-quoted; `apt-get` via `docker exec --env` + argv (no shell re-parse of `version`); version pinned with fail-fast; `pmm-agent` restarted with `setsid`; upgrade runs as a monitored async job that fails on non-zero exit.
- **`README.md`** documents provision → inventory → upgrade → teardown and the required env vars.

## Validation

`bash -n` + `shellcheck -S warning` clean on all scripts; `yamllint` clean on the playbook; tag exact-match and batch-selection logic checked against sample data. **Not run end-to-end** (needs live Linode/Ansible/Docker), so a smoke test before merge is worth doing — in particular confirm apt honors the `pmm-client=<version>*` spec.

## Follow-up outside this PR

The root password and personal SSH key committed in #1324 exist in that branch's history on a public repo. Removing them here does not undo that — they should be **rotated and scrubbed from history** separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBhvZuEUQU8ym347Xat4Yy

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBhvZuEUQU8ym347Xat4Yy)_