### PR TITLE
Clear QAN filters between PMM-T269 iterations

### DIFF
--- a/codeceptjs-e2e/tests/QAN/common_test.js
+++ b/codeceptjs-e2e/tests/QAN/common_test.js
@@ -28,8 +28,7 @@ Scenario('PMM-T269 - Verify QAN UI Elements are displayed @qan', async ({ I, que
 
     await queryAnalyticsPage.filters.selectFilterInGroupAtPosition(filter, randomFilterValue);
     I.assertTrue((await queryAnalyticsPage.data.getRowCount()) > 0, `No values for filter: "${filter}" were displayed`);
-    // Re-clicking the same index is not a reliable deselect, and a filter left applied here
-    // re-ranks the Service Name values the assertions below pick from.
+    // A leftover filter re-ranks the Service Name values the assertions below pick from.
     I.click(queryAnalyticsPage.filters.buttons.resetAll);
     queryAnalyticsPage.waitForLoaded();
   }

--- a/codeceptjs-e2e/tests/QAN/common_test.js
+++ b/codeceptjs-e2e/tests/QAN/common_test.js
@@ -28,7 +28,10 @@ Scenario('PMM-T269 - Verify QAN UI Elements are displayed @qan', async ({ I, que
 
     await queryAnalyticsPage.filters.selectFilterInGroupAtPosition(filter, randomFilterValue);
     I.assertTrue((await queryAnalyticsPage.data.getRowCount()) > 0, `No values for filter: "${filter}" were displayed`);
-    await queryAnalyticsPage.filters.selectFilterInGroupAtPosition(filter, randomFilterValue);
+    // Re-clicking the same index is not a reliable deselect, and a filter left applied here
+    // re-ranks the Service Name values the assertions below pick from.
+    I.click(queryAnalyticsPage.filters.buttons.resetAll);
+    queryAnalyticsPage.waitForLoaded();
   }
 
   const serverNodeName = homePage.pmmServerName;


### PR DESCRIPTION
## Failures fixed (investigator)

- source: nightly CI run https://github.com/percona/pmm-qa/actions/runs/34190474633 (`Nightly E2E tests Matrix (remote PMM Server)`, job `test execution / @qan|@valkey-nightly|@permissions-nightly|@pt-summary-nightly|@pbm-nightly`, `INSTALLATION_TYPE=docker`, `perconalab/pmm-server:3-dev-latest`, client `3.8.1`)
- tests:
  - `codeceptjs-e2e/tests/QAN/common_test.js:12` / `@qan` — PMM-T269 - Verify QAN UI Elements are displayed

The same run's other two failures (PMM-T2003, PMM-T2048) are already covered by **#1354** and are not touched here.

## What failed

```
locator.textContent: Timeout 20000ms exceeded.
  - waiting for locator('#grafana-iframe').contentFrame()
      .locator('//div[contains(@data-testid, "filter-checkbox")]//input[@type="checkbox" and @checked]
               //following-sibling::span[@class="checkbox-container__label-text"]').first()
```

That is `I.grabTextFrom(queryAnalyticsPage.filters.fields.checkedFilters())` at the end of the
scenario: after selecting a Service Name filter, no checkbox on the page was checked.

## Root cause

Established from the failing run's own Playwright trace, whose `trace.network` carries the
`POST /v1/qan/metrics:getFilters` request bodies **and** responses. Three consecutive calls tell
the whole story:

| # | at | request `labels` | first `service_name` values in the response |
|---|---|---|---|
| -3 | 05:43:08 | `[{cmd_type: [INSERT]}]` | **`pdpgsql_pmm_17_1_4196`** (36.3%), `socket_pdpgsql_pmm_17_1_4196`, `pdpgsql_pmm_patroni_17_1_5068`, … |
| -2 | 05:43:21 | `[]` | `mysql_pmm_9_7_1_91750`, `ps_pmm_8_0_1_61744`, `pgsql_pgss_pmm_17_service_1190`, … |
| -1 | 05:43:23 | `[{service_name: ["$__all", "pdpgsql_pmm_17_1_4196"]}]` | unchanged from -2 — nothing filtered |

Reading that with the trace's action log:

1. The filter-group loop's last iteration is `Command Type`. It selects position 3
   (`var-cmd_type=INSERT` appears in the URL), then tries to undo it by clicking **the same
   index again** — and that click does not deselect. Call -3 proves the filter was still live.
2. The scenario then reads its Service Name candidates **while `cmd_type=INSERT` is still
   applied**, so the list it grabs is ranked by INSERT load. `serviceLabels[0]` is
   `pdpgsql_pmm_17_1_4196` — a service that does not appear anywhere near the top of the
   *unfiltered* ranking.
3. Between that read and the click the `cmd_type` filter goes away (call -2 sends `labels: []`),
   so the panel now holds the unfiltered value set, which no longer contains
   `pdpgsql_pmm_17_1_4196`.
4. The click therefore submits `service_name: ["$__all", "pdpgsql_pmm_17_1_4196"]` (call -1) —
   `$__all` alongside a value that is no longer in the list. QAN treats that as "all", so nothing
   is filtered and, crucially, **nothing is checked**.
5. `checkedFilters()` has nothing to match and burns its 20s timeout. The DOM snapshot at that
   moment agrees: 76 checkboxes, 62 disabled, **0 checked**, 0 rows in the grid.

So this is a pmm-qa test bug: a filter the loop failed to clear re-ranks the data the rest of the
scenario depends on. Intermittent because it only bites when the leftover filter promotes a
service that is absent from the unfiltered list — the same `@qan` job was fully green on run
[34172190364](https://github.com/percona/pmm-qa/actions/runs/34172190364) five hours earlier on
this exact commit.

## The fix

`Reset All` instead of a second position-based click, so every iteration starts from an
unfiltered panel and the Service Name candidates are read from the unfiltered value set. This is
what the sibling loop in `QAN/filters_test.js:152` already does.

The button is only clicked while a selection is applied, which the preceding
`getRowCount() > 0` assertion establishes — and because each iteration now starts clean, every
value listed in a group has rows, so `selectFilterInGroupAtPosition` cannot land on a disabled
checkbox. No assertion is loosened; the scenario still asserts the same things.

## Verification

Throwaway Linode VM, `perconalab/pmm-server:3-dev-latest`, client `3.8.1`, setup
`--database ps --database psmdb,SETUP_TYPE=pss --database pdpgsql`.

**Measured on the VM at `main`** — a throwaway spec drove each filter group from a clean
baseline, selecting position 3 and then re-clicking the same index:

| group | reordered after select | leftover after the second click |
|---|---|---|
| Environment, Cluster, Database, Node Name, User Name, Service Type | no | **no** |
| **Command Type** | no | **yes — `var-cmd_type=INSERT` still applied** |

Command Type is the one group where the position-based deselect fails, and it is the **last**
entry in `filters.labels.filterGroups` — so its leftover is what the Service Name step inherits,
exactly as in CI.

**Reset All does clear it**: `rows 25 → 5` on selecting INSERT, `→ 25` after Reset All.

**PMM-T269 on this branch: 3/3 pass** (3m / 3m / 4m). Stated plainly — this alone is weak
evidence, because the scenario also passed 3/3 at `main` on the same box: with only 6 services
the promoted service is always present in the unfiltered list, so the box cannot reproduce the CI
failure end to end. The evidence that this is the right fix is the network log above plus the
reproduced Command Type leftover, not the green runs. Only the next nightly can confirm it
against CI's ~15-service inventory; `@qan` is not exercised by this PR's own workflows.

### Two hypotheses checked and disproved — please don't re-tread them

- **"The leftover `cmd_type` filtered the results to nothing."** No. Selecting a service with a
  stale `var-cmd_type=INSERT` in the URL and selecting it without one give identical outcomes
  (`rows=24`, `checked=["rs101_19505"]` both ways). The stale variable is inert; the damage is to
  the *candidate ranking*, not to the result set.
- **"Clearing the search field re-collapses the group so the checked box leaves the DOM."** Not
  reproducible — the Service Name group is not truncated at 6 services, and the CI trace's
  snapshots are incremental, so a value missing from one of them is not evidence of absence.

### Observation, not filed as a product bug

After a Command Type filter is cleared — by re-clicking it *or* by Reset All — `var-cmd_type=<v>`
stays behind in the URL, while every other filter group's `var-*` is removed. Reset All then
greys out, so the URL keeps a variable with no control left to clear it. Reproduced on the VM,
but it is cosmetic: reloading that URL gives `rows=25` with nothing checked, i.e. the stale
variable is not re-applied, and results are unaffected. No PMM ticket filed for it on that basis;
worth a look if someone sees a real symptom hanging off it.

### Lint

`npx eslint tests/QAN/common_test.js` reports one `prefer-destructuring` error on
`const services = (await inventoryAPI.apiGetServices()).data.services` — pre-existing, present
identically on `main` (line 35 there, 38 here). Left alone rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAv5iMqDruDp1oe5dDeEQZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAv5iMqDruDp1oe5dDeEQZ)_