### PR TITLE
PMM-T9994 Fix valkey change agent TLS test

### DIFF
--- a/e2e_tests/tests/cli/valkey/valkeyChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/valkey/valkeyChangeAgent.test.ts
@@ -133,10 +133,14 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
         `docker exec ${containerName} bash -c "cat /easy-rsa/easyrsa3/pki/private/pmm-test.key > /certs/client.key"`,
         `docker exec ${containerName} bash -c "cat /easy-rsa/easyrsa3/pki/issued/pmm-test.crt > /certs/client.crt"`,
         `docker exec ${containerName} cp /easy-rsa/easyrsa3/pki/ca.crt /certs/ca-certs.pem`,
+        // valkey-server runs as uid 999, so it must own every file it reads:
+        // the server cert/key and the CA used to verify client certs.
         `docker exec ${containerName} chown 999:999 /certs/${containerName}.crt`,
         `docker exec ${containerName} chown 999:999 /certs/${containerName}.key`,
+        `docker exec ${containerName} chown 999:999 /certs/ca-certs.pem`,
         `docker exec ${containerName} chmod 600 /certs/${containerName}.key`,
         `docker exec ${containerName} chmod 644 /certs/${containerName}.crt`,
+        `docker exec ${containerName} chmod 644 /certs/ca-certs.pem`,
       ];
 
       commands.forEach((command) => cliHelper.execSilent(command).assertSuccess());

--- a/e2e_tests/tests/cli/valkey/valkeyChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/valkey/valkeyChangeAgent.test.ts
@@ -133,8 +133,8 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
         `docker exec ${containerName} bash -c "cat /easy-rsa/easyrsa3/pki/private/pmm-test.key > /certs/client.key"`,
         `docker exec ${containerName} bash -c "cat /easy-rsa/easyrsa3/pki/issued/pmm-test.crt > /certs/client.crt"`,
         `docker exec ${containerName} cp /easy-rsa/easyrsa3/pki/ca.crt /certs/ca-certs.pem`,
-        `docker exec ${containerName} chown 999:999 /certs/valkey-primary-1.crt`,
-        `docker exec ${containerName} chown 999:999 /certs/valkey-primary-1.key`,
+        `docker exec ${containerName} chown 999:999 /certs/${containerName}.crt`,
+        `docker exec ${containerName} chown 999:999 /certs/${containerName}.key`,
         `docker exec ${containerName} chmod 600 /certs/${containerName}.key`,
         `docker exec ${containerName} chmod 644 /certs/${containerName}.crt`,
       ];
@@ -143,7 +143,7 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
 
       fs.writeFileSync(
         '/tmp/ssl.conf',
-        `tls-port 6379\nport 0\ntls-cert-file /certs/${containerName}.crt\ntls-key-file /certs/${containerName}.key\ntls-ca-cert-file /certs/${containerName}.crt\ntls-auth-clients yes\ntls-replication yes\ntls-cluster yes`,
+        `tls-port 6379\nport 0\ntls-cert-file /certs/${containerName}.crt\ntls-key-file /certs/${containerName}.key\ntls-ca-cert-file /certs/ca-certs.pem\ntls-auth-clients yes\ntls-replication yes\ntls-cluster yes`,
       );
 
       cliHelper.execSilent(`docker cp /tmp/ssl.conf ${containerName}:/tmp/ssl.conf`);


### PR DESCRIPTION
## What / why

Fixes the e2e test **PMM-T9994 – Verify Change agent tls @valkey-integration** (`e2e_tests/tests/cli/valkey/valkeyChangeAgent.test.ts`), which could never pass because the TLS-only Valkey config it wrote was wrong in two ways:

1. **Wrong CA file.** `tls-ca-cert-file` pointed at the server's own leaf certificate instead of the CA. With `tls-auth-clients yes`, Valkey uses that file as the trust store to verify the exporter's **client** certificate (signed by the CA), so client-cert verification always failed. → point it at `ca-certs.pem`.
2. **CA unreadable by Valkey.** `valkey-server` runs as uid 999, but `ca-certs.pem` was created root-owned mode 600, so TLS failed to configure and the cluster node crash-looped. → `chown 999:999` + `chmod 644` the CA (and derive the chown paths from the container name), matching the existing server cert/key handling.

## Testing

Validated end-to-end on a live PMM Server + Valkey native cluster on a throwaway VM: the service goes `Down` (TLS-only, exporter not yet configured over TLS) then back `Up` after the `--tls` change-agent command. **1 passed (1.5m).**

> This test also required a matching **product** fix in pmm-managed so the valkey_exporter is actually given its TLS client-cert flags — without it `redis_up` stays 0.

## Related work

- Product fix (pmm): https://github.com/percona/pmm/pull/5903

> Note: `PMM-T9994` is the e2e test id; please retitle to the real Jira `PMM-XXXX` key before merge if required.

https://claude.ai/code/session_01KLycPTYMgrZfdc3ifb8nXe

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLycPTYMgrZfdc3ifb8nXe)_