### PR TITLE
Make the pmm-client download survive a slow repo.percona.com

### DIFF
--- a/.github/workflows/ha-e2e-tests.yml
+++ b/.github/workflows/ha-e2e-tests.yml
@@ -146,13 +146,13 @@ jobs:
       - name: Setup PMM-Client against remote PMM HA Server
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 10
+          timeout_minutes: 20
           retry_wait_seconds: '10'
           max_attempts: 2
           retry_on: 'any'
           command: |
             cd pmm-qa/qa-integration/pmm_qa
-            sudo timeout -k 30 9m bash -x pmm3-client-setup.sh \
+            sudo timeout -k 30 19m bash -x pmm3-client-setup.sh \
               --pmm_server_ip "${SERVER_IP}" \
               --client_version "${PMM_CLIENT_VERSION}" \
               --admin_password "${ADMIN_PASSWORD}" \

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -107,13 +107,13 @@ jobs:
       - name: Setup PMM-Client against remote PMM Server
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 10
+          timeout_minutes: 20
           retry_wait_seconds: '10'
           max_attempts: 2
           retry_on: 'any'
           command: |
             cd pmm-qa/qa-integration/pmm_qa
-            sudo timeout -k 30 9m bash -x pmm3-client-setup.sh \
+            sudo timeout -k 30 19m bash -x pmm3-client-setup.sh \
               --pmm_server_ip "${SERVER_IP}" \
               --client_version "${{ env.PMM_CLIENT_VERSION }}" \
               --admin_password "${{ env.ADMIN_PASSWORD }}" \

--- a/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
@@ -90,8 +90,11 @@ if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
   elif [ "$client_version" = "3.8.1" ] || [ "$minor_version" -gt 8 ]; then
     build_number=1
   fi
-  wget -O pmm-client.rpm https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-${build_number}.el9.x86_64.rpm
-  rpm -i pmm-client.rpm
+  rpm_file="pmm-client-${client_version}-${build_number}.el9.x86_64.rpm"
+  # Resumable: a released version's URL is immutable and the file name carries the version.
+  wget --continue --timeout=60 --waitretry=15 --progress=dot:giga \
+    -O "${rpm_file}" "https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/${rpm_file}"
+  rpm -i "${rpm_file}"
 fi
 
 ## Default Binary path
@@ -102,7 +105,10 @@ ln -sf ${path}/bin/pmm-agent /usr/local/bin/pmm-agent
 
 if [[ "$client_version" == http* ]]; then
     if [[ "$install_client" == "yes" ]]; then
-       wget -O pmm-client.tar.gz --progress=dot:giga "${client_version}"
+       # No --continue: this URL is mutable (pmm-client-latest.tar.gz), so a partial
+       # left by an earlier build must not be resumed into.
+       wget -O pmm-client.tar.gz --progress=dot:giga \
+         --timeout=60 --waitretry=15 "${client_version}"
     fi
     tar -zxpf pmm-client.tar.gz
     rm -r pmm-client.tar.gz

--- a/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
@@ -105,8 +105,6 @@ ln -sf ${path}/bin/pmm-agent /usr/local/bin/pmm-agent
 
 if [[ "$client_version" == http* ]]; then
     if [[ "$install_client" == "yes" ]]; then
-       # No --continue: this URL is mutable (pmm-client-latest.tar.gz), so a partial
-       # left by an earlier build must not be resumed into.
        wget -O pmm-client.tar.gz --progress=dot:giga \
          --timeout=60 --waitretry=15 "${client_version}"
     fi

--- a/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup-centos.sh
@@ -91,7 +91,6 @@ if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
     build_number=1
   fi
   rpm_file="pmm-client-${client_version}-${build_number}.el9.x86_64.rpm"
-  # Resumable: a released version's URL is immutable and the file name carries the version.
   wget --continue --timeout=60 --waitretry=15 --progress=dot:giga \
     -O "${rpm_file}" "https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/${rpm_file}"
   rpm -i "${rpm_file}"

--- a/qa-integration/pmm_qa/pmm3-client-setup.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup.sh
@@ -105,8 +105,15 @@ if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
   elif [ "$client_version" = "3.8.1" ] || [ "$minor_version" -gt 8 ]; then
     build_number=1
   fi
-  wget -O pmm-client.deb "https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb"
-  dpkg -i pmm-client.deb
+  deb_file="pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb"
+  # ~170MB, and repo.percona.com has served it to CI runners as slowly as 190KB/s.
+  # Resume instead of restarting: the callers wrap this script in a retry that gives
+  # every attempt the same wall clock, so without --continue a slow link never finishes.
+  # Safe to resume here (a released version's URL is immutable, and the file name
+  # carries the version, so a stale partial can never belong to a different build).
+  wget --continue --tries=3 --timeout=60 --waitretry=15 --progress=dot:giga \
+    -O "${deb_file}" "https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/${deb_file}"
+  dpkg -i "${deb_file}"
 fi
 
 ## Default Binary path
@@ -117,7 +124,10 @@ ln -sf ${path}/bin/pmm-agent /usr/local/bin/pmm-agent
 
 if [[ "$client_version" == http* ]]; then
     if [[ "$install_client" == "yes" ]]; then
-       wget -O pmm-client.tar.gz --progress=dot:giga "${client_version}"
+       # No --continue: this URL is mutable (pmm-client-latest.tar.gz), so a partial
+       # left by an earlier build must not be resumed into.
+       wget -O pmm-client.tar.gz --progress=dot:giga \
+         --tries=3 --timeout=60 --waitretry=15 "${client_version}"
     fi
     tar -zxpf pmm-client.tar.gz
     rm -r pmm-client.tar.gz

--- a/qa-integration/pmm_qa/pmm3-client-setup.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup.sh
@@ -106,7 +106,6 @@ if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
     build_number=1
   fi
   deb_file="pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb"
-  # Resumable: a released version's URL is immutable and the file name carries the version.
   wget --continue --timeout=60 --waitretry=15 --progress=dot:giga \
     -O "${deb_file}" "https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/${deb_file}"
   dpkg -i "${deb_file}"
@@ -120,8 +119,6 @@ ln -sf ${path}/bin/pmm-agent /usr/local/bin/pmm-agent
 
 if [[ "$client_version" == http* ]]; then
     if [[ "$install_client" == "yes" ]]; then
-       # No --continue: this URL is mutable (pmm-client-latest.tar.gz), so a partial
-       # left by an earlier build must not be resumed into.
        wget -O pmm-client.tar.gz --progress=dot:giga \
          --timeout=60 --waitretry=15 "${client_version}"
     fi

--- a/qa-integration/pmm_qa/pmm3-client-setup.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup.sh
@@ -106,11 +106,7 @@ if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
     build_number=1
   fi
   deb_file="pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb"
-  # ~170MB, and repo.percona.com has served it to CI runners as slowly as 190KB/s.
-  # Resume instead of restarting: the callers wrap this script in a retry that gives
-  # every attempt the same wall clock, so without --continue a slow link never finishes.
-  # Safe to resume here (a released version's URL is immutable, and the file name
-  # carries the version, so a stale partial can never belong to a different build).
+  # Resumable: a released version's URL is immutable and the file name carries the version.
   wget --continue --tries=3 --timeout=60 --waitretry=15 --progress=dot:giga \
     -O "${deb_file}" "https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/${deb_file}"
   dpkg -i "${deb_file}"

--- a/qa-integration/pmm_qa/pmm3-client-setup.sh
+++ b/qa-integration/pmm_qa/pmm3-client-setup.sh
@@ -107,7 +107,7 @@ if [[ "$client_version" =~ ^3\.[0-9]+\.[0-9]+$ ]]; then
   fi
   deb_file="pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb"
   # Resumable: a released version's URL is immutable and the file name carries the version.
-  wget --continue --tries=3 --timeout=60 --waitretry=15 --progress=dot:giga \
+  wget --continue --timeout=60 --waitretry=15 --progress=dot:giga \
     -O "${deb_file}" "https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/${deb_file}"
   dpkg -i "${deb_file}"
 fi
@@ -123,7 +123,7 @@ if [[ "$client_version" == http* ]]; then
        # No --continue: this URL is mutable (pmm-client-latest.tar.gz), so a partial
        # left by an earlier build must not be resumed into.
        wget -O pmm-client.tar.gz --progress=dot:giga \
-         --tries=3 --timeout=60 --waitretry=15 "${client_version}"
+         --timeout=60 --waitretry=15 "${client_version}"
     fi
     tar -zxpf pmm-client.tar.gz
     rm -r pmm-client.tar.gz

--- a/qa-integration/pmm_qa/tasks/install_pmm_client.yml
+++ b/qa-integration/pmm_qa/tasks/install_pmm_client.yml
@@ -148,7 +148,11 @@
       elif [ "$client_version" = "3.8.1" ] || [ "$minor_version" -gt 8 ]; then
         build_number=1
       fi
-      wget -O /pmm-client.deb "https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb"
+      # Removed first so wget resumes only its own partial: containers are recreated
+      # between outer retries, so nothing older can be resumed into.
+      rm -f /pmm-client.deb
+      wget --continue --timeout=60 --waitretry=15 --progress=dot:giga \
+        -O /pmm-client.deb "https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb"
     '
     docker exec --user root {{ container_name }} dpkg -i /pmm-client.deb
   when:
@@ -167,7 +171,9 @@
       elif [ "$client_version" = "3.8.1" ] || [ "$minor_version" -gt 8 ]; then
         build_number=1
       fi
-      wget -O /pmm-client.rpm "https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-${build_number}.el9.x86_64.rpm"
+      rm -f /pmm-client.rpm
+      wget --continue --timeout=60 --waitretry=15 --progress=dot:giga \
+        -O /pmm-client.rpm "https://repo.percona.com/pmm3-client/yum/release/9/RPMS/x86_64/pmm-client-${client_version}-${build_number}.el9.x86_64.rpm"
     '
     docker exec --user root {{ container_name }} rpm -i /pmm-client.rpm
   when:
@@ -177,7 +183,7 @@
 - name: Install tarball PMM client version
   shell: |
     docker exec --user root {{ container_name }} sh -c '
-      wget -O /pmm-client.tar.gz "{{ client_version }}" &&
+      wget --timeout=60 --waitretry=15 --progress=dot:giga -O /pmm-client.tar.gz "{{ client_version }}" &&
       tar -zxpf /pmm-client.tar.gz &&
       PMM_CLIENT=`ls -1td pmm-client* 2>/dev/null | grep -v ".tar" | grep -v ".sh" | head -n1` &&
       echo ${PMM_CLIENT} &&

--- a/qa-integration/pmm_qa/tasks/install_pmm_client.yml
+++ b/qa-integration/pmm_qa/tasks/install_pmm_client.yml
@@ -148,8 +148,6 @@
       elif [ "$client_version" = "3.8.1" ] || [ "$minor_version" -gt 8 ]; then
         build_number=1
       fi
-      # Removed first so wget resumes only its own partial: containers are recreated
-      # between outer retries, so nothing older can be resumed into.
       rm -f /pmm-client.deb
       wget --continue --timeout=60 --waitretry=15 --progress=dot:giga \
         -O /pmm-client.deb "https://repo.percona.com/pmm3-client/apt/pool/main/p/pmm-client/pmm-client_${client_version}-${build_number}.$(lsb_release -sc)_amd64.deb"


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://github.com/percona/pmm-qa/actions/runs/34233153827
- tests:
  - `.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml` / setup shard `ps-replication`, step **Setup PMM-Client against remote PMM Server** (no test spec — the failure is in setup, and it took the whole run's tests with it)

## What happened

Nightly run **316** (`SERVER_IP=3.141.43.210`, `client_version=3.8.1`) failed on exactly one job: `setup / ps-replication`. The step runs

```
sudo timeout -k 30 9m bash -x pmm3-client-setup.sh --client_version 3.8.1 …
```

which lands in the released-version branch of `pmm3-client-setup.sh` and did a bare
`wget -O pmm-client.deb https://repo.percona.com/…/pmm-client_3.8.1-1.jammy_amd64.deb` —
`Length: 178025706 (170M)`.

From the job log:

| | reached | rate | outcome |
|---|---|---|---|
| Attempt 1 (13:50:51 → 13:59:29) | `94650K` — **54%** | ~190 KB/s | `Code: 124` |
| Attempt 2 (13:59:43 → 14:08:40) | `113750K` — **65%** | ~250 KB/s | `Code: 124`, `Final attempt failed` |

`--continue` was absent, so attempt 2 threw away attempt 1's 94 MB and re-raced the same
9-minute clock from byte 0. Then `fail-fast: true` on the `setup` matrix cancelled the other
13 setup shards, and all three `test execution / …` jobs failed in **Wait for all setup jobs
to be ready** having executed **zero tests**.

## Not the product, and not a broken artifact

Re-checked the URL during triage: `HTTP/2 200`, `content-length: 178025706`,
`etag: "6a31348d-a9c74ea"`, `last-modified: Tue, 16 Jun 2026 11:33:33 GMT` — unchanged and
healthy, and it served the full 170 MB in 11 s (16 MB/s) from the triage host. The origin is
fine; the runner→OVH path was slow at that moment. Throughput for this same file *within the
same run* spanned **0.19–3.8 MB/s**:

| shard | step 7 duration |
|---|---|
| `mysql` | 1m15s |
| `pgsql` | 2m16s |
| `pxc` | **8m18s** — under the 9m wall by 42 s |
| `ps-replication` | never finished |

So `pxc` was one bad minute away from failing the same way. This is not specific to
`ps-replication`: today's other nightly failures tripped on a different shard each time
(`setup / ps-gr` in run 314, `setup / extra-pxc` in run 312).

## The fix

Every place that fetches the PMM client for CI. Review of the first commit established that
hardening only `pmm3-client-setup.sh` left the same defect on the path that installs the
client *inside each monitored container* — see the resolved threads.

**Download hardening** — `--continue` where the URL is immutable, `--timeout=60
--waitretry=15` everywhere, `--progress=dot:giga` so a failing step stays readable (the
default dot style emitted ~2000 progress lines per attempt, which is what made the original
failure unreadable from a log tail):

| file | site | resumable? |
|---|---|---|
| `pmm3-client-setup.sh` | deb (released version) | yes — partial named after the version |
| `pmm3-client-setup.sh` | tarball | **no** |
| `pmm3-client-setup-centos.sh` | rpm (released version) | yes — partial named after the version |
| `pmm3-client-setup-centos.sh` | tarball | **no** |
| `tasks/install_pmm_client.yml:151` | deb, in-container | yes — `rm -f` first |
| `tasks/install_pmm_client.yml:170` | rpm, in-container | yes — `rm -f` first |
| `tasks/install_pmm_client.yml:183` | tarball, in-container | **no** |

The tarball paths deliberately keep restarting: `pmm-client-latest.tar.gz` is mutable under a
fixed name, so resuming into it would splice two different builds. The two scripts run in the
runner workspace, which survives an outer retry, so their partials are version-named and
resume *across* attempts. The container paths cannot — `on_retry_command` wipes every
container — so there the deb and rpm are removed first and `--continue` serves only wget's own
internal retries, with no stale file to splice into.

`tasks/install_pmm_client.yml` matters because ten setup playbooks include it (mysql,
percona-server, postgresql, pdpgsql single/replication/patroni, valkey sentinel/cluster,
external, add_mysql), making it what runs during **Run setup for E2E tests** — the sibling
step in these same two workflows, under the same budget.

**No `--tries`.** An earlier revision set `--tries=3`; that replaced wget's default of **20**
and did not do what it was added for. A stall is bounded by `--timeout=60`; `--tries` caps how
many times wget *recovers*, and with `--continue` each recovery is a resume. Three connection
resets and wget would exit, discarding the rest of the budget this PR buys. The outer
`timeout -k 30 19m` is the bound.

**Budget: 9m → 19m** (`timeout_minutes: 10 → 20`) in the two workflows that wrap
`pmm3-client-setup.sh` in a clock — `runner-e2e-tests-codeceptjs-remote-nightly-setup.yml` and
`ha-e2e-tests.yml`. This matches the sibling **Run setup for E2E tests** step already at
20m/19m in both files, and sits well inside the job budgets (120 min nightly, 90 min HA).
`ha-e2e-tests.yml` carried the byte-identical 9m wrapper, so it had the same latent failure.

## Verification

Against the real artifact URL, not a mock.

**1. Resume produces a byte-identical file.** Killed a download at 135,757,469 bytes, re-ran
with `--continue`: wget skipped the existing data and finished at exactly `178025706`.
`md5 = 00e2a5ae3b7284663c4fae51b090a5bf`, identical to a full fresh `curl` of the same URL.

**2. The failure reproduces under the wrapper, and the fix changes the outcome.** Two
attempts of a 20 s `timeout` against a `--limit-rate=4m` cap — the same shape as CI's
`2 × timeout 9m` at ~190 KB/s:

```
OLD (no --continue)  attempt 1: exit=124 size=81641117   attempt 2: exit=124 size=82099869
NEW (--continue)     attempt 1: exit=124 size=75087517   attempt 2: exit=124 size=156761360
```

The old command's second attempt lands where the first did — the real run's 54% → 65% dead
end. The new one carries 75 MB forward and reaches 88% of the file on the same total budget;
at 2 × 19m rather than 2 × 20s it completes with wide margin.

**Static:** `.claude/hooks/lint-changed.sh` (yamllint + shellcheck) clean on all changed
files; `bash -n` clean on both scripts; the ansible task file parses.

### Reproduction gap, stated plainly

**No Linode VM was provisioned.** The failure is a `timeout` killing a `wget` on a GitHub
runner, and the log carries the byte counts, rates and both exit-124s directly — and a
throwaway VM on a fast link cannot reproduce a runner→OVH network path either way. The
mechanism was instead reproduced against the real URL under the same wrapper shape, above.
Nightly's PMM Server is external and already gone, so the original run cannot be re-run.

**What only a real run can confirm:** that a nightly at ~190 KB/s now completes. A fresh
nightly against this branch is available if wanted — the dispatching Jenkins job takes
`PMM_QA_GIT_BRANCH`.

## Left out deliberately: `fail-fast: true`

The download timeout is the *cause*; `fail-fast: true` on the `setup` matrix
(`nightly-e2e-tests-matrix.yml:80`) is the *amplifier* that turned one slow shard into 13
cancelled shards and a nightly that reported nothing. Flipping it to `false` is not a
one-liner: the test-execution runners wait on `expected_setup_jobs: 14`, so surviving shards
would need that counting logic reworked to distinguish "failed" from "not ready yet", plus its
own verification. Worth doing as its own change — flagging it rather than smuggling it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S56rE1VTWvwwNpa5CBgy1e

---
_Generated by [Claude Code](https://claude.ai/code/session_01S56rE1VTWvwwNpa5CBgy1e)_