### PR TITLE
PMM-7 Fix pre-upgrade alerts test for PMM 3.6.0

### DIFF
--- a/e2e_tests/api/alerting.api.ts
+++ b/e2e_tests/api/alerting.api.ts
@@ -60,6 +60,22 @@ export default class AlertingApi {
     return await (await this.request.get(apiEndpoints.alerting.folders, { headers: authHeaders })).json();
   };
 
+  getAlertRuleState = async (ruleName: string, headers?: Headers): Promise<string | undefined> => {
+    const authHeaders = headers ? headers : GrafanaHelper.getAuthHeader();
+    const response = await this.request.get(apiEndpoints.alerting.listAlerts, { headers: authHeaders });
+    const body = await response.json();
+
+    for (const group of body?.data?.groups ?? []) {
+      const rule = (group.rules ?? []).find((item: { name?: string }) => item.name === ruleName);
+
+      if (rule) {
+        return rule.state;
+      }
+    }
+
+    return undefined;
+  };
+
   listTemplates = async (headers: Headers) => this.request.get(apiEndpoints.alerting.templates, { headers });
 
   updateTemplate = async (headers: Headers, templateName: string, yamlBody: AlertTemplateBody) =>

--- a/e2e_tests/tests/upgrade/alerts.test.ts
+++ b/e2e_tests/tests/upgrade/alerts.test.ts
@@ -12,8 +12,8 @@ pmmTest.describe('PMM Alerts tests for upgrade', () => {
 
   pmmTest(
     'PMM-T577 - Verify user is able to create and see firing alerts before upgrade @pre-upgrade',
-    async ({ alertStatusPage, api, page }) => {
-      const folder = await api.alertingApi.getFolderByName('PMM Health');
+    async ({ api }) => {
+      const folder = await api.alertingApi.getFolderByName('Insight');
 
       await api.alertingApi.createRule(GrafanaHelper.getAuthHeader(), {
         filters: [{ label: 'node_name', regexp: 'pmm-server', type: 'FILTER_TYPE_MATCH' }],
@@ -26,10 +26,12 @@ pmmTest.describe('PMM Alerts tests for upgrade', () => {
         template_name: 'pmm_node_high_cpu_load',
       });
 
-      await page.goto(alertStatusPage.url);
-      await expect(alertStatusPage.builders.firingAlert(upgradeRuleName)).toBeVisible({
-        timeout: Timeouts.TWO_MINUTES,
-      });
+      await expect
+        .poll(() => api.alertingApi.getAlertRuleState(upgradeRuleName), {
+          message: `Expected alert rule "${upgradeRuleName}" to be firing`,
+          timeout: Timeouts.TWO_MINUTES,
+        })
+        .toBe('firing');
     },
   );
 });


### PR DESCRIPTION
## What

Fixes the `@pre-upgrade` **PMM-T577** alerts test (`e2e_tests/tests/upgrade/alerts.test.ts`) so it passes against the PMM **3.6.0** baseline used by the upgrade suite.

## Why

The [PMM Upgrade run for 3.6.0](https://github.com/percona/pmm-qa/actions/runs/34096343174/job/101660759883) failed in the pre-upgrade step with:

```
Error: Folder with name: PMM Health not found
    at AlertingApi.getFolderByName (e2e_tests/api/alerting.api.ts:51)
```

Two things in the migrated test assume a newer PMM than 3.6.0:

1. **`getFolderByName('PMM Health')`** — the `PMM Health` alerting folder does not exist in 3.6.0. Its default folders are `Insight`, `MySQL`, `OS`, `MongoDB`, `PostgreSQL`, … (verified against `graph/api/folders` on a live `percona/pmm-server:3.6.0`).
2. **The firing check navigated to `pmm-ui/alerting/status`** — that route does not exist in 3.6.0's UI; it renders the pmm-ui *"Not found"* page, so the assertion could never pass (this is why the test still timed out after the folder was fixed).

## Changes

- Use the **`Insight`** folder, which is present in 3.6.0.
- Verify the rule reaches the **`firing`** state via the Grafana rules API (`graph/api/prometheus/grafana/api/v1/rules`, already defined as `apiEndpoints.alerting.listAlerts`) instead of the missing UI page. This mirrors the original API-based verification of PMM-T577 and is robust across versions. Added `AlertingApi.getAlertRuleState` for that.

## Verification

Ran the test against a live `percona/pmm-server:3.6.0` container:

```
✓ 1 [chromium] › tests/upgrade/alerts.test.ts:13 › PMM-T577 - ... before upgrade @pre-upgrade (39.3s)
  1 passed (40.5s)
```

The rule fires (`state: firing`) within ~40s and the API assertion confirms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfpQ14ibvyiMkUJ8W6KvCF

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfpQ14ibvyiMkUJ8W6KvCF)_