### PR TITLE
Add e2e test for postgres exporter auto-discovery limit

### DIFF
--- a/e2e_tests/tests/cli/pgsql/pgsqlChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/pgsql/pgsqlChangeAgent.test.ts
@@ -386,6 +386,27 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
   );
 
   pmmTest(
+    'PMM-T1017 - Verify Change agent auto-discovery limit @pgsm-pmm-integration',
+    async ({ api, cliHelper }) => {
+      const autoDiscoveryLimit = 25;
+
+      await cliHelper
+        .execSilent(
+          `docker exec ${containerName} pmm-admin inventory change agent postgres-exporter ${pgExporterId} --auto-discovery-limit=${autoDiscoveryLimit}`,
+        )
+        .assertSuccess()
+        .outContains(`- changed auto-discovery limit to ${autoDiscoveryLimit}`);
+
+      const agent = await api.inventoryApi.getAgentById(pgExporterId);
+
+      expect(
+        agent.postgresql_options?.auto_discovery_limit,
+        'Auto-discovery limit was not persisted on the postgresql_exporter agent',
+      ).toEqual(autoDiscoveryLimit);
+    },
+  );
+
+  pmmTest(
     'PMM-T1013 - Verify Change agent skip connection check @pgsm-pmm-integration',
     async ({ cliHelper, grafanaHelper, page, servicesPage }) => {
       let commands = [


### PR DESCRIPTION
## What

Add an e2e CLI test case for the `pmm-admin inventory change agent` command with the postgres-exporter agent:

- **PMM-T1017**: Verify `--auto-discovery-limit` sets the auto-discovery limit on the postgres-exporter and persists the value.

## Why

Mirrors the recently added perfschema change-agent flag tests, extending change-agent coverage to the postgres-exporter `--auto-discovery-limit` flag.

## Verification

The test executes the CLI command, asserts the success change message (`- changed auto-discovery limit to <N>`), then confirms the value is persisted by reading `postgresql_options.auto_discovery_limit` back through the inventory API.

Added to `e2e_tests/tests/cli/pgsql/pgsqlChangeAgent.test.ts`, tagged `@pgsm-pmm-integration`, matching the surrounding tests' style and placement (before the connection-affecting/skip-connection-check cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbmakubB2xzHRgnDewFt7g

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbmakubB2xzHRgnDewFt7g)_