### PR TITLE
Stop a skipped run per review comment in the Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,8 +3,6 @@ name: Claude Code
 on:
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
 
 jobs:
   claude:


### PR DESCRIPTION
## What

`.github/workflows/claude.yml` no longer subscribes to `pull_request_review_comment`. `issue_comment: [created]` stays, so `@claude` still works from the PR or issue timeline.

## Why

GitHub creates the workflow run the moment the event arrives, so the job's `if: contains(github.event.comment.body, '@claude')` can only skip that run — it can never stop it from being created. Every inline review comment therefore left a `skipped` run in the Actions tab.

Measured over the 24h to 2026-09-07 23:58 UTC:

| Event | Runs | Conclusion |
|---|---|---|
| `pull_request_review_comment` | 87 | all `skipped` |
| `issue_comment` | 21 | all `skipped` |
| **Total** | **108** | 100% skipped |

That was 57% of all 189 workflow runs in this repo over the same window, and 46% of them came from review comments alone. Top sources of the 87: `coderabbitai[bot]` (43), a human reviewer (24), and `claude[bot]`'s own thread replies re-firing the event (14).

Not a single one of the 108 runs was a real `@claude` mention, so this window cost nothing in functionality. Dropping the trigger removes 87 of the 108 (~80%); the remaining 21 are timeline comments, which we keep because that is where mentions are actually written.

## Trade-off

`@claude` written *inside an inline review thread* no longer starts a run — that event is `pull_request_review_comment`, not `issue_comment`. Mentions have to go on the PR or issue timeline. A run summoned that way can still reply into a review thread and resolve it (`gh api`, `resolveReviewThread`), so only the entry point narrows, not what a run can do.

There is no way to keep the trigger and avoid the skipped runs — `on:` has no filter for comment body, and any job-level condition runs after the run already exists.

## Testing

`actionlint .github/workflows/claude.yml` — clean. Behaviour change is in the `on:` block only; no job, permission or `claude_args` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFRxyGTgVh3nuxJL6uSKUk


---
_Generated by [Claude Code](https://claude.ai/code/session_01HFRxyGTgVh3nuxJL6uSKUk)_