### PR TITLE
PMM-T9991 Use admin_credentials for ProxySQL exporter auth

### DIFF
--- a/e2e_tests/tests/cli/mysql/proxysql.test.ts
+++ b/e2e_tests/tests/cli/mysql/proxysql.test.ts
@@ -43,7 +43,7 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
     async ({ cliHelper, grafanaHelper, page, servicesPage }) => {
       cliHelper
         .execSilent(
-          `docker exec ${containerName} mysql -h127.0.0.1 -P6032 -uadmin -p${mysqlPassword} -e "INSERT INTO mysql_users (username, password) VALUES ('${newUsername}', '${newPassword}-wrong'); LOAD MYSQL USERS TO RUNTIME; SAVE MYSQL USERS TO DISK;"`,
+          `docker exec ${containerName} mysql -h127.0.0.1 -P6032 -uadmin -p${mysqlPassword} -e "SET admin-admin_credentials='admin:${mysqlPassword};${newUsername}:${newPassword}-wrong'; LOAD ADMIN VARIABLES TO RUNTIME; SAVE ADMIN VARIABLES TO DISK;"`,
         )
         .assertSuccess();
 
@@ -59,7 +59,7 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
       await page.waitForTimeout(Timeouts.TEN_SECONDS);
 
       cliHelper.execSilent(
-        `docker exec ${containerName} mysql -h127.0.0.1 -P6032 -uadmin -p${mysqlPassword} -e "UPDATE mysql_users SET password='${newPassword}' WHERE username='${newUsername}'; LOAD MYSQL USERS TO RUNTIME; SAVE MYSQL USERS TO DISK;"`,
+        `docker exec ${containerName} mysql -h127.0.0.1 -P6032 -uadmin -p${mysqlPassword} -e "SET admin-admin_credentials='admin:${mysqlPassword};${newUsername}:${newPassword}'; LOAD ADMIN VARIABLES TO RUNTIME; SAVE ADMIN VARIABLES TO DISK;"`,
       );
 
       // eslint-disable-next-line playwright/no-wait-for-timeout -- Developing tests


### PR DESCRIPTION
## Summary

Follow-up fix for the `PMM-T9991 - Verify Change agent username and password @proxysql-integration` test, which still failed with `Access denied` after the earlier `mysql_users` change (#1362).

## Root cause

The proxysql-exporter — and pmm-managed's connection check — authenticate against the ProxySQL **admin interface (port 6032)**. That interface authenticates from the `admin-admin_credentials` variable, **not** the `mysql_users` table (which governs the data plane on port 6033 to the backend MySQL/PXC nodes). So registering the test user in `mysql_users` never produced a credential the exporter could log in with: the negative step passed only because the user wasn't a valid admin credential, and the positive step could never succeed — exactly the observed failure.

## Changes

- Register the test user via `admin-admin_credentials` instead of `mysql_users`, appending it to the default `admin:admin` login (`LOAD ADMIN VARIABLES TO RUNTIME; SAVE ADMIN VARIABLES TO DISK;`).
  - Negative step sets the wrong password → change-agent with the correct password is denied.
  - Positive step sets the correct password → change-agent succeeds and the service comes Up.
- Preserving `admin:admin` keeps all other `-uadmin -padmin` calls and the later serial tests in the suite working; the new user gets the same full-admin access the exporter was originally added with.

## Testing

Not yet run end-to-end — this `@proxysql-integration` test requires a live PMM Server + `pxc_proxysql` container, which wasn't available in the authoring environment. The change is grounded in the ProxySQL admin-auth model, confirmed by the failure surviving the `mysql_users` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X6jqFX5mKwVhHjUPXvAqJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016X6jqFX5mKwVhHjUPXvAqJ)_