### PR TITLE
Drop ignored numeric arg from seeElement/dontSeeElement

### DIFF
--- a/codeceptjs-e2e/tests/upgrade/advisorsAlerting_test.js
+++ b/codeceptjs-e2e/tests/upgrade/advisorsAlerting_test.js
@@ -153,7 +153,7 @@ Scenario(
     I, homePage,
   }) => {
     await homePage.open();
-    I.dontSeeElement(homePage.fields.sttDisabledFailedChecksPanelSelector, 15);
+    I.dontSeeElement(homePage.fields.sttDisabledFailedChecksPanelSelector);
     I.waitForVisible(homePage.fields.failedChecksPanelContent, 30);
   },
 );

--- a/codeceptjs-e2e/tests/upgrade/annotationsPrometheus_test.js
+++ b/codeceptjs-e2e/tests/upgrade/annotationsPrometheus_test.js
@@ -49,6 +49,5 @@ Data(clientDbServices).Scenario(
     I.amOnPage(dashboardUrl);
     dashboardPage.waitForDashboardOpened();
     dashboardPage.verifyAnnotationsLoaded(annotationName);
-    I.seeElement(dashboardPage.annotationText(annotationName));
   },
 );

--- a/codeceptjs-e2e/tests/upgrade/annotationsPrometheus_test.js
+++ b/codeceptjs-e2e/tests/upgrade/annotationsPrometheus_test.js
@@ -49,6 +49,6 @@ Data(clientDbServices).Scenario(
     I.amOnPage(dashboardUrl);
     dashboardPage.waitForDashboardOpened();
     dashboardPage.verifyAnnotationsLoaded(annotationName);
-    I.seeElement(dashboardPage.annotationText(annotationName), 10);
+    I.seeElement(dashboardPage.annotationText(annotationName));
   },
 );

--- a/codeceptjs-e2e/tests/verifyRemoteInstances_test.js
+++ b/codeceptjs-e2e/tests/verifyRemoteInstances_test.js
@@ -241,21 +241,21 @@ Scenario('PMM-T1089 - Verify UI elements for PostgreSQL Instance @fb-instances',
   I.click(remoteInstancesPage.fields.addService);
   remoteInstancesPage.checkRequiredField();
   // Verify fields on the page
-  I.seeElement(remoteInstancesPage.fields.hostName, 30);
-  I.seeElement(remoteInstancesPage.fields.serviceName, 30);
-  I.seeElement(remoteInstancesPage.fields.portNumber, 30);
-  I.seeElement(remoteInstancesPage.fields.userName, 30);
-  I.seeElement(remoteInstancesPage.fields.password, 30);
-  I.seeElement(remoteInstancesPage.fields.environment, 30);
-  I.seeElement(remoteInstancesPage.fields.region, 30);
-  I.seeElement(remoteInstancesPage.fields.availabilityZone, 30);
-  I.seeElement(remoteInstancesPage.fields.replicationSet, 30);
-  I.seeElement(remoteInstancesPage.fields.cluster, 30);
-  I.seeElement(remoteInstancesPage.fields.customLabels, 30);
-  I.seeElement(remoteInstancesPage.fields.skipConnectionCheck, 30);
-  I.seeElement(remoteInstancesPage.fields.dontTrackingRadio, 30);
-  I.seeElement(remoteInstancesPage.fields.pgStatStatementsRadio, 30);
-  I.seeElement(remoteInstancesPage.fields.pgStatMonitorRadio, 30);
+  I.seeElement(remoteInstancesPage.fields.hostName);
+  I.seeElement(remoteInstancesPage.fields.serviceName);
+  I.seeElement(remoteInstancesPage.fields.portNumber);
+  I.seeElement(remoteInstancesPage.fields.userName);
+  I.seeElement(remoteInstancesPage.fields.password);
+  I.seeElement(remoteInstancesPage.fields.environment);
+  I.seeElement(remoteInstancesPage.fields.region);
+  I.seeElement(remoteInstancesPage.fields.availabilityZone);
+  I.seeElement(remoteInstancesPage.fields.replicationSet);
+  I.seeElement(remoteInstancesPage.fields.cluster);
+  I.seeElement(remoteInstancesPage.fields.customLabels);
+  I.seeElement(remoteInstancesPage.fields.skipConnectionCheck);
+  I.seeElement(remoteInstancesPage.fields.dontTrackingRadio);
+  I.seeElement(remoteInstancesPage.fields.pgStatStatementsRadio);
+  I.seeElement(remoteInstancesPage.fields.pgStatMonitorRadio);
 });
 
 Data(remotePostgreSQL).Scenario(


### PR DESCRIPTION
## What failed

`PMM-T1089 - Verify UI elements for PostgreSQL Instance @fb-instances` dies on its first assertion:

```
TypeError: locator.replace is not a function
    at isXPath (codeceptjs/lib/locator.js:711:27)
    at new Locator (codeceptjs/lib/locator.js:55:9)
    at handleRoleLocator (codeceptjs/lib/helper/Playwright.js:4202:15)
    at Playwright.findElements (codeceptjs/lib/helper/Playwright.js:4228:30)
✖ I.seeElement("$address-text-input", 30)
```

Seen on https://github.com/percona/pmm-qa/actions/runs/34121606545 (job `@fb-instances`).

## Root cause — the CodeceptJS 4 upgrade

The Playwright helper's signature changed:

| | v3.7.6 | v4.1.0 |
|---|---|---|
| `seeElement` | `(locator)` | `(locator, context = null)` |
| `dontSeeElement` | `(locator)` | `(locator, context = null)` |

`I.seeElement(locator, 30)` passed a number that v3 silently discarded. In v4 it is a **context locator**, so `_locate(30)` → `findElements(ctx, 30)` → `handleRoleLocator` → `new Locator(30)` → `isXPath(30)` calls `.replace()` on a number.

Confirmed directly against the installed version:

```
FAIL new Locator(30)                    -> TypeError: locator.replace is not a function
OK   new Locator("$address-text-input") -> isRole=false value=$address-text-input
```

This is a `main`-branch breakage inherited from the CodeceptJS 4 upgrade, not something the currently-failing feature PRs introduced.

## The fix

Removed the dead argument at all 17 call sites — 15 in `verifyRemoteInstances_test.js`, plus two latent ones that would fail identically when those upgrade suites next run:

- `tests/upgrade/annotationsPrometheus_test.js:52` — `seeElement(annotationText(...), 10)`
- `tests/upgrade/advisorsAlerting_test.js:156` — `dontSeeElement(sttDisabledFailedChecksPanelSelector, 15)`

**Behaviour-preserving, not a weakened assertion.** `seeElement` never waited, so these numbers were inert under v3 too; every call site is already preceded by a real wait (`checkRequiredField()`, `verifyAnnotationsLoaded()`, `homePage.open()`).

A follow-up commit (`8d7ddbd`, from review feedback) then deletes the `annotationsPrometheus_test.js` line outright: `verifyAnnotationsLoaded(title)` already ends with `I.waitForVisible(this.annotationText(title), 30)` on the identical locator, so once the inert `10` was gone that `seeElement` could not fail without the wait failing first. The wait still covers the check. The other two sites were checked for the same redundancy and are not duplicates.

## Sweep for the rest of the class

Diffed the v3.7.6 and v4.1.0 packages and checked each breakage class against the repo with an AST sweep (regex misses multi-line calls and non-numeric args).

**Extra args now consumed as `context`** — ten methods changed signature: `seeElement`, `dontSeeElement`, and `+context` on `fillField` / `appendField` / `seeInField` / `dontSeeInField` / `attachFile` / `selectOption`; `clearField` had its second parameter reinterpreted from `options` to `context`; `click` only gained a default. Sweep over all 221 files: **0 remaining suspect calls**, and `clearField` is never called with a second argument.

**Removed methods** — `clickLink`, `restartBrowser` (Playwright) and `I.retry` / `I.limitTime` (actor). Built the full v4 `I.*` surface (322 methods: Playwright + FileSystem + REST + base Helper + 9 local helpers + 3 third-party + `custom_steps.js` actor steps) and checked every `I.*` call against it — **nothing missing**. The ~50 `.retry(n)` calls are `Scenario()` / `Feature()` config, a different and unchanged API.

**Config and plugins** — helper defaults gained only `onResponse` and `strict`, and `strict: false` preserves the permissive locator behaviour. `restart: true` still maps to the browser strategy. `autoDelay` and `customLocator` differ by ESM conversion only. `FileSystem` and `REST` have no surface change. The third-party helpers declare peer `codeceptjs ^3` but import no CodeceptJS internals — they use the `codecept_helper` global, which v4 still sets — so that range is stale metadata, not an incompatibility.

## Verification

- **The failing job is green on this branch.** `FB E2E tests / Instances UI tests / e2e tests: @fb-instances` ([job 101792121119](https://github.com/percona/pmm-qa/actions/runs/34137614242/job/101792121119)) passed on `ef15b0a` — `PMM-T1089` now passes against a live PMM server, which is the conclusive signal for this fix.
- Reproduced the exact error causally (above), and confirmed the string locator the test actually wants resolves fine.
- Both sweeps were validated against positive controls before their empty results were trusted: the extra-arg sweep flagged all 17 known sites when run against the pre-fix commit, and the surface sweep flagged `clickLink`, `restartBrowser`, `limitTime` and a nonsense method in a synthetic file.
- `node --check` clean on all three files.

Note on the `Lint` check: `lint-changed.sh` selects only `.ts`, so it does not cover `codeceptjs-e2e/**/*.js` — a green `Lint` here says nothing about these three files. The e2e run above is the gate that matters.

The two `tests/upgrade/` scenarios are not exercised by this PR's CI (they run in the upgrade suites), so those two sites rest on the static argument above rather than on a passing run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bq6Ra5k83aF4qgcTQ6Xh9M