### PR TITLE
Fix the two failing @nightly tests, and stop the skipped Claude runs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,8 +3,6 @@ name: Claude Code
 on:
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
 
 jobs:
   claude:

--- a/codeceptjs-e2e/tests/pages/dashboardPage.js
+++ b/codeceptjs-e2e/tests/pages/dashboardPage.js
@@ -1196,6 +1196,7 @@ module.exports = {
     for (const i in metrics) {
       I.pressKey('PageDown');
       await this.expandEachDashboardRow();
+      await this.scrollBackToPanel(this.graphsLocator(metrics[i]));
       I.waitForElement(this.graphsLocator(metrics[i]), 5);
       I.scrollTo(this.graphsLocator(metrics[i]));
     }
@@ -1205,8 +1206,22 @@ module.exports = {
     for (const i in metrics) {
       I.pressKey('PageDown');
       await this.expandEachDashboardRow();
+      await this.scrollBackToPanel(this.graphsLocatorPartialMatch(metrics[i]));
       I.waitForElement(this.graphsLocatorPartialMatch(metrics[i]), 5);
       I.scrollTo(this.graphsLocatorPartialMatch(metrics[i]));
+    }
+  },
+
+  // The metric walk pages down blindly and Grafana unmounts whatever is off-screen, so a
+  // panel can be scrolled past. Step back up until it is mounted again; a panel that is
+  // genuinely missing still fails on the wait that follows.
+  async scrollBackToPanel(panelLocator, pages = 3) {
+    let attempts = 0;
+
+    while (attempts < pages && await I.grabNumberOfVisibleElements(panelLocator) === 0) {
+      I.pressKey('PageUp');
+      I.wait(1);
+      attempts += 1;
     }
   },
 

--- a/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
+++ b/codeceptjs-e2e/tests/verifyMongodbDashboards_test.js
@@ -134,7 +134,7 @@ Scenario(
     dashboardPage.mongodbInstancesCompareDashboard.unselectCluster();
 
     dashboardPage.mongodbInstancesCompareDashboard.selectReplicationSet('rs');
-    I.waitInUrl('&var-replication_set=rs', 2);
+    I.waitForURL(/[?&]var-replication_set=rs(&|$)/, { timeout: 10000 });
     dashboardPage.mongodbInstancesCompareDashboard.unselectReplicationSet();
 
     dashboardPage.mongodbInstancesCompareDashboard.selectNode([mongoServices[0]]);


### PR DESCRIPTION
## Failures fixed (investigator)

- source: nightly CI run https://github.com/percona/pmm-qa/actions/runs/34160212296 (`Nightly E2E tests Matrix (remote PMM Server)`, job `test execution / @nightly`, `INSTALLATION_TYPE=ami`, `perconalab/pmm-server:3.9.1-rc`) — both tests failed again in the next run, https://github.com/percona/pmm-qa/actions/runs/34161536267
- tests:
  - `codeceptjs-e2e/tests/verifyMongodbDashboards_test.js:137` / `@nightly` — PMM-T2003 - Verify that MongoDB Compare dashboard has Cluster, Replication, Node filters
  - `codeceptjs-e2e/tests/dashboards/verifyPostgresqlDashboards_test.js:84` / `@nightly @dashboards` — PMM-T2048 - Verify PostgreSQL Instances Overview Extended metrics

Consolidated on request so the whole nightly goes green in one merge: this PR carries **#1352** (PMM-T2003) and **#1355** (skipped Claude workflow runs) as their original commits, plus the PMM-T2048 fix. Close #1352 and #1355 in favour of this one.

## 1. PMM-T2003 — `waitInUrl` broke in codeceptjs 4 (from #1352)

Deterministic, not flaky — the scenario cannot pass on 4.x.

```
expected url to include https://<host>/&var-replication_set=rs, but found
https://<host>/graph/d/mongodb-instance-compare/…&var-replication_set=rs&var-service_name=$__all
  at I.waitInUrl("&var-replication_set=rs", 2)
```

The URL in the "but found" half already contains the fragment, so the message reads like a flaky 2-second timeout. It is not: #1315 bumped codeceptjs **3.7.9 → 4.1.0** (2026-09-04), and 4.x resolves a relative `waitInUrl` argument against the base URL before matching (`const expectedUrl = resolveUrl(urlPart, this.options.url)`). `'&var-replication_set=rs'` is therefore searched for as `https://<host>/&var-replication_set=rs`, a string no URL can contain.

Fixed by matching with a regex, which no base-URL resolution can rewrite:

```js
I.waitForURL(/[?&]var-replication_set=rs(&|$)/, { timeout: 10000 });
```

### Other `waitInUrl` call sites — checked, left alone

| Call site | Verdict |
|---|---|
| `tests/verifyMysqlDashboards_test.js:184-185` | Same latent breakage, but the scenario is `xScenario` (skipped) |
| `tests/QAN/filters_test.js:261` | Same latent breakage, but the scenario sits inside a `/** … */` block |
| `tests/leftNavigation_migrated.js:47` | Commented out |
| `tests/ia/common_test.js:16`, `tests/configuration/verifyPMMSettingsPageFunctionality_test.js:158` | Pass a relative **path**, which `resolveUrl` handles correctly |

Only live tests are touched; if a disabled scenario is re-enabled it needs the same treatment.

## 2. PMM-T2048 — the panel walk overshoots panels Grafana has unmounted

Intermittent: 1 of 3 idle repro runs failed, on a different panel each time (CI: `Active Connections`; repro: `Top 5 Fsync calls by a backend`).

```
element ([data-testid*="data-testid Panel header"][data-testid*="Active Connections"])
still not present on page after 5 sec
  at I.waitForElement(…, 5) at Object.verifyMetricsExistencePartialMatch (./tests/pages/dashboardPage.js:1208:9)
```

`verifyMetricsExistence` / `verifyMetricsExistencePartialMatch` walk a dashboard top-down, pressing `PageDown` once before each panel check. Grafana keeps only the panels around the viewport mounted, so one `PageDown` can scroll a whole row past the viewport and leave its panels out of the DOM — the 5s wait then fails on a panel that is really there. The failure screenshot shows the page parked at *Tuples Details*, two sections below the *Connections Details* row being asserted on, with the dashboard rendering normally. `Active Connections` is in `PostgreSQL_Overview_Extended.json`, right next to `Top 5 Active Connections`, which the previous step of the same run matched successfully.

Fixed by stepping back up to three pages until the panel is mounted again. The `waitForElement` that follows is unchanged, so a panel that is genuinely missing fails exactly as before. Both walkers get it because both have live callers — `verifyMetricsExistencePartialMatch` is what PMM-T2048 uses, `verifyMetricsExistence` is used by PMM-T2050/T2049 and the MySQL, MongoDB, OS and VM dashboard scenarios.

One step back is not enough: a revision of this branch that pressed `PageUp` once failed on its first repro run, on `Top 5 Rollbacks Transactions`.

## 3. Claude workflow: a skipped run per review comment (from #1355)

`.github/workflows/claude.yml` no longer subscribes to `pull_request_review_comment`; `issue_comment: [created]` stays, so `@claude` still works from the PR or issue timeline. GitHub creates the run the moment the event arrives, so the job's `if: contains(github.event.comment.body, '@claude')` can only skip it, never prevent it. In the 24h to 2026-09-07 23:58 UTC that was 87 runs from review comments (all skipped), 57% of all runs in the repo, none of them a real mention.

Trade-off: `@claude` written *inside* an inline review thread no longer starts a run — mentions have to go on the timeline. A run summoned that way can still reply into a review thread and resolve it.

## Verification

Throwaway Linode VM, `perconalab/pmm-server:3.9.1-rc`, client `pmm3-rc`, setup `--database psmdb,SETUP_TYPE=pss --database pdpgsql` — the same image and setup shards the failing run used.

| Revision | PMM-T2003 | PMM-T2048 (partial-match walk) | PMM-T2050 (exact-match walk) |
|---|---|---|---|
| `main` (e7f35d7) | **FAIL ×3**, same message as CI | **1 of 3 runs failed** | — |
| parent of the codeceptjs bump #1315 | PASS | — | — |
| this branch | **PASS ×3** | **PASS ×3** (6m / 5m / 6m) | **PASS ×2** |

PMM-T2003's pre-bump run pins the regression to #1315 rather than to an older latent problem, and its failure is deterministic (a string match that can never succeed), so no load comparison was needed there.

Runs on the same box deliberately saturated (12 busy loops, load ~19) are not evidence either way for PMM-T2048: there every run dies in `scrollTo` with `locator.evaluate: Timeout 20000ms exceeded` — the browser cannot evaluate a script inside the helper's 20s action timeout — which is machine starvation, not this failure mode.

`actionlint` + `yamllint` clean on the workflow change. Only the next nightly can confirm end-to-end on CI's own runners; the `@nightly` tag is not exercised by this PR's own workflows.

### Not a product bug

Nothing in `percona/pmm` or `percona/grafana` — in both failures the dashboard renders and the metrics are there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zwfJfjmRbLvnUqYi3NkWK