### PR TITLE
Fix pmm-agent startup after port reconfiguration in test

### DIFF
--- a/e2e_tests/tests/cli/pgsql/pgsqlPgssChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/pgsql/pgsqlPgssChangeAgent.test.ts
@@ -415,6 +415,7 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
       let commands = [
         `docker exec ${containerName} sed -i 's/listen-port: 7777/listen-port: 7778/' /usr/local/percona/pmm/config/pmm-agent.yaml`,
         `docker restart ${containerName}`,
+        `docker exec -d ${containerName} pmm-agent --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml`,
       ];
 
       commands.forEach((command) => cliHelper.execSilent(command).assertSuccess());


### PR DESCRIPTION
## Summary
Adds explicit pmm-agent startup command after reconfiguring its listen port in the pgsql change agent test.

## Changes
- Added `docker exec -d` command to start pmm-agent with the updated configuration after the container restart
- This ensures the agent is running with the new port configuration (7778) before subsequent test assertions

## Details
The test modifies the pmm-agent configuration file to change the listen port from 7777 to 7778 and restarts the container. The new command explicitly starts the pmm-agent process with the updated configuration file to guarantee it's running with the correct settings for the remainder of the test.

https://claude.ai/code/session_011E4NE64BNkswvR2dE48jCt