### PR TITLE
Fix ProxySQL user update test to modify existing user

### DIFF
--- a/e2e_tests/tests/cli/mysql/proxysql.test.ts
+++ b/e2e_tests/tests/cli/mysql/proxysql.test.ts
@@ -59,7 +59,7 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
       await page.waitForTimeout(Timeouts.TEN_SECONDS);
 
       cliHelper.execSilent(
-        `docker exec ${containerName} mysql -h127.0.0.1 -P6032 -uadmin -p${mysqlPassword} -e "INSERT INTO mysql_users (username, password) VALUES ('${newUsername}', '${newPassword}'); LOAD MYSQL USERS TO RUNTIME; SAVE MYSQL USERS TO DISK;"`,
+        `docker exec ${containerName} mysql -h127.0.0.1 -P6032 -uadmin -p${mysqlPassword} -e "UPDATE mysql_users SET password='${newPassword}' WHERE username='${newUsername}'; LOAD MYSQL USERS TO RUNTIME; SAVE MYSQL USERS TO DISK;"`,
       );
 
       // eslint-disable-next-line playwright/no-wait-for-timeout -- Developing tests


### PR DESCRIPTION
## Summary
Updated the ProxySQL user management test to use an UPDATE statement instead of INSERT when modifying user credentials. This ensures the test correctly updates an existing user rather than attempting to insert a duplicate.

## Changes
- Modified the MySQL command in the ProxySQL inventory test to UPDATE the password for an existing user instead of INSERT a new user
- Changed from `INSERT INTO mysql_users (username, password) VALUES (...)` to `UPDATE mysql_users SET password='...' WHERE username='...'`
- Maintains the same LOAD and SAVE operations to apply changes to runtime and persist to disk

## Details
The test was attempting to insert a new user with the same username, which would fail if the user already exists. The UPDATE approach correctly modifies the password of an existing user, making the test more robust and aligned with the intended behavior of testing credential changes in the inventory.

https://claude.ai/code/session_016X6jqFX5mKwVhHjUPXvAqJ