### PR TITLE
Increase service status wait timeout in MySQL slowlog agent test

### DIFF
--- a/e2e_tests/tests/cli/mysql/mysqlSlowlogChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/mysql/mysqlSlowlogChangeAgent.test.ts
@@ -411,7 +411,7 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
 
       await grafanaHelper.authorize();
       await page.goto(servicesPage.url);
-      await servicesPage.waitForServiceStatus(serviceName, 'Down', Timeouts.TWO_MINUTES);
+      await servicesPage.waitForServiceStatus(serviceName, 'Down', Timeouts.FIVE_MINUTES);
 
       commands = [
         `docker exec ${containerName} pmm-admin inventory change agent mysqld-exporter ${mysqldExporterId} --tls-cert-file=/certs/client.crt --tls-key-file=/certs/client.key --tls-ca-file=/certs/ca-certs.pem --tls --tls-skip-verify`,
@@ -419,7 +419,7 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
       ];
 
       commands.forEach((command) => cliHelper.execSilent(command));
-      await servicesPage.waitForServiceStatus(serviceName, 'Up', Timeouts.TWO_MINUTES);
+      await servicesPage.waitForServiceStatus(serviceName, 'Up', Timeouts.FIVE_MINUTES);
     },
   );
 


### PR DESCRIPTION
Increase the timeout for service status checks in the MySQL slowlog agent change functionality test from 2 minutes to 5 minutes.

**Changes:**
- Updated `waitForServiceStatus` timeout from `Timeouts.TWO_MINUTES` to `Timeouts.FIVE_MINUTES` for both the 'Down' and 'Up' status checks after running pmm-admin inventory change agent commands

**Rationale:**
The test was experiencing timeout issues when waiting for services to transition states after agent configuration changes. The increased timeout provides more time for the service status to update in the UI, reducing flakiness in the test execution.

https://claude.ai/code/session_01BEWcNaYW5sgkf7i5woFkkE