### PR TITLE
Keep parallel setup logs when the framework is interrupted

### DIFF
--- a/qa-integration/pmm_qa/pmm-framework/lib/execution.sh
+++ b/qa-integration/pmm_qa/pmm-framework/lib/execution.sh
@@ -214,7 +214,9 @@ print_setup_log() {
 # half-provisioned containers mid-run leaves more mess than it saves.
 #
 # On success the log directory is removed; on failure it is kept and its path
-# printed, so the full transcripts survive for inspection.
+# printed, so the full transcripts survive for inspection. An INT/TERM
+# interrupt keeps it too and dumps the partial log of every setup still
+# running -- under `timeout` in CI that is the only record there will be.
 #
 # Requires: bash 5.1+ for `wait -n -p`
 # Reads:    DATABASE_SPECS
@@ -234,14 +236,31 @@ run_parallel_setups() {
 
   # shellcheck disable=SC2329 # Invoked by the INT/TERM trap.
   cleanup_parallel_jobs() {
-    local pid
+    local pid index
     for pid in "${pids[@]}"; do
       # Negative PID targets the whole process group; fall back to the single
       # process if the group is already gone.
       kill -- -"$pid" >/dev/null 2>&1 || kill "$pid" >/dev/null 2>&1 || true
     done
+    # The kills are issued, so job control has done its job; leaving monitor
+    # mode on would interleave "[1]+ Terminated ..." notices into the dump.
+    set +m
+
+    # In CI the signal is almost always `timeout` firing, and the buffered logs
+    # are the only record of how far each setup got. Deleting them left a
+    # nightly shard that burned two 19-minute attempts reporting nothing but
+    # "Starting [1/1] valkey". Dump before waiting on the children: `timeout
+    # -k` follows up with SIGKILL, and output already written beats output
+    # complete but never printed.
+    printf '\nInterrupted -- dumping partial logs of the setups still running.\n'
+    for ((index = 0; index < total; index++)); do
+      [[ -n ${pids[index]} ]] || continue
+      print_setup_log \
+        "$((index + 1))" "$total" "${DATABASE_SPECS[index]}" 130 "${logs[index]}"
+    done
+    printf '\nParallel setup logs kept at: %s\n' "$log_dir"
+
     wait >/dev/null 2>&1 || true
-    rm -rf "$log_dir"
     exit 130
   }
   trap cleanup_parallel_jobs INT TERM

--- a/qa-integration/pmm_qa/pmm-framework/tests/integration.bats
+++ b/qa-integration/pmm_qa/pmm-framework/tests/integration.bats
@@ -31,6 +31,10 @@ if [[ ${PARALLEL_TEST:-false} == true ]]; then
     echo 'PGSQL parallel log'
   fi
 fi
+if [[ ${HANG_PS:-false} == true && -n ${PS_VERSION:-} ]]; then
+  echo 'PS is still working'
+  sleep 60
+fi
 if [[ ${FAIL_PS:-false} == true && -n ${PS_VERSION:-} ]]; then
   echo 'PS failed as requested'
   exit 9
@@ -125,6 +129,32 @@ EOF
   [[ $output == *'[2/2] pgsql=16: OK (log:'* ]]
   [[ $output == *'Parallel setup logs kept at:'* ]]
   [[ $(grep -c -- '--- call ---' "$RECORD_FILE") -eq 2 ]]
+}
+
+@test "a parallel run killed mid-setup dumps the partial logs it had" {
+  # `timeout` around the framework is how CI runs it, so SIGTERM must not take
+  # the buffered logs with it -- that is what left a nightly valkey shard
+  # reporting nothing after two 19-minute attempts.
+  run timeout -s TERM 8 env \
+    PATH="$TEST_BIN:$PATH" \
+    RECORD_FILE="$RECORD_FILE" \
+    HANG_PS=true \
+    "$FRAMEWORK_DIR/pmm-framework" \
+      --parallel \
+      --pmm-server-ip 10.0.0.5 \
+      --database ps=8.4 \
+      --database pgsql=16
+
+  # 124 is `timeout`'s own "I had to signal it" status -- the exact code the
+  # failing nightly job reported.
+  [[ $status -eq 124 ]]
+  [[ $output == *'Interrupted -- dumping partial logs'* ]]
+  [[ $output == *'PS is still working'* ]]
+  [[ $output == *'Parallel setup logs kept at:'* ]]
+  if grep -qE '^\[[0-9]+\][-+]?[[:space:]]' <<<"$output"; then
+    echo "job-control notifications leaked into the interrupted dump"
+    return 1
+  fi
 }
 
 @test "parallel mode job control emits no job-status noise" {


### PR DESCRIPTION
## Failures fixed (investigator)

- source: `Nightly E2E tests Matrix (remote PMM Server)` run https://github.com/percona/pmm-qa/actions/runs/34233131739
- tests:
  - `setup / valkey` shard, step *Run setup for E2E tests* — `pmm-framework --parallel --database valkey`, killed by `timeout -k 30 19m` on both attempts (`Child_process exited with error code 124`)

**This PR does not fix that timeout — the timeout did not reproduce.** It fixes why the timeout arrived with no evidence at all, which is what made it undiagnosable.

## What the failing run reported

```
##[group]Attempt 1
Starting [1/1] valkey
<19 minutes of silence>
##[warning]Attempt 1 failed. Reason: Child_process exited with error code 124
##[group]Attempt 2
Starting [1/1] valkey
##[error]Final attempt failed. Child_process exited with error code 124
```

That is the whole record of a 38-minute failure. `valkey` was the only failing shard; `fail-fast: true` then cancelled the other 13 setup shards, and all three `test execution / *` jobs aborted with *"Setup job(s) failed or were cancelled"*, so the run executed **zero tests**.

## Root cause of the missing output

In `--parallel` mode every setup's stdout/stderr goes to a per-setup file and is echoed only once that setup finishes (`print_setup_log`). The nightly setup shards always pass `--parallel` with a single `--database`, so *all* output is buffered. `run_parallel_setups`' INT/TERM trap then did:

```bash
    wait >/dev/null 2>&1 || true
    rm -rf "$log_dir"
    exit 130
```

`timeout` kills the framework with SIGTERM, the trap deletes the log directory, and the transcript dies with it.

The fix dumps the partial log of every setup still running and keeps the directory. Two details are deliberate:

- **Dump before `wait`.** CI runs `timeout -k 30`, so SIGKILL follows 30 s later; output already written beats output complete but never printed.
- **`set +m` first.** The kills are already issued, and leaving monitor mode on interleaved `[1]+ Terminated ( run_database_spec ... )` into the dump.

Slots that already reported are skipped (`pids[index]` is cleared as each is reaped), so nothing is printed twice, and the success path is untouched.

## Verification

Throwaway Linode VM (6 vCPU), `perconalab/pmm-server:3-dev-latest` (`sha256:b5e301b7de7c…`), client `3.7.1`, `--database valkey` — the same setup args and client version the failing shard used.

**Before / after, same box, same command under a deliberately short `timeout -k 30 90s`:**

| Revision | Output on timeout |
|---|---|
| `main` (c80047c) | `Starting [1/1] valkey`, exit 124 — **1 line, byte-identical to CI** |
| this branch | 436 lines: the full partial Ansible transcript, ending at the task it was on — `TASK [Install specific PMM client version on Debian-family containers]` |

**Success path unchanged** on this branch: `[1/1] valkey: OK (log: …)`, rc=0, 175 s — one summary line, no dump, log directory removed.

`bats tests` — **57/57 pass**, including the new *"a parallel run killed mid-setup dumps the partial logs it had"*, which drives the real `timeout -s TERM` path and asserts exit 124 (what CI actually reports), the dumped partial log, the kept log directory, and no job-control noise. `make syntax` clean; `shellcheck -S warning -x` (the severity `.claude/hooks/lint-changed.sh` uses) clean on both changed files. `make lint` inside `pmm-framework` fails identically on `main` and on this branch — 17 pre-existing `SC2317` infos plus a stray `*.sh` glob — so it is untouched here, not newly broken.

## Why the valkey timeout itself is not fixed here

It did not reproduce, and nothing in the evidence points at the playbook:

| Condition (VM, client 3.7.1) | Result |
|---|---|
| Idle | **pass**, 2m59s |
| Saturated (`load avg ≈ 14` on 6 vCPU, 12 spinners) | **pass ×3** — 264s / 251s / 260s |

Against a 19-minute budget, even the loaded runs finish 4× inside it. And the same shard, same playbook, was green 8 hours earlier in run [34190484752](https://github.com/percona/pmm-qa/actions/runs/34190484752) at **4m48s** (`05:26:09 → 05:30:57`).

What the run's own artifacts add: `logs/pmm-managed.log` only covers `14:14:00 → 14:20:16` (30 MB of debug logging, rotated), so it says nothing about attempt 1. Inside that window the valkey nodes register at `14:16:19` (`valkey-primary-2`) and `14:16:42` (`valkey-primary-3`) — 23 s apart, i.e. running at normal speed by then, but only on container 2 of 6 some 18 minutes into attempt 2. No server-side error accompanies it. The concurrent sibling run [34233153827](https://github.com/percona/pmm-qa/actions/runs/34233153827) (own server, client 3.8.1) failed the same shape in a *different* shard — `setup / ps-replication` blowing the 9-minute `pmm3-client-setup.sh` budget twice — which fits environment-wide slowness at 13:37–14:18 UTC rather than anything valkey-specific. Jenkins fanned out 11 `pmm3-ui-tests-nightly-gha` builds within the same second (`#422`–`#432`, 13:26:18 UTC), i.e. ~154 setup runners at once, all pulling the same Debian/Percona packages and Docker images.

Nightly cannot be re-run (its PMM Server is external and already gone), so the timeout stays classified as environmental and is **not** filed as a product bug. Deliberately **not** done here: raising the 19-minute budget. Nothing measured says the budget is too small — a green 4m48s in CI and 4m24s under saturation say the opposite — so raising it would only hide the next occurrence. With this PR merged, the next occurrence names the task it hung on, and that is what a budget change should be argued from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rSXWNc5XT6WidxpmgV8hd

---
_Generated by [Claude Code](https://claude.ai/code/session_019rSXWNc5XT6WidxpmgV8hd)_