### PR TITLE
Add external exporter agent configuration e2e tests

### DIFF
--- a/e2e_tests/tests/cli/externalExporterChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/externalExporterChangeAgent.test.ts
@@ -222,4 +222,77 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
       }
     },
   );
+
+  pmmTest('PMM-T1014 - Verify Change agent username @external-integration', async ({ cliHelper }) => {
+    const testUsername = 'external_flag_test_user';
+    const result = cliHelper
+      .execSilent(
+        `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --username=${testUsername} --skip-connection-check`,
+      )
+      .assertSuccess();
+
+    await result.outContains('agent configuration updated.');
+    await result.outContains('- updated username');
+
+    await cliHelper
+      .execSilent(
+        `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --username=${newUsername} --skip-connection-check`,
+      )
+      .assertSuccess();
+  });
+
+  pmmTest('PMM-T1015 - Verify Change agent listen port @external-integration', async ({ cliHelper }) => {
+    const originalPort = cliHelper
+      .execSilent(
+        `docker exec ${containerName} pmm-admin list | grep ${externalExporterId} | awk -F' ' '{print $6}'`,
+      )
+      .stdout.trim();
+    const newPort = '42201';
+
+    await cliHelper
+      .execSilent(
+        `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --listen-port=${newPort} --skip-connection-check`,
+      )
+      .assertSuccess()
+      .outContains(`- changed listen port to ${newPort}`);
+
+    await cliHelper
+      .execSilent(
+        `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --listen-port=${originalPort} --skip-connection-check`,
+      )
+      .assertSuccess()
+      .outContains(`- changed listen port to ${originalPort}`);
+  });
+
+  pmmTest('PMM-T1016 - Verify Change agent metrics scheme @external-integration', async ({ cliHelper }) => {
+    await cliHelper
+      .execSilent(
+        `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-scheme=https --skip-connection-check`,
+      )
+      .assertSuccess()
+      .outContains('- changed metrics scheme to https');
+
+    await cliHelper
+      .execSilent(
+        `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-scheme=http --skip-connection-check`,
+      )
+      .assertSuccess()
+      .outContains('- changed metrics scheme to http');
+  });
+
+  pmmTest('PMM-T1017 - Verify Change agent metrics path @external-integration', async ({ cliHelper }) => {
+    await cliHelper
+      .execSilent(
+        `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-path=/custom-metrics --skip-connection-check`,
+      )
+      .assertSuccess()
+      .outContains('- changed metrics path to /custom-metrics');
+
+    await cliHelper
+      .execSilent(
+        `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-path=/metrics --skip-connection-check`,
+      )
+      .assertSuccess()
+      .outContains('- changed metrics path to /metrics');
+  });
 });

--- a/e2e_tests/tests/cli/externalExporterChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/externalExporterChangeAgent.test.ts
@@ -1,4 +1,5 @@
 import pmmTest from '@fixtures/pmmTest';
+import CliHelper from '@helpers/cli.helper';
 import { Timeouts } from '@helpers/timeouts';
 import { expect } from '@playwright/test';
 
@@ -33,6 +34,34 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
       )
       .stdout.trim();
   });
+
+  // The external exporter is a redis_exporter serving http /metrics on :42200 (see
+  // qa-integration/pmm_qa/external_setup.yml). To prove metrics are reachable on a *changed*
+  // path/scheme the redis_exporter itself must serve there, so these helpers stop it and relaunch
+  // it with extra flags, reusing its original argv captured from /proc.
+  const redisExporterPort = '42200';
+  const captureRedisExporterCmd = (cliHelper: CliHelper) =>
+    cliHelper
+      .execSilent(
+        `docker exec ${containerName} bash -c 'for p in /proc/[0-9]*; do if [ "$(cat "$p/comm" 2>/dev/null)" = "redis_exporter" ]; then tr "\\0" " " < "$p/cmdline" > /redis_orig_cmd; break; fi; done'`,
+      )
+      .assertSuccess();
+  const stopRedisExporter = (cliHelper: CliHelper) =>
+    cliHelper.execSilent(
+      `docker exec ${containerName} bash -c 'for p in /proc/[0-9]*; do [ "$(cat "$p/comm" 2>/dev/null)" = "redis_exporter" ] && kill "$(basename "$p")"; done; sleep 2'`,
+    );
+  const startRedisExporter = (cliHelper: CliHelper, extraFlags: string) =>
+    cliHelper
+      .execSilent(
+        `docker exec -d ${containerName} bash -c 'cd / && $(cat /redis_orig_cmd) ${extraFlags} > /redis_reconfig.log 2>&1'`,
+      )
+      .assertSuccess();
+  const waitForRedisMetrics = (cliHelper: CliHelper, url: string) =>
+    cliHelper
+      .execSilent(
+        `docker exec ${containerName} bash -c 'timeout 60 bash -c "until curl -skf ${url} >/dev/null 2>&1; do sleep 2; done"'`,
+      )
+      .assertSuccess();
 
   pmmTest(
     'PMM-T1001 - Verify Change agent username and password @ps-integration',
@@ -276,37 +305,88 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
   });
 
   pmmTest('PMM-T1016 - Verify Change agent metrics scheme @external-integration', async ({ cliHelper }) => {
-    await cliHelper
-      .execSilent(
-        `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-scheme=https --skip-connection-check`,
-      )
-      .assertSuccess()
-      .outContainsNormalizedMany(['- changed metrics scheme to https', 'Scheme : https']);
+    const httpsUrl = `https://127.0.0.1:${redisExporterPort}/metrics`;
+    const httpUrl = `http://127.0.0.1:${redisExporterPort}/metrics`;
 
-    await cliHelper
-      .execSilent(
-        `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-scheme=http --skip-connection-check`,
-      )
-      .assertSuccess()
-      .outContainsNormalizedMany(['- changed metrics scheme to http', 'Scheme : http']);
+    captureRedisExporterCmd(cliHelper);
+
+    try {
+      // Serve the redis_exporter over TLS with a self-signed certificate.
+      cliHelper
+        .execSilent(
+          `docker exec ${containerName} bash -c 'openssl req -x509 -newkey rsa:2048 -nodes -keyout /redis_tls.key -out /redis_tls.crt -days 1 -subj "/CN=${containerName}" >/dev/null 2>&1'`,
+        )
+        .assertSuccess();
+      stopRedisExporter(cliHelper);
+      startRedisExporter(
+        cliHelper,
+        '-tls-server-cert-file=/redis_tls.crt -tls-server-key-file=/redis_tls.key',
+      );
+      await waitForRedisMetrics(cliHelper, httpsUrl);
+
+      // Metrics are served on the changed (https) scheme.
+      await cliHelper
+        .execSilent(`docker exec ${containerName} curl -skf ${httpsUrl}`)
+        .assertSuccess()
+        .outContains('redis_up');
+
+      await cliHelper
+        .execSilent(
+          `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-scheme=https --skip-connection-check`,
+        )
+        .assertSuccess()
+        .outContainsNormalizedMany(['- changed metrics scheme to https', 'Scheme : https']);
+    } finally {
+      stopRedisExporter(cliHelper);
+      startRedisExporter(cliHelper, '');
+      await waitForRedisMetrics(cliHelper, httpUrl);
+      await cliHelper
+        .execSilent(
+          `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-scheme=http --skip-connection-check`,
+        )
+        .assertSuccess()
+        .outContainsNormalizedMany(['- changed metrics scheme to http', 'Scheme : http']);
+    }
   });
 
   pmmTest('PMM-T1017 - Verify Change agent metrics path @external-integration', async ({ cliHelper }) => {
-    await cliHelper
-      .execSilent(
-        `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-path=/custom-metrics --skip-connection-check`,
-      )
-      .assertSuccess()
-      .outContainsNormalizedMany([
-        '- changed metrics path to /custom-metrics',
-        'Metrics path : /custom-metrics',
-      ]);
+    const customPath = '/custom-metrics';
+    const customUrl = `http://127.0.0.1:${redisExporterPort}${customPath}`;
+    const defaultUrl = `http://127.0.0.1:${redisExporterPort}/metrics`;
 
-    await cliHelper
-      .execSilent(
-        `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-path=/metrics --skip-connection-check`,
-      )
-      .assertSuccess()
-      .outContainsNormalizedMany(['- changed metrics path to /metrics', 'Metrics path : /metrics']);
+    captureRedisExporterCmd(cliHelper);
+
+    try {
+      // Serve the redis_exporter metrics on a custom telemetry path.
+      stopRedisExporter(cliHelper);
+      startRedisExporter(cliHelper, `-web.telemetry-path=${customPath}`);
+      await waitForRedisMetrics(cliHelper, customUrl);
+
+      // Metrics are served on the changed path.
+      await cliHelper
+        .execSilent(`docker exec ${containerName} curl -sf ${customUrl}`)
+        .assertSuccess()
+        .outContains('redis_up');
+
+      await cliHelper
+        .execSilent(
+          `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-path=${customPath} --skip-connection-check`,
+        )
+        .assertSuccess()
+        .outContainsNormalizedMany([
+          `- changed metrics path to ${customPath}`,
+          `Metrics path : ${customPath}`,
+        ]);
+    } finally {
+      stopRedisExporter(cliHelper);
+      startRedisExporter(cliHelper, '');
+      await waitForRedisMetrics(cliHelper, defaultUrl);
+      await cliHelper
+        .execSilent(
+          `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-path=/metrics --skip-connection-check`,
+        )
+        .assertSuccess()
+        .outContainsNormalizedMany(['- changed metrics path to /metrics', 'Metrics path : /metrics']);
+    }
   });
 });

--- a/e2e_tests/tests/cli/externalExporterChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/externalExporterChangeAgent.test.ts
@@ -225,28 +225,36 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
 
   pmmTest('PMM-T1014 - Verify Change agent username @external-integration', async ({ cliHelper }) => {
     const testUsername = 'external_flag_test_user';
-    const result = cliHelper
+
+    // The change command output echoes the agent config the server stored, so asserting the
+    // "Username" field verifies the flag was applied, not just parsed.
+    await cliHelper
       .execSilent(
         `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --username=${testUsername} --skip-connection-check`,
       )
-      .assertSuccess();
-
-    await result.outContains('agent configuration updated.');
-    await result.outContains('- updated username');
+      .assertSuccess()
+      .outContainsNormalizedMany([
+        'agent configuration updated.',
+        '- updated username',
+        `Username : ${testUsername}`,
+      ]);
 
     await cliHelper
       .execSilent(
         `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --username=${newUsername} --skip-connection-check`,
       )
-      .assertSuccess();
+      .assertSuccess()
+      .outContains(`Username : ${newUsername}`);
   });
 
   pmmTest('PMM-T1015 - Verify Change agent listen port @external-integration', async ({ cliHelper }) => {
-    const originalPort = cliHelper
-      .execSilent(
-        `docker exec ${containerName} pmm-admin list | grep ${externalExporterId} | awk -F' ' '{print $6}'`,
-      )
-      .stdout.trim();
+    const readPort = () =>
+      cliHelper
+        .execSilent(
+          `docker exec ${containerName} pmm-admin list | grep ${externalExporterId} | awk -F' ' '{print $6}'`,
+        )
+        .stdout.trim();
+    const originalPort = readPort();
     const newPort = '42201';
 
     await cliHelper
@@ -254,7 +262,9 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
         `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --listen-port=${newPort} --skip-connection-check`,
       )
       .assertSuccess()
-      .outContains(`- changed listen port to ${newPort}`);
+      .outContainsNormalizedMany([`- changed listen port to ${newPort}`, `Listen port : ${newPort}`]);
+    // Independently confirm the new port via pmm-admin list.
+    expect(readPort(), 'Listen port should be updated in pmm-admin list').toEqual(newPort);
 
     await cliHelper
       .execSilent(
@@ -262,6 +272,7 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
       )
       .assertSuccess()
       .outContains(`- changed listen port to ${originalPort}`);
+    expect(readPort(), 'Listen port should be restored in pmm-admin list').toEqual(originalPort);
   });
 
   pmmTest('PMM-T1016 - Verify Change agent metrics scheme @external-integration', async ({ cliHelper }) => {
@@ -270,14 +281,14 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
         `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-scheme=https --skip-connection-check`,
       )
       .assertSuccess()
-      .outContains('- changed metrics scheme to https');
+      .outContainsNormalizedMany(['- changed metrics scheme to https', 'Scheme : https']);
 
     await cliHelper
       .execSilent(
         `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-scheme=http --skip-connection-check`,
       )
       .assertSuccess()
-      .outContains('- changed metrics scheme to http');
+      .outContainsNormalizedMany(['- changed metrics scheme to http', 'Scheme : http']);
   });
 
   pmmTest('PMM-T1017 - Verify Change agent metrics path @external-integration', async ({ cliHelper }) => {
@@ -286,13 +297,16 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
         `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-path=/custom-metrics --skip-connection-check`,
       )
       .assertSuccess()
-      .outContains('- changed metrics path to /custom-metrics');
+      .outContainsNormalizedMany([
+        '- changed metrics path to /custom-metrics',
+        'Metrics path : /custom-metrics',
+      ]);
 
     await cliHelper
       .execSilent(
         `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --metrics-path=/metrics --skip-connection-check`,
       )
       .assertSuccess()
-      .outContains('- changed metrics path to /metrics');
+      .outContainsNormalizedMany(['- changed metrics path to /metrics', 'Metrics path : /metrics']);
   });
 });


### PR DESCRIPTION
Add four new end-to-end tests for the `pmm-admin inventory change agent` command with external exporter agents, covering username, listen port, metrics scheme, and metrics path modifications.

**Changes:**
- PMM-T1014: Test changing agent username and verify the configuration update message
- PMM-T1015: Test changing agent listen port, capturing the original port and restoring it after verification
- PMM-T1016: Test changing metrics scheme between https and http
- PMM-T1017: Test changing metrics path to a custom path and restoring the default

All tests use `--skip-connection-check` flag and verify successful configuration updates through output assertions.

https://claude.ai/code/session_01CjatG99Z9HFmC9u888FKrR