### PR TITLE
[draft] perf-testing CI: provision/cleanup pipelines + Performance Analyst skill

### DIFF
--- a/.claude/skills/performance-analyst/SKILL.md
+++ b/.claude/skills/performance-analyst/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: performance-analyst
+description: Judge a PMM performance-test run from collected metrics against predefined thresholds, write a human report, and emit a pass/fail verdict that gates the CI pipeline green/red. Use inside perf-provision.yml (the "Performance Analyst" CI step); also usable to interpret a metrics.json from a manual run.
+---
+
+# Performance Analyst
+
+Turn one performance-test run's metrics into a **verdict** (pass/fail) and a short **report**. The CI pipeline exits green/red on the verdict, and notifies only on fail — so the verdict must be deterministic and defensible, not a vibe.
+
+## Inputs
+
+- `metrics.json` — produced by `performance/ci/collect_metrics.sh`: `{server, window, generated_at, checks:[{name, promql, unit, stat, op, threshold, observed:{max, avg, last, samples}}]}`.
+- `performance/ci/thresholds.yml` — the source of `stat`/`op`/`threshold` per check (already folded into `metrics.json`; read it only for context/comments).
+
+The workflow passes the paths and the output locations in the prompt.
+
+## Procedure
+
+1. Read `metrics.json`. For each check, compare the observed statistic named by `stat` (`max`/`avg`/`last`) to `threshold` using `op` (`lte` = observed must be ≤ threshold).
+2. A check **fails** if it breaches its threshold, **or** if `observed.samples == 0` or the stat is `null` — no data is a failure, not a pass, because the collector or the query is wrong and the run proved nothing. Say which in the report.
+3. The run **passes** only if every check passes.
+4. Do not invent thresholds, re-weight checks, or excuse a breach as "probably noise". If a threshold looks wrong, still judge against it and flag it in the report for Shruti/Nailya to revise — the numbers are theirs to change, not yours.
+
+## Outputs (exact — the gate depends on them)
+
+Write **`perf-verdict.json`** to the path the prompt gives:
+
+```json
+{
+  "status": "pass",              // "pass" | "fail"
+  "server": "<from metrics.json>",
+  "window": "<from metrics.json>",
+  "checks": [
+    {"name": "exporter_memory_rss_bytes", "stat": "max", "observed": 191234048, "threshold": 268435456, "unit": "bytes", "ok": true}
+  ],
+  "failures": ["<name: observed vs threshold>", "..."],   // empty when status=pass
+  "summary": "one line"
+}
+```
+
+Write **`perf-report.md`** — a short human report: one-line headline (PASS/FAIL + server + window), a table of each check (observed / threshold / ok), and for any failure a sentence on what breached and by how much. No preamble, no restating this skill. Keep it to what a reviewer needs at a glance.
+
+## How CI consumes it
+
+The workflow runs this skill via `anthropics/claude-code-action@v1`, then a **gate** step does `jq -e '.status=="pass"' perf-verdict.json` — exit non-zero flips the job red. `perf-report.md` and `metrics.json` are uploaded as artifacts; an `if: failure()` step sends the notification. So: always write both files, always set `status` to exactly `pass` or `fail`, and never leave the verdict file unwritten (a missing file must read as a failure to the gate).

--- a/.github/workflows/perf-cleanup.yml
+++ b/.github/workflows/perf-cleanup.yml
@@ -1,0 +1,47 @@
+---
+# Delete the Linode client VMs from a performance run, by its pmm-qa-perf-run tag.
+# Pairs with perf-provision.yml (which leaves the batch alive on failure for
+# investigation). Uses performance/teardown_perf_linodes.sh from #1324/#1333.
+#
+# DRAFT — depends on the performance/ scripts landing on main (PR #1333).
+name: perf-cleanup
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'PERF_RUN_ID of the batch to delete (from the provision run''s log/summary).'
+        type: string
+        required: true
+      dry_run:
+        description: 'List what would be deleted without deleting.'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    name: "perf-cleanup: ${{ inputs.run_id }}"
+    runs-on: ubuntu-22.04
+    # Environment protection gates who can spend/delete on the Linode account.
+    # TODO: create this environment and attach the LINODE_CLI_TOKEN secret to it.
+    environment: pmm-perf-staging
+    env:
+      LINODE_CLI_TOKEN: ${{ secrets.LINODE_CLI_TOKEN }}
+    steps:
+      - name: Checkout pmm-qa
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install linode-cli
+        run: pipx install linode-cli
+
+      - name: Tear down the batch
+        env:
+          PMM_PERF_TAG: pmm-qa-perf-run:${{ inputs.run_id }}
+        run: |
+          set -Eeuo pipefail
+          chmod +x performance/teardown_perf_linodes.sh
+          performance/teardown_perf_linodes.sh ${{ inputs.dry_run && '--dry-run' || '' }}

--- a/.github/workflows/perf-provision.yml
+++ b/.github/workflows/perf-provision.yml
@@ -186,11 +186,14 @@ jobs:
           echo "Investigate, then run perf-cleanup with run_id=${PERF_RUN_ID}."
           # TODO: wire a real notification (Slack webhook / routine-fire like notify-investigator.yml).
 
-      - name: Tear down clients on success
-        if: success()
+      - name: Tear down clients (success or cancel/timeout)
+        # A genuine test failure (gate red) is left running for investigation
+        # (meeting: keep ~12h). A cancel/timeout has nothing to investigate, so
+        # cancelled() cleans up rather than leaking — the CI-level backstop for the
+        # ERR/signal traps in the create script, which a hard SIGKILL escapes.
+        if: ${{ success() || cancelled() }}
         env:
           PMM_PERF_TAG: pmm-qa-perf-run:${{ env.PERF_RUN_ID }}
         run: performance/teardown_perf_linodes.sh
-        # On failure the batch is intentionally left running for investigation
-        # (meeting: keep ~12h). TODO: a delayed/auto cleanup so a forgotten failed
-        # run can't bill forever — e.g. a scheduled sweep of expired pmm-qa-perf tags.
+        # Even this can't survive a runner dying, so a scheduled out-of-band sweep
+        # of expired pmm-qa-perf tags is still the real guarantee. TODO.

--- a/.github/workflows/perf-provision.yml
+++ b/.github/workflows/perf-provision.yml
@@ -1,0 +1,196 @@
+---
+# Provision N PMM client VMs on Linode against a PMM server, run an install or
+# upgrade test, collect exporter/server metrics, and let the "Performance Analyst"
+# Claude step decide the run green/red (notify only on fail). Pairs with
+# perf-cleanup.yml.
+#
+# DRAFT — depends on the performance/ scripts landing on main (PR #1333). Two
+# pieces are deliberately stubbed and marked TODO:
+#   * PMM SERVER provisioning: no callable Linode server-provisioner exists yet
+#     (Alex's Terraform / the relay flow are agent-driven), so the server address
+#     + admin password are inputs here, like ha-e2e-tests.yml. Wire the real
+#     provisioner in later.
+#   * THRESHOLDS + PromQL in performance/ci/thresholds.yml are placeholders for
+#     Shruti + Nailya to confirm.
+name: perf-provision
+
+on:
+  workflow_dispatch:
+    inputs:
+      pmm_server_address:
+        description: 'PMM server hostname (no scheme). TODO: auto-provision instead.'
+        type: string
+        required: true
+      client_count:
+        description: 'Clients to provision per DB type (~50-100 dev, 300-500 RC).'
+        type: string
+        required: false
+        default: '50'
+      db_types:
+        description: 'Space-separated DB types: mysql postgresql mongodb.'
+        type: string
+        required: false
+        default: 'mysql'
+      pmm_version:
+        description: 'PMM client version to install (and, for upgrade, to upgrade to).'
+        type: string
+        required: false
+        default: '3-dev-latest'
+      install_repo:
+        description: 'percona-release repo for the client (release|testing|experimental).'
+        type: string
+        required: false
+        default: 'testing'
+      test_type:
+        description: 'install = fresh install only; upgrade = install then upgrade.'
+        type: choice
+        options: [install, upgrade]
+        default: install
+      metrics_window:
+        description: 'How long to let metrics settle/spike before sampling (e.g. 30m).'
+        type: string
+        required: false
+        default: '30m'
+      data_wait_minutes:
+        description: 'Minutes to wait after provisioning for clients to register + accumulate data.'
+        type: string
+        required: false
+        default: '20'
+      run_id:
+        description: 'Batch id (tags + labels the VMs; used by perf-cleanup). Default: gha-<run id>.'
+        type: string
+        required: false
+        default: ''
+  # TODO: enable weekly once validated (meeting: weekly, not daily).
+  # schedule:
+  #   - cron: '0 3 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  perf:
+    name: "perf: ${{ inputs.test_type }} ${{ inputs.client_count }}x${{ inputs.db_types }}"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+    # Gates who can spend on the Linode account and reach the server creds.
+    # TODO: create this environment and attach the secrets below to it.
+    environment: pmm-perf-staging
+    env:
+      PERF_RUN_ID: ${{ inputs.run_id || format('gha-{0}', github.run_id) }}
+      SERVER_ADDR: ${{ inputs.pmm_server_address }}
+      LINODE_CLI_TOKEN: ${{ secrets.LINODE_CLI_TOKEN }}
+      LINODE_ROOT_PASS: ${{ secrets.PERF_LINODE_ROOT_PASS }}
+      PMM_PERF_SSH_PUBKEY: ${{ secrets.PERF_SSH_PUBKEY }}
+      PMM_SERVER_PASSWORD: ${{ secrets.PMM_ADMIN_PASSWORD }}
+      ADMIN_PASSWORD: ${{ secrets.PMM_ADMIN_PASSWORD }}
+    steps:
+      - name: Checkout pmm-qa
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install tooling
+        run: |
+          set -Eeuo pipefail
+          pipx install linode-cli
+          python3 -m pip install --user pyyaml
+          sudo apt-get update && sudo apt-get install -y ansible jq
+
+      - name: Sanity-check the PMM server is reachable
+        run: |
+          set -eu
+          host="${SERVER_ADDR#http://}"; host="${host#https://}"; host="${host%/}"
+          for i in $(seq 1 60); do
+            code=$(curl -ksS -o /dev/null -w "%{http_code}" "https://${host}/v1/server/readyz" || echo 000)
+            [ "$code" = "200" ] && { echo "server ready"; exit 0; }
+            echo "attempt $i: server not ready (http=$code)"; sleep 5
+          done
+          echo "PMM server did not become ready" >&2; exit 1
+
+      - name: Provision client VMs
+        run: |
+          set -Eeuo pipefail
+          host="${SERVER_ADDR#http://}"; host="${host#https://}"; host="${host%/}"
+          chmod +x performance/*.sh
+          for db in ${{ inputs.db_types }}; do
+            PERF_RUN_ID="${PERF_RUN_ID}" \
+              performance/linode_stackScript_load_pmm3.sh \
+                "$host" "${{ inputs.pmm_version }}" "${{ inputs.client_count }}" push "$db"
+          done
+
+      - name: Wait for clients to register and accumulate data
+        run: sleep "$(( ${{ inputs.data_wait_minutes }} * 60 ))"
+
+      - name: Upgrade clients (test_type=upgrade)
+        if: ${{ inputs.test_type == 'upgrade' }}
+        env:
+          PMM_PERF_SSH_KEY: ${{ github.workspace }}/.perf_ssh_key
+        run: |
+          set -Eeuo pipefail
+          umask 077
+          printf '%s' "${{ secrets.PERF_SSH_PRIVATE_KEY }}" > "$PMM_PERF_SSH_KEY"
+          chmod 600 "$PMM_PERF_SSH_KEY"
+          cd performance
+          PERF_RUN_ID="${PERF_RUN_ID}" PMM_PERF_SSH_KEY="$PMM_PERF_SSH_KEY" ./prepare_ansible_client_inventory.sh
+          ./start_upgrade_v3.sh "${{ inputs.pmm_version }}" "${{ inputs.install_repo }}"
+
+      - name: Let metrics settle / spike
+        run: sleep "$(python3 -c "import sys;w='${{ inputs.metrics_window }}';print(int(w[:-1])*({'h':3600,'m':60,'s':1}[w[-1]]))")"
+
+      - name: Collect metrics
+        run: |
+          set -Eeuo pipefail
+          chmod +x performance/ci/collect_metrics.sh
+          performance/ci/collect_metrics.sh \
+            --server "$SERVER_ADDR" \
+            --thresholds performance/ci/thresholds.yml \
+            --window "${{ inputs.metrics_window }}" \
+            --out metrics.json
+          cat metrics.json
+
+      - name: Analyze with the Performance Analyst skill
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: >
+            /performance-analyst Read ./metrics.json and ./performance/ci/thresholds.yml,
+            then write ./perf-verdict.json and ./perf-report.md exactly as the skill's
+            output contract specifies. Do not push, comment, or touch anything else.
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Read,Write,Bash(jq:*),Bash(cat:*)"
+
+      - name: Gate the run on the verdict (green/red)
+        run: |
+          set -Eeuo pipefail
+          test -f perf-verdict.json || { echo "no verdict written -> fail" >&2; exit 1; }
+          cat perf-report.md 2>/dev/null || true
+          jq -e '.status=="pass"' perf-verdict.json >/dev/null \
+            || { echo "performance verdict: FAIL" >&2; exit 1; }
+          echo "performance verdict: PASS"
+
+      - name: Upload report + metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-${{ env.PERF_RUN_ID }}
+          path: |
+            metrics.json
+            perf-report.md
+            perf-verdict.json
+
+      - name: Notify on failure
+        if: failure()
+        continue-on-error: true
+        run: |
+          echo "::warning::perf run ${PERF_RUN_ID} FAILED — clients left up for investigation."
+          echo "Investigate, then run perf-cleanup with run_id=${PERF_RUN_ID}."
+          # TODO: wire a real notification (Slack webhook / routine-fire like notify-investigator.yml).
+
+      - name: Tear down clients on success
+        if: success()
+        env:
+          PMM_PERF_TAG: pmm-qa-perf-run:${{ env.PERF_RUN_ID }}
+        run: performance/teardown_perf_linodes.sh
+        # On failure the batch is intentionally left running for investigation
+        # (meeting: keep ~12h). TODO: a delayed/auto cleanup so a forgotten failed
+        # run can't bill forever — e.g. a scheduled sweep of expired pmm-qa-perf tags.

--- a/performance/ci/collect_metrics.sh
+++ b/performance/ci/collect_metrics.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Sample the performance checks defined in thresholds.yml against a running PMM
+# server and write a JSON summary the Performance Analyst skill then judges.
+#
+# Reads metrics through Grafana's datasource proxy (the same path e2e_tests uses;
+# PMM's /prometheus route 500s on the single-node query path). Self-signed TLS on
+# the PMM server, hence curl -k -- matches the repo's `curl -ksS` convention.
+#
+#   ADMIN_PASSWORD=... collect_metrics.sh --server <host> --thresholds thresholds.yml --out metrics.json
+set -Eeuo pipefail
+
+SERVER="" THRESHOLDS="" OUT="metrics.json" WINDOW="" STEP=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --server)     SERVER="$2"; shift 2 ;;
+    --thresholds) THRESHOLDS="$2"; shift 2 ;;
+    --out)        OUT="$2"; shift 2 ;;
+    --window)     WINDOW="$2"; shift 2 ;;
+    --step)       STEP="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+: "${SERVER:?--server <host> (no scheme) is required}"
+: "${THRESHOLDS:?--thresholds <file> is required}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}"
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "python3 is required (YAML parsing)" >&2; exit 1; }
+
+host="${SERVER#http://}"; host="${host#https://}"; host="${host%/}"
+CURL=(curl -ksS --connect-timeout 10 --max-time 60 -u "admin:${ADMIN_PASSWORD}")
+
+cfg="$(python3 -c 'import sys,yaml,json; json.dump(yaml.safe_load(open(sys.argv[1])), sys.stdout)' "$THRESHOLDS")"
+WINDOW="${WINDOW:-$(printf '%s' "$cfg" | jq -r '.window // "30m"')}"
+STEP="${STEP:-$(printf '%s' "$cfg" | jq -r '.step // "15s"')}"
+
+to_seconds() { case "$1" in *h) echo $(( ${1%h} * 3600 ));; *m) echo $(( ${1%m} * 60 ));; *s) echo "${1%s}";; *) echo "$1";; esac; }
+end="$(date -u +%s)"; start="$(( end - $(to_seconds "$WINDOW") ))"; step_s="$(to_seconds "$STEP")"
+
+uid="$("${CURL[@]}" "https://${host}/graph/api/datasources" | jq -r 'map(select(.type=="prometheus"))[0].uid // empty')"
+[ -n "$uid" ] || { echo "no prometheus datasource found on ${host}" >&2; exit 1; }
+base="https://${host}/graph/api/datasources/proxy/uid/${uid}/api/v1/query_range"
+
+results='[]'
+while read -r check; do
+  promql="$(jq -r '.promql' <<<"$check")"
+  enc="$(jq -rn --arg q "$promql" '$q|@uri')"
+  resp="$("${CURL[@]}" "${base}?query=${enc}&start=${start}&end=${end}&step=${step_s}" 2>/dev/null || echo '{}')"
+  vals="$(jq -c '[.data.result[]?.values[]? ] ' <<<"$resp")"
+  observed="$(jq -n --argjson v "$vals" '
+    ($v | map(.[1]|tonumber)) as $n |
+    { max:   ($n | if length>0 then max else null end),
+      avg:   ($n | if length>0 then (add/length) else null end),
+      last:  ($v | sort_by(.[0]) | if length>0 then (last[1]|tonumber) else null end),
+      samples: ($n | length) }')"
+  results="$(jq -c --argjson c "$check" --argjson o "$observed" \
+    '. + [{name:$c.name, promql:$c.promql, unit:$c.unit, stat:$c.stat, op:$c.op, threshold:$c.max, observed:$o}]' <<<"$results")"
+done < <(printf '%s' "$cfg" | jq -c '.checks[]')
+
+jq -n --arg server "$host" --arg window "$WINDOW" --arg gen "$(date -u +%FT%TZ)" --argjson checks "$results" \
+  '{server:$server, window:$window, generated_at:$gen, checks:$checks}' > "$OUT"
+echo "wrote $(jq '.checks|length' "$OUT") check(s) to $OUT (window=$WINDOW, datasource=$uid)"

--- a/performance/ci/thresholds.yml
+++ b/performance/ci/thresholds.yml
@@ -1,0 +1,38 @@
+# Performance-test checks + thresholds for the "Performance Analyst" skill.
+#
+# TODO(Shruti + Nailya, per the 2026-09-04 perf meeting): confirm the PromQL and
+# the numbers. The queries below are plausible placeholders keyed off standard
+# exporter/process metrics; they have NOT been validated against a live PMM
+# server. collect_metrics.sh runs each `promql` as a range query over the test
+# window and records max/avg/last per check; the skill compares those to `max`.
+#
+# comparison: the recorded statistic is compared to `max` with `op`
+#   stat: max | avg | last     op: lte (value must be <= max) is the only one implemented
+window: 30m          # how far back collect_metrics.sh samples (overridable by the workflow)
+step: 15s            # range-query resolution
+
+checks:
+  - name: exporter_memory_rss_bytes
+    promql: 'max(process_resident_memory_bytes{job=~".*exporter.*"})'
+    stat: max
+    op: lte
+    max: 268435456          # 256 MiB -- PLACEHOLDER
+    unit: bytes
+  - name: exporter_cpu_cores
+    promql: 'max(rate(process_cpu_seconds_total{job=~".*exporter.*"}[5m]))'
+    stat: max
+    op: lte
+    max: 0.5                 # half a core -- PLACEHOLDER
+    unit: cores
+  - name: pmm_server_memory_rss_bytes
+    promql: 'max(process_resident_memory_bytes{job="pmm-managed"})'
+    stat: max
+    op: lte
+    max: 2147483648          # 2 GiB -- PLACEHOLDER
+    unit: bytes
+  - name: pmm_server_cpu_cores
+    promql: 'sum(rate(process_cpu_seconds_total{job=~"pmm-.*"}[5m]))'
+    stat: max
+    op: lte
+    max: 4                   # PLACEHOLDER
+    unit: cores


### PR DESCRIPTION
**Draft** — CI for the performance-testing goal (2026-09-04 meeting). Builds on the `performance/` scripts (merged in #1333).

## Files
- **`perf-provision.yml`** — dispatch: provision N Linode client VMs → install/upgrade test → collect metrics → **Claude verdict gates the run green/red** → notify on fail; cleans up on success or cancel.
- **`perf-cleanup.yml`** — dispatch: tear down a batch by its `pmm-qa-perf-run` tag.
- **`.claude/skills/performance-analyst/SKILL.md`** — judges metrics vs thresholds, writes report + verdict.
- **`performance/ci/collect_metrics.sh`** + **`thresholds.yml`** — sample exporter/server metrics via Grafana's datasource proxy.

## Before merge (stubs)
- **PMM server provisioning** — currently an input (like `ha-e2e-tests.yml`); real provisioner to be wired.
- **Thresholds/PromQL** in `thresholds.yml` — placeholders (Shruti + Nailya).
- **Secrets** — attach to a `pmm-perf-staging` environment.
- **Not yet run in CI** — needs a first live dispatch.

Static-validated (yamllint/shellcheck) only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)