### PR TITLE
Expect 4 queries in PMM-T1063 after the pg_stat_monitor 2.4.0 change

### DIFF
--- a/codeceptjs-e2e/tests/qa-integration/pmm_pgsm_integration_test.js
+++ b/codeceptjs-e2e/tests/qa-integration/pmm_pgsm_integration_test.js
@@ -415,7 +415,9 @@ Scenario(
 
     const count = await queryAnalyticsPage.data.getRowCount();
 
-    assert.ok(parseInt(count, 10) === 5, `Expected only 5 Queries to show up for ${applicationName} based on the load script but found ${count}`);
+    // The script's own `SET application_name` is attributed to the name in effect before it
+    // ran, so only the four statements after it carry PMMT1063 (pg_stat_monitor 2.4.0, d25da64).
+    assert.ok(parseInt(count, 10) === 4, `Expected only 4 Queries to show up for ${applicationName} based on the load script but found ${count}`);
   },
 );
 


### PR DESCRIPTION
## Failures fixed (investigator)

- source: `E2E tests Matrix` run https://github.com/percona/pmm-qa/actions/runs/34218949932/job/102037363390 (PR #1330, job `FB E2E tests / PGSM UI tests / e2e tests: @pgsm-pmm-integration`)
- tests:
  - `codeceptjs-e2e/tests/qa-integration/pmm_pgsm_integration_test.js:418` / `@pgsm-pmm-integration @not-ui-pipeline` — PMM-T1063 - Verify Application Name with pg_stat_monitor

```
Expected only 5 Queries to show up for PMMT1063 based on the load script but found 4
  at tests/qa-integration/pmm_pgsm_integration_test.js:418
```

## Root cause — an intentional upstream pg_stat_monitor change

`testdata/pgsql/pgsm_applicationName.sql` runs, in one batch: `SET application_name = 'PMMT1063'`, then `create table`, 4× `insert` (one digest), `select`, `update`. The expected 5 counted the `SET` itself as one of the queries carrying the new application name.

pg_stat_monitor **2.4.0** now creates the stats entry in the executor-start hook, so `application_name` is snapshotted **before** the statement's own mutations — its comment says so outright:

```c
/*
 * Make sure a local stats entry exists before the query runs, so its
 * snapshot of the execution info (application_name, user) reflects
 * the state at statement start.
 */
```

That comes from [`d25da64`](https://github.com/percona/pg_stat_monitor/commit/d25da647db1cf5674433849e8de2220607c8b465) — *"Fix stats for queries executed via prepared statements … it may produce entry with incorrect data if query itself changes application name or user"* (2026-07-28), present in 2.4.0 and absent in 2.3.2. A statement that sets the application name is exactly the case that fix targets, so `SET application_name = 'PMMT1063'` is now attributed to the name in effect before it ran, leaving four statements under `PMMT1063`.

This is upstream behaviour working as intended; PMM and QAN report it faithfully, and the QA setup produces the data it should. Nothing was filed against `percona/pmm` or `percona/grafana`.

### Why it started now

`percona-pg-stat-monitor17` `1:2.4.0-1.noble` was built **2026-09-07 16:23 UTC** (package changelog) and the `--database pdpgsql` setup installs the repo's current candidate, with no version pin. The last green run of this scenario was 2026-09-08 00:40 UTC; it has failed since.

## Verification

Throwaway Linode VM, `perconalab/pmm-server:3-dev-latest` (`sha256:b5e301b7de7c…`), client `latest-tarball`, setup `--database pdpgsql` — the same image and setup args the failing job used. Percona Server for PostgreSQL 17.11, `pgsm_track=all`, `pgsm_track_utility=on`.

Digests under `application_name = 'PMMT1063'` after the unmodified load script, read straight from `pg_stat_monitor`:

| pg_stat_monitor | extension recreated | digests | `SET application_name` row |
|---|---|---|---|
| 2.4.0 (as installed) | no | **4** | attributed to `psql` |
| 2.3.2 | yes | **5** | attributed to `PMMT1063` |
| 2.4.0 | yes | **4** | attributed to `psql` |

The middle row isolates the library as the only variable — recreating the extension on 2.4.0 still gives 4.

End-to-end through the scenario itself, on the same VM:

| Revision | PMM-T1063 |
|---|---|
| `main` (9374b4a) | **FAIL**, `found 4` — byte-identical to CI |
| this branch | **PASS ×2** (2m / 2m) |

## Note for reviewers

The count stays hard-coded, one lower, with a comment naming the upstream commit — deliberately minimal. If you would rather the scenario not depend on a count at all, the load script could set the application name on the connection instead of through a tracked `SET`; that is a larger change and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zwfJfjmRbLvnUqYi3NkWK

---
_Generated by [Claude Code](https://claude.ai/code/session_014zwfJfjmRbLvnUqYi3NkWK)_