### PR TITLE
PMM-7 Fix PMM-T577 upgrade alerts test for 3.7.0

### DIFF
--- a/e2e_tests/pages/alerts/alertStatus.page.ts
+++ b/e2e_tests/pages/alerts/alertStatus.page.ts
@@ -1,11 +1,18 @@
 import BasePage from '../base.page';
 
 export default class AlertStatusPage extends BasePage {
-  url = 'pmm-ui/alerting/status';
+  // PMM 3.7.0 has no native "pmm-ui/alerting/status" page (that route was added in
+  // a later release and returns "Not found" here). On 3.7.0 alerting lives in the
+  // embedded Grafana UI; firing alert instances are listed on the "Fired alerts"
+  // page inside the Grafana iframe.
+  url = 'pmm-ui/graph/alerting/alerts';
   builders = {
+    // The rule name is rendered as a link in the first column and the State
+    // column ("Triggered by rule", "State", ...) holds the alert instance state,
+    // whose DOM text is the lowercase "active" (CSS capitalises it to "Active").
     firingAlert: (alertName: string) =>
-      this.page.locator(
-        `//td[text()="${alertName}"]/parent::tr//td[position()="2"]//span[contains(text(), "Firing")]`,
+      this.grafanaIframe().locator(
+        `//td[a[contains(text(), "${alertName}")]]/parent::tr//td[position()="2"]//span[contains(translate(text(), "ACTIVE", "active"), "active")]`,
       ),
   };
   buttons = {};

--- a/e2e_tests/tests/upgrade/alerts.test.ts
+++ b/e2e_tests/tests/upgrade/alerts.test.ts
@@ -17,6 +17,10 @@ pmmTest.describe('PMM Alerts tests for upgrade', () => {
       // release); "Insight" is a default PMM folder present on 3.7.0.
       const folder = await api.alertingApi.getFolderByName('Insight');
 
+      // Use a 0% CPU-load threshold so the rule fires deterministically: any node
+      // always has some non-idle CPU, so the alert reaches the firing state even on
+      // an otherwise idle CI runner. A non-zero threshold (e.g. 1%) sits at the idle
+      // noise floor and makes the alert flap in and out of firing.
       await api.alertingApi.createRule(GrafanaHelper.getAuthHeader(), {
         filters: [{ label: 'node_name', regexp: 'pmm-server', type: 'FILTER_TYPE_MATCH' }],
         folder_uid: folder.uid,
@@ -24,7 +28,7 @@ pmmTest.describe('PMM Alerts tests for upgrade', () => {
         group: 'upgrade test group',
         interval: '10s',
         name: upgradeRuleName,
-        params: [{ float: 1, name: 'threshold', type: 'PARAM_TYPE_FLOAT' }],
+        params: [{ float: 0, name: 'threshold', type: 'PARAM_TYPE_FLOAT' }],
         template_name: 'pmm_node_high_cpu_load',
       });
 


### PR DESCRIPTION
## What

Fixes the `@pre-upgrade` alerts test (`e2e_tests/tests/upgrade/alerts.test.ts` → **PMM-T577 - Verify user is able to create and see firing alerts before upgrade**) that fails on PMM Server **3.7.0** in the [upgrade pipeline](https://github.com/percona/pmm-qa/actions/runs/34096343174/job/101660759847).

## Why it failed

Two independent problems, both specific to 3.7.0:

1. **Wrong page (the actual failure).** `AlertStatusPage` navigated to the native `pmm-ui/alerting/status` page. That React route does not exist on 3.7.0 (it was added in a later release) — the page renders **"Not found"**, so the firing-alert locator never matched and the test timed out on all three retries. On 3.7.0 alerting lives in the **embedded Grafana UI**.
2. **Fragile threshold.** The rule used a `pmm_node_high_cpu_load` template with a **1%** CPU-load threshold. That expression is CPU-utilisation-percent, and 1% sits right at an idle node's noise floor, so the alert flaps in and out of firing on an idle CI runner.

## The fix

- Point `AlertStatusPage` at the 3.7.0 **"Fired alerts"** page, `pmm-ui/graph/alerting/alerts`, and read the alert from **inside the Grafana iframe** (`this.grafanaIframe()`, matching the pattern already used by `AdvisorsPage`). On this page the alert-instance **State** column DOM text is the lowercase `"active"` (CSS capitalises it to "Active"), not "Firing" — the locator matches it case-insensitively.
- Lower the rule's CPU-load threshold from **1% → 0%** so it fires deterministically: any node always has some non-idle CPU above 0%.

## Verification

Reproduced and fixed against a **live PMM Server 3.7.0** (`percona/pmm-server:3.7.0`):

- Before: the target page renders "Not found"; test times out (reproduced the CI failure locally).
- After: the rule reaches the firing state and the `@pre-upgrade` test **passes in ~35–47s**, well within the 2-minute timeout (two consecutive clean runs from a fresh rule).
- `eslint` and `prettier --check` are clean on both changed files.

## Scope

Only the pre-upgrade alerts test and its page object are touched; no post-upgrade counterpart references this rule/page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gx4ippDH1dvDXFkiWucvKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gx4ippDH1dvDXFkiWucvKG)_