### PR TITLE
Stop one setup shard's death from tearing down the nightly

### DIFF
--- a/.github/workflows/nightly-e2e-tests-matrix.yml
+++ b/.github/workflows/nightly-e2e-tests-matrix.yml
@@ -82,7 +82,12 @@ jobs:
   setup:
     name: "setup / ${{ matrix.shard_name }}"
     strategy:
-      fail-fast: true
+      # Each shard holds its own databases alive for the whole run, so under
+      # fail-fast one shard's death cancels the other 13 and strips the server
+      # of every monitored service while the test jobs still have over an hour
+      # to run. Shards are independent: losing one must cost only its own
+      # tests, which is why both test_execution matrices are already false.
+      fail-fast: false
       matrix:
         include:
           - shard_name: external

--- a/.github/workflows/nightly-e2e-tests-matrix.yml
+++ b/.github/workflows/nightly-e2e-tests-matrix.yml
@@ -82,11 +82,8 @@ jobs:
   setup:
     name: "setup / ${{ matrix.shard_name }}"
     strategy:
-      # Each shard holds its own databases alive for the whole run, so under
-      # fail-fast one shard's death cancels the other 13 and strips the server
-      # of every monitored service while the test jobs still have over an hour
-      # to run. Shards are independent: losing one must cost only its own
-      # tests, which is why both test_execution matrices are already false.
+      # Each shard holds its own databases alive for the whole run, so
+      # cancelling siblings strips the server of services mid-test.
       fail-fast: false
       matrix:
         include:

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -143,6 +143,12 @@ jobs:
       - name: Waiting for tests execution
         uses: actions/github-script@v7
         with:
+          # Enables @octokit/plugin-retry on this script's `github` client, so a
+          # transient API reply is retried instead of ending the job. Every shard
+          # polls this run on the same interval, and a job that dies here takes the
+          # databases it holds open with it. Exempt (not retried) by default:
+          # 400,401,403,404,422.
+          retries: 5
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -157,35 +163,8 @@ jobs:
               return new Promise((resolve) => setTimeout(resolve, ms));
             }
 
-            // Every shard polls this run on the same interval, so these calls
-            // reach the API in bursts and a transient 5xx or rate-limit reply
-            // is expected. Unretried, one such reply ends the job -- and with
-            // it the databases that job holds open for the whole run.
-            const apiRetryAttempts = 5;
-            const apiRetryBaseDelayMs = 5000;
-
-            function isRetriableApiError(error) {
-              const status = error?.status;
-              return status === undefined || status >= 500 || status === 403 || status === 429;
-            }
-
-            async function withApiRetry(label, call) {
-              for (let attempt = 1; ; attempt += 1) {
-                try {
-                  return await call();
-                } catch (error) {
-                  if (attempt >= apiRetryAttempts || !isRetriableApiError(error)) {
-                    throw error;
-                  }
-                  const delayMs = apiRetryBaseDelayMs * attempt;
-                  core.warning(`${label} failed (attempt ${attempt}/${apiRetryAttempts}, status=${error?.status ?? 'unknown'}): ${error?.message}. Retrying in ${delayMs}ms.`);
-                  await sleep(delayMs);
-                }
-              }
-            }
-
             async function listJobs() {
-              return withApiRetry('listJobsForWorkflowRun', () => github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              return github.paginate(github.rest.actions.listJobsForWorkflowRun, {
                 owner,
                 repo,
                 run_id,
@@ -194,18 +173,18 @@ jobs:
                 headers: {
                   'X-GitHub-Api-Version': '2026-03-10',
                 },
-              }));
+              });
             }
 
             async function getJob(job) {
-              const response = await withApiRetry(`getJobForWorkflowRun(${job.id})`, () => github.rest.actions.getJobForWorkflowRun({
+              const response = await github.rest.actions.getJobForWorkflowRun({
                 owner,
                 repo,
                 job_id: job.id,
                 headers: {
                   'X-GitHub-Api-Version': '2026-03-10',
                 },
-              }));
+              });
               return response.data;
             }
 

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -143,11 +143,9 @@ jobs:
       - name: Waiting for tests execution
         uses: actions/github-script@v7
         with:
-          # Enables @octokit/plugin-retry on this script's `github` client, so a
-          # transient API reply is retried instead of ending the job. Every shard
-          # polls this run on the same interval, and a job that dies here takes the
-          # databases it holds open with it. Exempt (not retried) by default:
-          # 400,401,403,404,422.
+          # Enables @octokit/plugin-retry on this script's `github` client; a
+          # transient reply here would otherwise end the shard and drop the
+          # databases it holds open. Exempt by default: 400,401,403,404,422.
           retries: 5
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -157,8 +157,35 @@ jobs:
               return new Promise((resolve) => setTimeout(resolve, ms));
             }
 
+            // Every shard polls this run on the same interval, so these calls
+            // reach the API in bursts and a transient 5xx or rate-limit reply
+            // is expected. Unretried, one such reply ends the job -- and with
+            // it the databases that job holds open for the whole run.
+            const apiRetryAttempts = 5;
+            const apiRetryBaseDelayMs = 5000;
+
+            function isRetriableApiError(error) {
+              const status = error?.status;
+              return status === undefined || status >= 500 || status === 403 || status === 429;
+            }
+
+            async function withApiRetry(label, call) {
+              for (let attempt = 1; ; attempt += 1) {
+                try {
+                  return await call();
+                } catch (error) {
+                  if (attempt >= apiRetryAttempts || !isRetriableApiError(error)) {
+                    throw error;
+                  }
+                  const delayMs = apiRetryBaseDelayMs * attempt;
+                  core.warning(`${label} failed (attempt ${attempt}/${apiRetryAttempts}, status=${error?.status ?? 'unknown'}): ${error?.message}. Retrying in ${delayMs}ms.`);
+                  await sleep(delayMs);
+                }
+              }
+            }
+
             async function listJobs() {
-              return github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              return withApiRetry('listJobsForWorkflowRun', () => github.paginate(github.rest.actions.listJobsForWorkflowRun, {
                 owner,
                 repo,
                 run_id,
@@ -167,18 +194,18 @@ jobs:
                 headers: {
                   'X-GitHub-Api-Version': '2026-03-10',
                 },
-              });
+              }));
             }
 
             async function getJob(job) {
-              const response = await github.rest.actions.getJobForWorkflowRun({
+              const response = await withApiRetry(`getJobForWorkflowRun(${job.id})`, () => github.rest.actions.getJobForWorkflowRun({
                 owner,
                 repo,
                 job_id: job.id,
                 headers: {
                   'X-GitHub-Api-Version': '2026-03-10',
                 },
-              });
+              }));
               return response.data;
             }
 

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
@@ -176,11 +176,9 @@ jobs:
         if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' }}
         uses: actions/github-script@v7
         with:
-          # Enables @octokit/plugin-retry on this script's `github` client, so a
-          # transient API reply is retried instead of ending the job. Every shard
-          # polls this run on the same interval, and a job that dies here takes the
-          # databases it holds open with it. Exempt (not retried) by default:
-          # 400,401,403,404,422.
+          # Enables @octokit/plugin-retry on this script's `github` client.
+          # Setup shards and test jobs all poll this run on the same interval,
+          # so a transient 5xx or rate-limit reply is expected.
           retries: 5
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
@@ -191,8 +191,35 @@ jobs:
               return new Promise((resolve) => setTimeout(resolve, ms));
             }
 
+            // Every shard polls this run on the same interval, so these calls
+            // reach the API in bursts and a transient 5xx or rate-limit reply
+            // is expected. Unretried, one such reply ends the job -- and with
+            // it the databases that job holds open for the whole run.
+            const apiRetryAttempts = 5;
+            const apiRetryBaseDelayMs = 5000;
+
+            function isRetriableApiError(error) {
+              const status = error?.status;
+              return status === undefined || status >= 500 || status === 403 || status === 429;
+            }
+
+            async function withApiRetry(label, call) {
+              for (let attempt = 1; ; attempt += 1) {
+                try {
+                  return await call();
+                } catch (error) {
+                  if (attempt >= apiRetryAttempts || !isRetriableApiError(error)) {
+                    throw error;
+                  }
+                  const delayMs = apiRetryBaseDelayMs * attempt;
+                  core.warning(`${label} failed (attempt ${attempt}/${apiRetryAttempts}, status=${error?.status ?? 'unknown'}): ${error?.message}. Retrying in ${delayMs}ms.`);
+                  await sleep(delayMs);
+                }
+              }
+            }
+
             async function listJobs() {
-              return github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              return withApiRetry('listJobsForWorkflowRun', () => github.paginate(github.rest.actions.listJobsForWorkflowRun, {
                 owner,
                 repo,
                 run_id,
@@ -201,18 +228,18 @@ jobs:
                 headers: {
                   'X-GitHub-Api-Version': '2026-03-10',
                 },
-              });
+              }));
             }
 
             async function getJob(job) {
-              const response = await github.rest.actions.getJobForWorkflowRun({
+              const response = await withApiRetry(`getJobForWorkflowRun(${job.id})`, () => github.rest.actions.getJobForWorkflowRun({
                 owner,
                 repo,
                 job_id: job.id,
                 headers: {
                   'X-GitHub-Api-Version': '2026-03-10',
                 },
-              });
+              }));
               return response.data;
             }
 

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
@@ -176,6 +176,12 @@ jobs:
         if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' }}
         uses: actions/github-script@v7
         with:
+          # Enables @octokit/plugin-retry on this script's `github` client, so a
+          # transient API reply is retried instead of ending the job. Every shard
+          # polls this run on the same interval, and a job that dies here takes the
+          # databases it holds open with it. Exempt (not retried) by default:
+          # 400,401,403,404,422.
+          retries: 5
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -191,35 +197,8 @@ jobs:
               return new Promise((resolve) => setTimeout(resolve, ms));
             }
 
-            // Every shard polls this run on the same interval, so these calls
-            // reach the API in bursts and a transient 5xx or rate-limit reply
-            // is expected. Unretried, one such reply ends the job -- and with
-            // it the databases that job holds open for the whole run.
-            const apiRetryAttempts = 5;
-            const apiRetryBaseDelayMs = 5000;
-
-            function isRetriableApiError(error) {
-              const status = error?.status;
-              return status === undefined || status >= 500 || status === 403 || status === 429;
-            }
-
-            async function withApiRetry(label, call) {
-              for (let attempt = 1; ; attempt += 1) {
-                try {
-                  return await call();
-                } catch (error) {
-                  if (attempt >= apiRetryAttempts || !isRetriableApiError(error)) {
-                    throw error;
-                  }
-                  const delayMs = apiRetryBaseDelayMs * attempt;
-                  core.warning(`${label} failed (attempt ${attempt}/${apiRetryAttempts}, status=${error?.status ?? 'unknown'}): ${error?.message}. Retrying in ${delayMs}ms.`);
-                  await sleep(delayMs);
-                }
-              }
-            }
-
             async function listJobs() {
-              return withApiRetry('listJobsForWorkflowRun', () => github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              return github.paginate(github.rest.actions.listJobsForWorkflowRun, {
                 owner,
                 repo,
                 run_id,
@@ -228,18 +207,18 @@ jobs:
                 headers: {
                   'X-GitHub-Api-Version': '2026-03-10',
                 },
-              }));
+              });
             }
 
             async function getJob(job) {
-              const response = await withApiRetry(`getJobForWorkflowRun(${job.id})`, () => github.rest.actions.getJobForWorkflowRun({
+              const response = await github.rest.actions.getJobForWorkflowRun({
                 owner,
                 repo,
                 job_id: job.id,
                 headers: {
                   'X-GitHub-Api-Version': '2026-03-10',
                 },
-              }));
+              });
               return response.data;
             }
 

--- a/.github/workflows/runner-e2e-tests-playwright-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-playwright-remote-nightly-tests.yml
@@ -189,8 +189,35 @@ jobs:
               return new Promise((resolve) => setTimeout(resolve, ms));
             }
 
+            // Every shard polls this run on the same interval, so these calls
+            // reach the API in bursts and a transient 5xx or rate-limit reply
+            // is expected. Unretried, one such reply ends the job -- and with
+            // it the databases that job holds open for the whole run.
+            const apiRetryAttempts = 5;
+            const apiRetryBaseDelayMs = 5000;
+
+            function isRetriableApiError(error) {
+              const status = error?.status;
+              return status === undefined || status >= 500 || status === 403 || status === 429;
+            }
+
+            async function withApiRetry(label, call) {
+              for (let attempt = 1; ; attempt += 1) {
+                try {
+                  return await call();
+                } catch (error) {
+                  if (attempt >= apiRetryAttempts || !isRetriableApiError(error)) {
+                    throw error;
+                  }
+                  const delayMs = apiRetryBaseDelayMs * attempt;
+                  core.warning(`${label} failed (attempt ${attempt}/${apiRetryAttempts}, status=${error?.status ?? 'unknown'}): ${error?.message}. Retrying in ${delayMs}ms.`);
+                  await sleep(delayMs);
+                }
+              }
+            }
+
             async function listJobs() {
-              return github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              return withApiRetry('listJobsForWorkflowRun', () => github.paginate(github.rest.actions.listJobsForWorkflowRun, {
                 owner,
                 repo,
                 run_id,
@@ -199,18 +226,18 @@ jobs:
                 headers: {
                   'X-GitHub-Api-Version': '2026-03-10',
                 },
-              });
+              }));
             }
 
             async function getJob(job) {
-              const response = await github.rest.actions.getJobForWorkflowRun({
+              const response = await withApiRetry(`getJobForWorkflowRun(${job.id})`, () => github.rest.actions.getJobForWorkflowRun({
                 owner,
                 repo,
                 job_id: job.id,
                 headers: {
                   'X-GitHub-Api-Version': '2026-03-10',
                 },
-              });
+              }));
               return response.data;
             }
 

--- a/.github/workflows/runner-e2e-tests-playwright-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-playwright-remote-nightly-tests.yml
@@ -174,6 +174,12 @@ jobs:
         if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' }}
         uses: actions/github-script@v7
         with:
+          # Enables @octokit/plugin-retry on this script's `github` client, so a
+          # transient API reply is retried instead of ending the job. Every shard
+          # polls this run on the same interval, and a job that dies here takes the
+          # databases it holds open with it. Exempt (not retried) by default:
+          # 400,401,403,404,422.
+          retries: 5
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -189,35 +195,8 @@ jobs:
               return new Promise((resolve) => setTimeout(resolve, ms));
             }
 
-            // Every shard polls this run on the same interval, so these calls
-            // reach the API in bursts and a transient 5xx or rate-limit reply
-            // is expected. Unretried, one such reply ends the job -- and with
-            // it the databases that job holds open for the whole run.
-            const apiRetryAttempts = 5;
-            const apiRetryBaseDelayMs = 5000;
-
-            function isRetriableApiError(error) {
-              const status = error?.status;
-              return status === undefined || status >= 500 || status === 403 || status === 429;
-            }
-
-            async function withApiRetry(label, call) {
-              for (let attempt = 1; ; attempt += 1) {
-                try {
-                  return await call();
-                } catch (error) {
-                  if (attempt >= apiRetryAttempts || !isRetriableApiError(error)) {
-                    throw error;
-                  }
-                  const delayMs = apiRetryBaseDelayMs * attempt;
-                  core.warning(`${label} failed (attempt ${attempt}/${apiRetryAttempts}, status=${error?.status ?? 'unknown'}): ${error?.message}. Retrying in ${delayMs}ms.`);
-                  await sleep(delayMs);
-                }
-              }
-            }
-
             async function listJobs() {
-              return withApiRetry('listJobsForWorkflowRun', () => github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              return github.paginate(github.rest.actions.listJobsForWorkflowRun, {
                 owner,
                 repo,
                 run_id,
@@ -226,18 +205,18 @@ jobs:
                 headers: {
                   'X-GitHub-Api-Version': '2026-03-10',
                 },
-              }));
+              });
             }
 
             async function getJob(job) {
-              const response = await withApiRetry(`getJobForWorkflowRun(${job.id})`, () => github.rest.actions.getJobForWorkflowRun({
+              const response = await github.rest.actions.getJobForWorkflowRun({
                 owner,
                 repo,
                 job_id: job.id,
                 headers: {
                   'X-GitHub-Api-Version': '2026-03-10',
                 },
-              }));
+              });
               return response.data;
             }
 

--- a/.github/workflows/runner-e2e-tests-playwright-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-playwright-remote-nightly-tests.yml
@@ -174,11 +174,9 @@ jobs:
         if: ${{ steps.check_launchable_subset.outputs.has_subset == 'true' }}
         uses: actions/github-script@v7
         with:
-          # Enables @octokit/plugin-retry on this script's `github` client, so a
-          # transient API reply is retried instead of ending the job. Every shard
-          # polls this run on the same interval, and a job that dies here takes the
-          # databases it holds open with it. Exempt (not retried) by default:
-          # 400,401,403,404,422.
+          # Enables @octokit/plugin-retry on this script's `github` client.
+          # Setup shards and test jobs all poll this run on the same interval,
+          # so a transient 5xx or rate-limit reply is expected.
           retries: 5
           script: |
             const owner = context.repo.owner;


### PR DESCRIPTION
## Failures fixed (investigator)

- source: nightly CI run https://github.com/percona/pmm-qa/actions/runs/34190484752 (`Nightly E2E tests Matrix (remote PMM Server)`, `INSTALLATION_TYPE=docker`, `perconalab/pmm-server:3-dev-latest`, client `3.9.1`, `main` @ `e7f35d7`)
- tests: **66 failures across two jobs**, all one cause — not 66 test bugs. Whole suites, so the list is by suite rather than by scenario:
  - `test execution / @nightly` (24 of its 27 failures): MySQL folder (7), PostgreSQL folder (4 of 5), MongoDB folder (6 of 7), Folders collection (4), OS folder (1), PS Replica integration (2), VictoriaMetrics `PMM-T507` (1)
  - `test execution / @qan|@valkey-nightly|@permissions-nightly|@pt-summary-nightly|@pbm-nightly` (all 42): QAN overview (14), QAN timerange (5), QAN details (4), QAN filters (1), QAN pagination (2), Valkey Dashboards (10, `PMM-T2087`), PT Summary (4), MongoDB PBM `PMM-T2036` (2)
  - `setup / extra-pxc` — the trigger, not a test

Not claimed by this PR — the run's other 3 failures are separately tracked and would have failed anyway: `PMM-T2003` and `PMM-T2048` in **#1354**, `Open the MongoDB Cluster Summary Dashboard…` in **#1290**.

## What happened

The tests were fine. Their environment was destroyed under them 70 minutes before they finished.

Each of the `setup` matrix's 14 shards provisions its own databases and pmm-client **on its own runner** and holds them alive for the whole run, parked in a `Waiting for tests execution` poll. That matrix ran with `fail-fast: true`:

```
05:41:10  setup / extra-pxc   ##[error]Unhandled error: HttpError: Server Error
05:41:16  setup / external    ##[error]The operation was canceled.
05:41:16  setup / ps-myrocks  ##[error]The operation was canceled.
   … all 13 siblings, same second …
```

`extra-pxc`'s second poll took a transient **HTTP 500** from the GitHub API on `GET /repos/percona/pmm-qa/actions/jobs/101947354582`. The step ran with retries disabled, so the `HttpError` escaped `while (true)` and failed the job. Six seconds later fail-fast cancelled the other 13 — and every monitored service in the run went with them, at 05:41:16, while the two test jobs ran on until 06:53 and 06:59.

One failure, thirteen cancellations, six seconds apart, and the `test_execution` matrices (already `fail-fast: false`) untouched. There is no other reading.

### The timeline confirms it

| time | event |
|---|---|
| 05:38:49 – 05:46:32 | **10 consecutive passes** — environment healthy |
| 05:41:16 | all 14 setup shards cancelled; databases and vmagents die |
| **05:49:02** | **first failure** — one `now-5m` window after the teardown |
| 05:49 → 06:59 | failures dominate; only metric-independent scenarios still pass |

Dashboards query `from=now-5m` / `now-15m`, so panels stayed populated on already-scraped data for a few minutes and then emptied as the window slid past 05:41. That 3-minute lag between teardown and first failure is the signature.

### Not a product bug

The server was healthy throughout, and the run proves it from both ends:

- `PMM-T1988 - Verify that all statuses on PMM Health dashboards are UP` — **passed at 06:47:03**, 66 minutes after the teardown.
- `PMM-T506 - Verify metrics on VictoriaMetrics dashboard` — **passed at 06:51:13**.
- `PMM-T507 - Verify metrics on VM Agents Overview` — **failed** (32 empty panels).

`PMM-T506` green next to `PMM-T507` red is the discriminator: VictoriaMetrics itself was scraping and serving its own metrics; the **vmagents**, which lived on the cancelled runners, were gone. Same story on the home dashboard, where `PMM-T2007` read 13 MySQL services from the inventory API but 0 on the metrics-driven Monitored DB Services panel — registrations intact server-side, nothing left to scrape.

So no PMM/Grafana bug is implicated and nothing was filed against the product.

## The fix

Two changes, one per link in the chain. **12 added lines, 2 of them functional.**

**1. `fail-fast: false` on the `setup` matrix** (`nightly-e2e-tests-matrix.yml`) — matching both `test_execution` matrices, which already set it. Shards are independent environments; losing one should cost only the tests that need it, not the entire run. On this run that alone would have kept 13 shards and their databases alive and confined the damage to the pxc scenarios.

**2. `retries: 5` on the three poll steps** — `actions/github-script@v7` already has a retry mechanism, and it was simply switched off (`retries` defaults to `'0'`). Enabling it is one input per step.

An earlier revision of this PR hand-rolled ~30 lines of retry logic into each of the three copies of the poll script. Review caught that as redundant and it was; that is now gone. What the built-in gives, verified against the action's source rather than assumed:

| | |
|---|---|
| `action.yml@v7` | has `retries` (default `'0'`) and `retry-exempt-status-codes` (default `400,401,403,404,422`) |
| `src/main.ts` | `getOctokit(token, opts, retry, requestLog)` attaches `@octokit/plugin-retry` to the same `github` client the script uses — so the retry is at the **request layer** and covers `github.paginate`'s internal requests, not just the per-job calls |
| `src/retry-options.ts` | maps the input to `request.retries`, the exempt list to `doNotRetry` |
| `plugin-retry`'s `errorRequest` | retries every `status >= 400` not in `doNotRetry`, backoff `(retryCount + 1)²` seconds |

Net effect on the observed failure: the **500 is retried** at 1/4/9/16/25 s instead of ending the shard, **429 is retried**, and a genuine **404 still throws on the first attempt**.

**403 is deliberately left exempt** (the default). Nothing in the failing run shows a 403, and overriding the list to catch secondary rate limits would also retry genuine permission errors for ~55 s before failing.

## Verification

- **Repo linters clean** on all four changed files — `.claude/hooks/lint-changed.sh` (yamllint + `actionlint` + the `notify_investigator needs` check), exit 0. `actionlint` validates the `retries` input against the action's schema.
- **The retry semantics above were read out of the pinned action's and plugin's source**, not inferred from docs or memory — each claim in that table maps to a named file.
- The earlier hand-rolled version was additionally unit-exercised by replaying the exact `HttpError 500` against the shipped script. That harness is no longer meaningful now the logic is the platform's, so it is not offered as evidence for the current diff.

### Reproduction gap, stated plainly

**No Linode VM was used, and none would have helped.** The failure is GitHub Actions harness mechanics — a matrix fail-fast cancellation and an unretried exception in an `actions/github-script` step. That mechanism does not exist off GitHub Actions, so a pmm-framework VM cannot reproduce it. What replaces reproduction here is the run's own logs, which name the cause in plain text: the `##[error]` lines above, their six-second ordering, and the pass/fail timeline.

Nightly itself could not be re-run — the workflow takes an external `pmm_server_address` and that server (`18.223.255.134`) was gone before this investigation started.

**What only a real run can confirm:** that `fail-fast: false` and `retries: 5` behave as documented in this specific workflow. Note a fresh nightly on this branch would come back green *whether or not the fix works*, because the trigger was a transient API 500 that cannot be summoned on demand — so a green nightly here shows no regression, not a proven fix. Both halves now rest on documented, source-verified GitHub/Octokit behaviour plus the two sibling matrices already using `fail-fast: false`.

### Known limitation, not solved here

`@octokit/plugin-retry` does **not** read `retry-after` or `x-ratelimit-reset`, and its backoff is unjittered. Since the loop fans `getJob` out over all setup jobs with `Promise.all`, retries can still land in near-lockstep across jobs — the same synchronised burst that plausibly provoked the 500. This is now the platform's standard behaviour rather than something this repo hand-rolls, which is why it is left as is; honouring `retry-after` would need `@octokit/plugin-throttling`, which `github-script` does not expose.

### Follow-ups worth considering, deliberately not done here

- **The poll is far heavier than it needs to be**, and this is the change that would actually shrink the burst above. Every round is 1 `listJobsForWorkflowRun` + N `getJobForWorkflowRun`, from 17 jobs at once — roughly 250 requests per round. `listJobsForWorkflowRun` already returns a `steps` array per job, which is the **only** thing `getJob` is used for, so dropping the per-job calls would cut the API surface by ~95% and the fan-out with it. Not done here: it changes the gate logic's data source and cannot be validated without a real nightly run.
- **No watchdog during test execution.** The test-side `Wait for all setup jobs to be ready` step already treats a failed or cancelled setup job as fatal — but it only runs as a start gate, before tests begin. Nothing re-checks setup health afterwards, which is why the test jobs kept running for 70 minutes against a stripped environment instead of failing fast. Preventing the teardown is the better fix and is what this PR does; a mid-run watchdog is a separate design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lc3gBBkf8fbx8hMrUt421C