### PR TITLE
Fix PMM-T2003 URL wait broken by CodeceptJS 4

### DIFF
--- a/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
+++ b/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
@@ -134,8 +134,6 @@ Scenario(
     dashboardPage.mongodbInstancesCompareDashboard.unselectCluster();
 
     dashboardPage.mongodbInstancesCompareDashboard.selectReplicationSet('rs');
-    // Not waitInUrl: it resolves a relative argument against the base URL, turning a
-    // bare query fragment into an unmatchable "<baseUrl>/&var-replication_set=rs".
     I.waitForURL(/[?&]var-replication_set=rs(&|$)/, { timeout: 10000 });
     dashboardPage.mongodbInstancesCompareDashboard.unselectReplicationSet();
 

--- a/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
+++ b/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
@@ -134,7 +134,9 @@ Scenario(
     dashboardPage.mongodbInstancesCompareDashboard.unselectCluster();
 
     dashboardPage.mongodbInstancesCompareDashboard.selectReplicationSet('rs');
-    I.waitInUrl('&var-replication_set=rs', 2);
+    // Not waitInUrl: it resolves a relative argument against the base URL, turning a
+    // bare query fragment into an unmatchable "<baseUrl>/&var-replication_set=rs".
+    I.waitForURL(/[?&]var-replication_set=rs(&|$)/, { timeout: 10000 });
     dashboardPage.mongodbInstancesCompareDashboard.unselectReplicationSet();
 
     dashboardPage.mongodbInstancesCompareDashboard.selectNode([mongoServices[0]]);


### PR DESCRIPTION
## Failures fixed (investigator)

- source: nightly CI run https://github.com/percona/pmm-qa/actions/runs/34161536267 (`Nightly E2E tests Matrix (remote PMM Server)`, job `test execution / @nightly`) — same failure in https://github.com/percona/pmm-qa/actions/runs/34160212296
- tests:
  - `codeceptjs-e2e/tests/verifyMongodbDashboards_test.js:137` / `@nightly` — PMM-T2003 - Verify that MongoDB Compare dashboard has Cluster, Replication, Node filters

## What failed

```
expected url to include https://18.188.142.15/&var-replication_set=rs, but found
https://18.188.142.15/graph/d/mongodb-instance-compare/mongodb-instances-compare?from=now-5m&to=now
&refresh=5s&timezone=browser&var-interval=$__auto&orgId=1&var-environment=$__all&var-cluster=$__all
&var-node_name=$__all&var-replication_set=rs&var-service_name=$__all
  at I.waitInUrl("&var-replication_set=rs", 2)
```

The URL in the "but found" half already contains `&var-replication_set=rs`, so the message reads
like a flaky 2-second timeout. It isn't — the expected string is exactly what is searched for.

## Root cause — the test, not the product

`#1315` bumped `codeceptjs` **3.7.9 → 4.1.0** (2026-09-04). In 4.x, `waitInUrl` resolves a relative
argument against the configured base URL before matching:

```js
// codeceptjs 4.1.0, lib/helper/Playwright.js:3424
const expectedUrl = resolveUrl(urlPart, this.options.url)   // new URL(urlPart, baseUrl).href
return this.page.waitForFunction(urlPart => …indexOf(urlPart) > -1, expectedUrl, …)
```

3.7.9 passed the raw `urlPart` straight into the predicate. So `'&var-replication_set=rs'` is now
searched for as `https://<host>/&var-replication_set=rs`, a string no URL can ever contain — the
scenario cannot pass on 4.x, and both of the run's retries failed identically.

The Playwright trace from the failing run confirms the timing reading is wrong: `var-replication_set=rs`
was in the main-frame URL at **34.18 s**, and the `waitInUrl` predicate only started at **35.38 s** and
still "timed out" 2 s later. PMM is fine — Grafana had already applied the variable and synced the URL.

This is the first nightly since the bump that actually ran the scenario: the previous green run
([34068808442](https://github.com/percona/pmm-qa/actions/runs/34068808442)) logged
`Launchable subset is empty. Test execution will be skipped.` and executed zero tests.

## The fix

Match the URL directly with a regex, which no base-URL resolution can rewrite:

```js
I.waitForURL(/[?&]var-replication_set=rs(&|$)/, { timeout: 10000 });
```

`page.waitForURL` takes a RegExp verbatim, so this is immune to the class of change that broke the
original call.

### Other `waitInUrl` call sites — checked, no change needed

| Call site | Verdict |
|---|---|
| `tests/verifyMysqlDashboards_test.js:184-185` (`'&var-username=root'`, `'from=now-12h&to=now'`) | Same latent breakage, but the scenario is `xScenario` (skipped) |
| `tests/QAN/filters_test.js:260-263` (`shortCutLink.split('?var-')[1]`) | Same latent breakage, but the whole scenario is inside a `/** … */` comment block |
| `tests/leftNavigation_migrated.js:47` | Commented out |
| `tests/ia/common_test.js:16`, `tests/configuration/verifyPMMSettingsPageFunctionality_test.js:158` | Pass a relative **path**, which `resolveUrl` handles correctly |

Left alone rather than widening this PR; if either disabled scenario is re-enabled it needs the same treatment.

## Verification

Throwaway Linode VM, `perconalab/pmm-server:3.9.1-rc` at `sha256:003f9c25f842…` — byte-identical to
the digest the failing run recorded to Launchable — client `pmm3-rc`, setup
`--database psmdb,SETUP_TYPE=pss` (the `rs101/rs102/rs103` replica set the scenario needs).

| Revision | codeceptjs | PMM-T2003 |
|---|---|---|
| `main` (e7f35d7) | 4.1.0 | **FAIL**, same message: `expected url to include https://127.0.0.1:8443/&var-replication_set=rs` |
| `6f891ab` (parent of the bump #1315) | 3.7.9 | PASS |
| this branch | 4.1.0 | **PASS ×3** (44.6 s / 44.5 s / 45.6 s) |

The pre-bump run pins the regression window to #1315 rather than to an older latent problem, and the
failure is deterministic (a string match that can never succeed), so no load-vs-idle comparison was
needed to rule out contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sy2in6JgLjQi7hRLSUwY8

---
_Generated by [Claude Code](https://claude.ai/code/session_019sy2in6JgLjQi7hRLSUwY8)_