### PR TITLE
Add test for comments parsing in change agent command

### DIFF
--- a/e2e_tests/tests/cli/pgsql/pgsqlPgsmChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/pgsql/pgsqlPgsmChangeAgent.test.ts
@@ -407,6 +407,32 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
   );
 
   pmmTest(
+    'PMM-T1016 - Verify Change agent comments parsing @pgsm-pmm-integration',
+    async ({ api, cliHelper }) => {
+      const commentsParsingCases = [
+        { disabled: false, response: '- enabled comments parsing', value: 'on' },
+        { disabled: true, response: '- disabled comments parsing', value: 'off' },
+      ];
+
+      for (const commentsParsingCase of commentsParsingCases) {
+        await cliHelper
+          .execSilent(
+            `docker exec ${containerName} pmm-admin inventory change agent qan-postgresql-pgstatmonitor-agent ${pgStatMonitorId} --comments-parsing=${commentsParsingCase.value}`,
+          )
+          .assertSuccess()
+          .outContains(commentsParsingCase.response);
+
+        const agent = await api.inventoryApi.getAgentById(pgStatMonitorId);
+
+        expect(
+          agent.comments_parsing_disabled ?? false,
+          `Comments parsing '${commentsParsingCase.value}' was not persisted on the qan_postgresql_pgstatmonitor_agent`,
+        ).toEqual(commentsParsingCase.disabled);
+      }
+    },
+  );
+
+  pmmTest(
     'PMM-T1013 - Verify Change agent skip connection check @pgsm-pmm-integration',
     async ({ cliHelper, grafanaHelper, page, servicesPage }) => {
       let commands = [


### PR DESCRIPTION
## Summary
Adds a new end-to-end test case to verify that the `--comments-parsing` flag works correctly when changing a PostgreSQL pgStatMonitor agent configuration via the pmm-admin CLI.

## Changes
- Added test case `PMM-T1016` that validates comments parsing can be toggled on/off for the qan-postgresql-pgstatmonitor-agent
- Test verifies both the CLI output response and that the setting is persisted in the agent configuration via the API
- Tests both enabled (`on`) and disabled (`off`) states of the comments parsing feature

https://claude.ai/code/session_018ezYQe4qCh56fBfqzqs15K