### PR TITLE
Dump buffered setup logs when a parallel run is signalled

### DIFF
--- a/qa-integration/pmm_qa/pmm-framework/lib/execution.sh
+++ b/qa-integration/pmm_qa/pmm-framework/lib/execution.sh
@@ -210,15 +210,19 @@ print_setup_log() {
   dump_setup_log "$index" "$total" "$spec" "$log_file"
 }
 
-# Report one parallel setup that was still running when we were signalled.
+# Report one parallel setup that had not been reported when we were signalled.
 #
 # Usage: print_interrupted_setup_log INDEX TOTAL SPEC LOG_FILE
+#
+# A filled slot means "never reported", which is not the same as "still
+# running": a child that exited before `wait -n` reaped it also still holds its
+# slot. The banner says unreported rather than running for that reason.
 #
 # Stdout: an INTERRUPTED banner plus however much of the log had been written
 print_interrupted_setup_log() {
   local index=$1 total=$2 spec=$3 log_file=$4
 
-  printf '\n===== [%d/%d] %s INTERRUPTED (still running when signalled) =====\n' \
+  printf '\n===== [%d/%d] %s INTERRUPTED (no completion reported) =====\n' \
     "$index" "$total" "$spec"
   printf 'log: %s\n' "$log_file"
   dump_setup_log "$index" "$total" "$spec" "$log_file"
@@ -262,8 +266,8 @@ run_parallel_setups() {
       kill -- -"$pid" >/dev/null 2>&1 || kill "$pid" >/dev/null 2>&1 || true
     done
 
-    # A slot still holding a pid never reached print_setup_log, so its buffered
-    # log is the only record of how far it got. Dump before the wait and the rm:
+    # A slot still holding a pid was never reported, so its buffered log is the
+    # only record of how far it got. Dump before the wait and the rm:
     # `timeout -k 30` leaves only 30s before SIGKILL. The trap is installed
     # before the startup loop, so a signal mid-startup leaves later slots unset
     # and the fork's redirect may not have created the log yet -- hence `:-` and
@@ -309,10 +313,13 @@ run_parallel_setups() {
     for ((index = 0; index < total; index++)); do
       if [[ ${pids[index]} == "$finished_pid" ]]; then
         ((status == 0)) || overall_status=1
+        # Clear the slot *before* reporting: the INT/TERM trap treats a filled
+        # slot as unreported, so a signal arriving mid-report would otherwise
+        # dump this same log a second time under its own banner.
+        pids[index]=
         print_setup_log \
           "$((index + 1))" "$total" "${DATABASE_SPECS[index]}" \
           "$status" "${logs[index]}"
-        pids[index]=
         matched=true
         break
       fi

--- a/qa-integration/pmm_qa/pmm-framework/lib/execution.sh
+++ b/qa-integration/pmm_qa/pmm-framework/lib/execution.sh
@@ -164,6 +164,22 @@ should_dump_successful_logs() {
   [[ ${VERBOSE:-false} == true ]]
 }
 
+# Echo one buffered setup log between markers.
+#
+# Usage: dump_setup_log INDEX TOTAL SPEC LOG_FILE
+#
+# Stdout: the log file's contents, framed so concurrent setups stay readable
+dump_setup_log() {
+  local index=$1 total=$2 spec=$3 log_file=$4
+
+  cat "$log_file"
+  # Keep the END marker on its own line when the log has no trailing newline.
+  if [[ -s $log_file ]] && (($(tail -c 1 "$log_file" | wc -l) == 0)); then
+    printf '\n'
+  fi
+  printf '===== END [%d/%d] %s =====\n' "$index" "$total" "$spec"
+}
+
 # Report one finished parallel setup.
 #
 # Usage: print_setup_log INDEX TOTAL SPEC STATUS LOG_FILE
@@ -183,11 +199,7 @@ print_setup_log() {
     printf '[%d/%d] %s: OK (log: %s)\n' "$index" "$total" "$spec" "$log_file"
     if should_dump_successful_logs; then
       printf '\n===== [%d/%d] %s setup log =====\n' "$index" "$total" "$spec"
-      cat "$log_file"
-      if [[ -s $log_file ]] && (($(tail -c 1 "$log_file" | wc -l) == 0)); then
-        printf '\n'
-      fi
-      printf '===== END [%d/%d] %s =====\n' "$index" "$total" "$spec"
+      dump_setup_log "$index" "$total" "$spec" "$log_file"
     fi
     return
   fi
@@ -195,12 +207,21 @@ print_setup_log() {
   printf '\n===== [%d/%d] %s FAILED (exit=%d) =====\n' \
     "$index" "$total" "$spec" "$status"
   printf 'log: %s\n' "$log_file"
-  cat "$log_file"
-  # Keep the END marker on its own line when the log has no trailing newline.
-  if [[ -s $log_file ]] && (($(tail -c 1 "$log_file" | wc -l) == 0)); then
-    printf '\n'
-  fi
-  printf '===== END [%d/%d] %s =====\n' "$index" "$total" "$spec"
+  dump_setup_log "$index" "$total" "$spec" "$log_file"
+}
+
+# Report one parallel setup that was still running when we were signalled.
+#
+# Usage: print_interrupted_setup_log INDEX TOTAL SPEC LOG_FILE
+#
+# Stdout: an INTERRUPTED banner plus however much of the log had been written
+print_interrupted_setup_log() {
+  local index=$1 total=$2 spec=$3 log_file=$4
+
+  printf '\n===== [%d/%d] %s INTERRUPTED (still running when signalled) =====\n' \
+    "$index" "$total" "$spec"
+  printf 'log: %s\n' "$log_file"
+  dump_setup_log "$index" "$total" "$spec" "$log_file"
 }
 
 # Provision every spec concurrently, reporting each as it finishes.
@@ -234,12 +255,24 @@ run_parallel_setups() {
 
   # shellcheck disable=SC2329 # Invoked by the INT/TERM trap.
   cleanup_parallel_jobs() {
-    local pid
+    local pid index
     for pid in "${pids[@]}"; do
       # Negative PID targets the whole process group; fall back to the single
       # process if the group is already gone.
       kill -- -"$pid" >/dev/null 2>&1 || kill "$pid" >/dev/null 2>&1 || true
     done
+
+    # A slot still holding a pid never reached print_setup_log, so its buffered
+    # log is the only record of how far it got. CI runs this under `timeout`,
+    # whose SIGTERM lands here, and the log dir sits on a runner disk that is
+    # discarded with the job -- so dump before waiting (a wedged child must not
+    # cost us the bytes already on disk) and before the rm below.
+    for ((index = 0; index < total; index++)); do
+      [[ -n ${pids[index]} ]] || continue
+      print_interrupted_setup_log \
+        "$((index + 1))" "$total" "${DATABASE_SPECS[index]}" "${logs[index]}"
+    done
+
     wait >/dev/null 2>&1 || true
     rm -rf "$log_dir"
     exit 130

--- a/qa-integration/pmm_qa/pmm-framework/lib/execution.sh
+++ b/qa-integration/pmm_qa/pmm-framework/lib/execution.sh
@@ -263,12 +263,13 @@ run_parallel_setups() {
     done
 
     # A slot still holding a pid never reached print_setup_log, so its buffered
-    # log is the only record of how far it got. CI runs this under `timeout`,
-    # whose SIGTERM lands here, and the log dir sits on a runner disk that is
-    # discarded with the job -- so dump before waiting (a wedged child must not
-    # cost us the bytes already on disk) and before the rm below.
+    # log is the only record of how far it got. Dump before the wait and the rm:
+    # `timeout -k 30` leaves only 30s before SIGKILL. The trap is installed
+    # before the startup loop, so a signal mid-startup leaves later slots unset
+    # and the fork's redirect may not have created the log yet -- hence `:-` and
+    # the -f, without which `set -u`/`set -e` would abort the trap here.
     for ((index = 0; index < total; index++)); do
-      [[ -n ${pids[index]} ]] || continue
+      [[ -n ${pids[index]:-} && -f ${logs[index]} ]] || continue
       print_interrupted_setup_log \
         "$((index + 1))" "$total" "${DATABASE_SPECS[index]}" "${logs[index]}"
     done

--- a/qa-integration/pmm_qa/pmm-framework/tests/integration.bats
+++ b/qa-integration/pmm_qa/pmm-framework/tests/integration.bats
@@ -128,10 +128,8 @@ EOF
 }
 
 @test "an interrupted parallel run dumps the log of the setup still running" {
-  # CI wraps the framework in `timeout`, so a wedged setup is killed by SIGTERM
-  # and never reaches print_setup_log. Its buffered log is the only record of
-  # how far it got, and the log dir dies with the runner -- so the INT/TERM
-  # trap has to dump it before removing the dir.
+  # A wedged setup is SIGTERMed and never reaches print_setup_log, so only the
+  # INT/TERM trap can dump its buffered log before the log dir is removed.
   cat >"$TEST_BIN/ansible-playbook" <<'EOF'
 #!/usr/bin/env bash
 echo 'PS reached the wedge point'

--- a/qa-integration/pmm_qa/pmm-framework/tests/integration.bats
+++ b/qa-integration/pmm_qa/pmm-framework/tests/integration.bats
@@ -127,6 +127,49 @@ EOF
   [[ $(grep -c -- '--- call ---' "$RECORD_FILE") -eq 2 ]]
 }
 
+@test "an interrupted parallel run dumps the log of the setup still running" {
+  # CI wraps the framework in `timeout`, so a wedged setup is killed by SIGTERM
+  # and never reaches print_setup_log. Its buffered log is the only record of
+  # how far it got, and the log dir dies with the runner -- so the INT/TERM
+  # trap has to dump it before removing the dir.
+  cat >"$TEST_BIN/ansible-playbook" <<'EOF'
+#!/usr/bin/env bash
+echo 'PS reached the wedge point'
+touch "$WEDGE_MARKER"
+sleep 300
+EOF
+  chmod +x "$TEST_BIN/ansible-playbook"
+
+  local out=$BATS_TEST_TMPDIR/interrupted.log
+  local marker=$BATS_TEST_TMPDIR/wedged
+  local fw_pid status=0
+
+  env \
+    PATH="$TEST_BIN:$PATH" \
+    RECORD_FILE="$RECORD_FILE" \
+    WEDGE_MARKER="$marker" \
+    "$FRAMEWORK_DIR/pmm-framework" \
+      --parallel \
+      --pmm-server-ip 10.0.0.5 \
+      --database ps=8.4 \
+    >"$out" 2>&1 &
+  fw_pid=$!
+
+  for _ in $(seq 1 200); do
+    [[ -f $marker ]] && break
+    sleep 0.1
+  done
+  [[ -f $marker ]]
+
+  kill -TERM "$fw_pid"
+  wait "$fw_pid" || status=$?
+
+  [[ $status -eq 130 ]]
+  [[ $(cat "$out") == *'===== [1/1] ps=8.4 INTERRUPTED (still running when signalled) ====='* ]]
+  [[ $(cat "$out") == *'PS reached the wedge point'* ]]
+  [[ $(cat "$out") == *'===== END [1/1] ps=8.4 ====='* ]]
+}
+
 @test "parallel mode job control emits no job-status noise" {
   run env \
     PATH="$TEST_BIN:$PATH" \

--- a/qa-integration/pmm_qa/pmm-framework/tests/integration.bats
+++ b/qa-integration/pmm_qa/pmm-framework/tests/integration.bats
@@ -127,7 +127,7 @@ EOF
   [[ $(grep -c -- '--- call ---' "$RECORD_FILE") -eq 2 ]]
 }
 
-@test "an interrupted parallel run dumps the log of the setup still running" {
+@test "an interrupted parallel run dumps the log of the unreported setup" {
   # A wedged setup is SIGTERMed and never reaches print_setup_log, so only the
   # INT/TERM trap can dump its buffered log before the log dir is removed.
   cat >"$TEST_BIN/ansible-playbook" <<'EOF'
@@ -163,9 +163,52 @@ EOF
   wait "$fw_pid" || status=$?
 
   [[ $status -eq 130 ]]
-  [[ $(cat "$out") == *'===== [1/1] ps=8.4 INTERRUPTED (still running when signalled) ====='* ]]
+  [[ $(cat "$out") == *'===== [1/1] ps=8.4 INTERRUPTED (no completion reported) ====='* ]]
   [[ $(cat "$out") == *'PS reached the wedge point'* ]]
   [[ $(cat "$out") == *'===== END [1/1] ps=8.4 ====='* ]]
+}
+
+@test "a signal mid-report does not re-dump the reported setup as interrupted" {
+  # The reported slot must be cleared before print_setup_log runs, or a signal
+  # arriving while it cats a large log makes the trap dump that same log again
+  # under an INTERRUPTED banner -- mislabelling a setup that already reported.
+  # The window is the length of the cat, so the log has to be big to hit it.
+  cat >"$TEST_BIN/ansible-playbook" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n ${PGSQL_VERSION:-} ]]; then
+  yes 'PGSQL FAILED LOG LINE' | head -c 50000000
+  exit 9
+fi
+sleep 300
+EOF
+  chmod +x "$TEST_BIN/ansible-playbook"
+
+  local out=$BATS_TEST_TMPDIR/midreport.log
+  local fw_pid status=0
+
+  env \
+    PATH="$TEST_BIN:$PATH" \
+    RECORD_FILE="$RECORD_FILE" \
+    "$FRAMEWORK_DIR/pmm-framework" \
+      --parallel \
+      --pmm-server-ip 10.0.0.5 \
+      --database pgsql=16 \
+      --database ps=8.4 \
+    >"$out" 2>&1 &
+  fw_pid=$!
+
+  for _ in $(seq 1 600); do
+    grep -q 'pgsql=16 FAILED' "$out" 2>/dev/null && break
+    sleep 0.05
+  done
+
+  kill -TERM "$fw_pid"
+  wait "$fw_pid" || status=$?
+
+  [[ $status -eq 130 ]]
+  # ps never reported, so it is legitimately interrupted; pgsql did report.
+  [[ $(grep -c 'pgsql=16 INTERRUPTED' "$out") -eq 0 ]]
+  [[ $(grep -c 'ps=8.4 INTERRUPTED' "$out") -eq 1 ]]
 }
 
 @test "parallel mode job control emits no job-status noise" {


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://github.com/percona/pmm-qa/actions/runs/34232923771 (Nightly E2E tests Matrix, `INSTALLATION_TYPE=docker`)
- tests:
  - `setup / ps-gr` — `pmm-framework --parallel --database ps,SETUP_TYPE=gr` (not a spec/tag; the failing job is a setup shard)

## What actually failed

`setup / ps-gr` timed out on **both** attempts (`timeout -k 30 19m`, exit 124), which failed the run and cancelled the other 13 setup shards. The 3 `test execution` jobs then failed at their setup gate having run **zero** tests:

```
Setup job(s) failed or were cancelled: … setup / ps-gr (failure)
```

The entire diagnostic record of the 19-minute hang was these two lines:

```
Starting [1/1] ps,SETUP_TYPE=gr
##[warning]Attempt 1 failed. Reason: Child_process exited with error code 124
```

## Why there was nothing to go on — the bug this PR fixes

In `--parallel` mode `run_parallel_setups` redirects each setup's stdout/stderr to a per-setup log file and prints it only via `print_setup_log`, i.e. only once that setup *finishes*. CI wraps the framework in `timeout`, whose `SIGTERM` lands in the `INT`/`TERM` trap — and that trap killed the children and then `rm -rf`'d the log directory, destroying the only record of how far the setup got.

So a wedged setup could not produce a diagnosis on a CI runner even in principle: the buffered log was deleted, and its directory lived on a runner disk discarded with the job.

Reproduced byte-for-byte on a throwaway 6-vCPU Linode VM at `main`, same command shape as CI:

```
$ timeout -k 30 90s ./pmm-framework/pmm-framework --parallel … --database ps,SETUP_TYPE=gr
Starting [1/1] ps,SETUP_TYPE=gr
EXIT=124
--- what survived on disk? ---
LOG DIR GONE
```

One line of output and no log — exactly the CI symptom.

## The fix

Three commits — the first is the change, the other two are review findings against it, both real.

**`98017bb`** — in the `INT`/`TERM` trap, dump the buffered log of every setup whose slot is still filled (a cleared slot means it already went through `print_setup_log`) before waiting on the children and before removing the directory. Dumping *before* the `wait` is deliberate: a child that ignores `SIGTERM` must not cost us the bytes already on disk, and `timeout -k 30` leaves only 30s before `SIGKILL`. The cat/trailing-newline logic is factored into `dump_setup_log` so the new `print_interrupted_setup_log` and the existing success/failure paths share one implementation.

**`61e4310`** — guards the new loop's slot lookup. The trap is installed *before* the startup loop populates `pids`, so a signal arriving mid-startup reached the dump loop with slots that were never assigned; under the framework's `set -euo pipefail` (`pmm-framework:25`), `${pids[index]}` on an unset subscript is an unbound-variable error that aborts the trap **before** the `wait`, the `rm -rf` and `exit 130` — losing the banner for the slot that had started and leaking the log dir, the opposite of what the dump is for. Verified on bash 5.2.21:

```
slot 0 active
unbound-probe.sh: line 11: pids[index]: unbound variable
script exit=1
```

Guarded with `:-`, plus `-f` on the log so the narrow window where a fork's redirect has not yet created the file cannot trip `errexit` in `cat`.

**`feb6a80`** — clears the reported slot *before* `print_setup_log` runs. The wait loop cleared it only after that call returned, so a signal landing mid-report made the trap dump the same log a second time. With a 200 MB buffered log and `TERM` sent during the `FAILED` report:

```
line 4:           ===== [1/2] pgsql=16 FAILED (exit=1) =====
line 9,090,917:   ===== [1/2] pgsql=16 INTERRUPTED (still running when signalled) =====
line 18,181,830:  ===== END [1/2] pgsql=16 =====
```

382 MB of output for a 200 MB log, an already-reported setup relabelled interrupted, and the first report left with no `END` marker. The window is the length of the `cat`, so it is negligible on the default success path (one summary line) and wide whenever a setup fails (always dumps) or `--verbose` is used. The same commit renames the banner to `INTERRUPTED (no completion reported)`: a filled slot means "never reported", not "still running", since a child that exits before `wait -n` reaps it also still holds one.

No behaviour change on the success or failure paths, and the process exit code is unchanged (124 still comes from `timeout` itself).

## Verification

**Fix proven in the exact CI shape**, same VM, same command, on this branch:

| | output | interrupted banner | failing ansible task |
|---|---|---|---|
| `main` | 1 line | — | lost |
| this branch | 87 lines | present | `TASK [Install Percona Server for MySQL]` |

**Framework suite** — `bats tests`: **58/58 pass** (56 pre-existing + 2 new). Both new tests were confirmed to **fail** with only their respective fix reverted, so both are real regression tests:

- `an interrupted parallel run dumps the log of the unreported setup` — wedges a stubbed `ansible-playbook`, `SIGTERM`s the framework, asserts the banner, the buffered content and exit 130.
- `a signal mid-report does not re-dump the reported setup as interrupted` — 50 MB log to hold the window open; asserts the reported spec gets no `INTERRUPTED` banner while the genuinely unreported one does.

**Lint** — `make syntax` clean; `shellcheck -x -S warning` (the severity `.claude/hooks/lint-changed.sh` runs) clean across the framework. Note `make lint`'s bare `shellcheck` already fails on unmodified `main` — 17 × `SC2317`, all *info*, below the severity CI enforces; this PR adds no finding at or above `warning`.

**Happy path** — a full `ps,SETUP_TYPE=gr` provisioning run on this branch (green, healthy 3-node GR cluster: 1 `PRIMARY` + 2 `SECONDARY`, all `ONLINE`), plus two pre-fix runs on `main` (idle ~6 min, and ~7 min under `load average ≈ 18`); `bats` 42/43/50/51 cover the success- and failure-dump paths through the refactor.

## What this PR does *not* claim

**The underlying hang did not reproduce and is not fixed here.** `ps,SETUP_TYPE=gr` completed in ~6 min idle and ~7 min under saturation, against a 19-minute budget — 2/2 passes. Nightly cannot be re-run (its `pmm_server_address` points at an external Jenkins-provisioned server, long gone), so per the run's own artifacts instead: the remote server was healthy throughout (all supervisord services `RUNNING`, 44m uptime) and 13 of 14 shards registered their services — `ps_pmm_replication_8_0_*`, `ps_pmm_8_0_1`, `pxc_node_*`, `pdpgsql_pmm_patroni_*` and others all appear in `pmm-managed.log`, while `ps_pmm_gr_*` appears **zero** times. The hang was local to that shard's runner, with no server-side fault and no product-bug evidence.

**The mid-startup race (`61e4310`) has no test.** The startup loop's forks complete in microseconds, so a signal cannot be landed mid-startup deterministically from outside the process, and `cleanup_parallel_jobs` is nested inside `run_parallel_setups` so it cannot be driven directly. The probe above is the evidence; the guard is defensive. Stating it rather than implying coverage. (The mid-*report* race in `feb6a80` **is** covered — its window is large enough to hit reliably.)

**Nothing in CI runs these tests.** No workflow outside `helm-tests.yml` invokes `bats` or the framework `Makefile`'s targets, and `Lint` selects shell files with `select_files '\.sh$'` (`lint-changed.sh:46`) — so `lib/execution.sh` is shellchecked at `-S warning`, but `tests/integration.bats` is neither linted nor executed by any gate. The suite results above are therefore measurements I took, not invariants CI will hold. Pre-existing, and left alone deliberately: wiring `make check` cannot work as-is (it calls `make lint`, red on `main` today), so the workable shape is `make syntax` + `make test` with shellcheck left to the existing hook — a repo-CI decision with blast radius past this change. Details in [this comment](https://github.com/percona/pmm-qa/pull/1368#issuecomment-5587863958); happy to open it as its own PR.

Two observations worth a maintainer's eye, deliberately left out of this fix:

- **Not GR-specific.** Sibling nightly runs on the same commit that morning failed identically on `setup / ps-replication` ([313](https://github.com/percona/pmm-qa/actions/runs/34232768031), [316](https://github.com/percona/pmm-qa/actions/runs/34233153827)). The recurring pattern is "some setup shard blows the 19m budget", and until this PR every instance of it was undiagnosable for the reason above. **The next occurrence will name the ansible task it died in** — that is what this PR buys.
- **Eight nightly runs were dispatched within 13 minutes** on the same `head_sha` (run numbers 313–320, created 13:34–13:47Z), three still `queued` 40+ minutes later. 8 × 17 jobs is a lot of concurrent runners; I have not established that this caused the slow shard, so I am reporting it rather than acting on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bTFHgpcXrgwtvHUgciBCU