### PR TITLE
Add e2e test for slowlog max file size change agent

### DIFF
--- a/e2e_tests/tests/cli/mysql/mysqlSlowlogChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/mysql/mysqlSlowlogChangeAgent.test.ts
@@ -379,6 +379,27 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
   );
 
   pmmTest(
+    'PMM-T1018 - Verify Change agent max slowlog file size @ps-slowlog-integration',
+    async ({ api, cliHelper }) => {
+      const maxSlowlogFileSize = '104857600';
+
+      await cliHelper
+        .execSilent(
+          `docker exec ${containerName} pmm-admin inventory change agent qan-mysql-slowlog-agent ${mysqldSlowlogAgentId} --max-slowlog-file-size=${maxSlowlogFileSize}`,
+        )
+        .assertSuccess()
+        .outContains(`- changed max slowlog file size to ${maxSlowlogFileSize}`);
+
+      const agent = await api.inventoryApi.getAgentById(mysqldSlowlogAgentId);
+
+      expect(
+        agent.max_query_log_size,
+        'Max slowlog file size was not persisted on the qan_mysql_slowlog_agent',
+      ).toEqual(maxSlowlogFileSize);
+    },
+  );
+
+  pmmTest(
     'PMM-T1010 - Verify Change agent tls @ps-slowlog-integration',
     async ({ cliHelper, grafanaHelper, page, servicesPage }) => {
       const confPath = `/etc/mysql/mysql.conf.d/mysqld.cnf`;


### PR DESCRIPTION
## What

Add an e2e CLI test case for the `pmm-admin inventory change agent` command with the qan-mysql-slowlog-agent:

- **PMM-T1018**: Verify `--max-slowlog-file-size` sets the maximum slowlog file size on the slowlog QAN agent and persists the value.

## Why

Extends the slowlog change-agent coverage (alongside the existing disable-query-examples, max-query-length and comments-parsing cases) to the `--max-slowlog-file-size` flag.

## Verification

The test executes the CLI command, asserts the success change message (`- changed max slowlog file size to <N>`), then confirms the value is persisted by reading `max_query_log_size` back through the inventory API. The field is an `int64` in the API, serialized as a string in JSON, so the value is set and asserted as a string.

Added to `e2e_tests/tests/cli/mysql/mysqlSlowlogChangeAgent.test.ts`, tagged `@ps-slowlog-integration`, matching the surrounding tests' style and placed before the TLS case (where MySQL is reconfigured to require secure transport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbmakubB2xzHRgnDewFt7g

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbmakubB2xzHRgnDewFt7g)_