### PR TITLE
Keep the setup transcript when CI kills pmm-framework

### DIFF
--- a/qa-integration/pmm_qa/pmm-framework/ARCHITECTURE.md
+++ b/qa-integration/pmm_qa/pmm-framework/ARCHITECTURE.md
@@ -156,7 +156,10 @@ stay quiet. Individual callers can still opt in through `services_list` /
 
 Parallel mode enables job control (`set -m`) so each setup gets its own process
 group. That way an interrupt takes down `ansible-playbook` and its children
-too, not just the wrapper subshell. It is also why each job gets
+too, not just the wrapper subshell. The interrupt handler then dumps the
+buffered log of every setup still running and keeps the log directory, because
+CI wraps the framework in `timeout` and that buffer is the only record of where
+a hung setup got to. It is also why each job gets
 `</dev/null` — a background process group that reads the terminal is stopped by
 `SIGTTIN` and would hang forever.
 

--- a/qa-integration/pmm_qa/pmm-framework/README.md
+++ b/qa-integration/pmm_qa/pmm-framework/README.md
@@ -79,19 +79,14 @@ failure the log directory is kept for inspection; on a fully successful run it
 is removed.
 
 Each setup runs in its own process group, so interrupting the framework also
-terminates the `ansible-playbook` processes it started.
+terminates the `ansible-playbook` processes it started. An interrupt dumps the
+buffered log of every setup still running and keeps the log directory — under a
+`timeout` wrapper that buffer is the only record of where a setup got stuck.
 
 Setups that cannot run concurrently — two of the same database type, or any two
 of the MySQL family (PS/MySQL), which share `mysql_cluster_data` and host
 ports — are detected during preflight. The run is not rejected: it falls back
 to sequential execution with a warning, so every requested setup still runs.
-
-To rerun the representative four-database setup and print its wall-clock time
-to milliseconds:
-
-```bash
-qa-integration/pmm_qa/pmm-framework/run_parallel_timing.sh
-```
 
 `--database` values use this grammar:
 

--- a/qa-integration/pmm_qa/pmm-framework/lib/execution.sh
+++ b/qa-integration/pmm_qa/pmm-framework/lib/execution.sh
@@ -115,13 +115,6 @@ preflight_database_setups() {
     PARALLEL=false
   fi
 
-  # A lone setup has nothing to interleave with, so buffering its output buys
-  # nothing and costs live progress -- and costs it entirely when CI's
-  # `timeout` kills the run mid-setup, leaving only the "Starting" line behind.
-  if [[ $PARALLEL == true && ${#DATABASE_SPECS[@]} -eq 1 ]]; then
-    PARALLEL=false
-  fi
-
   [[ $needs_server == true ]] && resolve_pmm_server
   [[ $needs_curl == true ]] && require_command curl
   # Warm these up before forking so parallel jobs cannot race to install the
@@ -254,13 +247,15 @@ run_parallel_setups() {
     wait >/dev/null 2>&1 || true
     # The signal is usually CI's `timeout` giving up on a setup that hung, so
     # the buffers of the setups still running are the only record of where it
-    # got stuck. Dump them and keep the directory instead of deleting both.
+    # got stuck.
     for ((slot = 0; slot < total; slot++)); do
       [[ -n ${pids[slot]} ]] || continue
       printf '\n===== [%d/%d] %s INTERRUPTED =====\n' \
         "$((slot + 1))" "$total" "${DATABASE_SPECS[slot]}"
       printf 'log: %s\n' "${logs[slot]}"
-      cat_setup_log "${logs[slot]}"
+      # A signal between the fork and the child's own redirect leaves this file
+      # uncreated; errexit must not abandon the remaining slots over it.
+      cat_setup_log "${logs[slot]}" || true
       printf '===== END [%d/%d] %s =====\n' "$((slot + 1))" "$total" "${DATABASE_SPECS[slot]}"
     done
     printf '\nParallel setup logs kept at: %s\n' "$log_dir"

--- a/qa-integration/pmm_qa/pmm-framework/lib/execution.sh
+++ b/qa-integration/pmm_qa/pmm-framework/lib/execution.sh
@@ -115,6 +115,13 @@ preflight_database_setups() {
     PARALLEL=false
   fi
 
+  # A lone setup has nothing to interleave with, so buffering its output buys
+  # nothing and costs live progress -- and costs it entirely when CI's
+  # `timeout` kills the run mid-setup, leaving only the "Starting" line behind.
+  if [[ $PARALLEL == true && ${#DATABASE_SPECS[@]} -eq 1 ]]; then
+    PARALLEL=false
+  fi
+
   [[ $needs_server == true ]] && resolve_pmm_server
   [[ $needs_curl == true ]] && require_command curl
   # Warm these up before forking so parallel jobs cannot race to install the
@@ -164,6 +171,16 @@ should_dump_successful_logs() {
   [[ ${VERBOSE:-false} == true ]]
 }
 
+# Echo one buffered log, guaranteeing it ends on a line of its own so the END
+# marker that follows it is not appended to the log's last line.
+cat_setup_log() {
+  local log_file=$1
+  cat "$log_file"
+  if [[ -s $log_file ]] && (($(tail -c 1 "$log_file" | wc -l) == 0)); then
+    printf '\n'
+  fi
+}
+
 # Report one finished parallel setup.
 #
 # Usage: print_setup_log INDEX TOTAL SPEC STATUS LOG_FILE
@@ -183,10 +200,7 @@ print_setup_log() {
     printf '[%d/%d] %s: OK (log: %s)\n' "$index" "$total" "$spec" "$log_file"
     if should_dump_successful_logs; then
       printf '\n===== [%d/%d] %s setup log =====\n' "$index" "$total" "$spec"
-      cat "$log_file"
-      if [[ -s $log_file ]] && (($(tail -c 1 "$log_file" | wc -l) == 0)); then
-        printf '\n'
-      fi
+      cat_setup_log "$log_file"
       printf '===== END [%d/%d] %s =====\n' "$index" "$total" "$spec"
     fi
     return
@@ -195,11 +209,7 @@ print_setup_log() {
   printf '\n===== [%d/%d] %s FAILED (exit=%d) =====\n' \
     "$index" "$total" "$spec" "$status"
   printf 'log: %s\n' "$log_file"
-  cat "$log_file"
-  # Keep the END marker on its own line when the log has no trailing newline.
-  if [[ -s $log_file ]] && (($(tail -c 1 "$log_file" | wc -l) == 0)); then
-    printf '\n'
-  fi
+  cat_setup_log "$log_file"
   printf '===== END [%d/%d] %s =====\n' "$index" "$total" "$spec"
 }
 
@@ -213,8 +223,9 @@ print_setup_log() {
 # Every setup is allowed to finish even after one fails, because tearing down
 # half-provisioned containers mid-run leaves more mess than it saves.
 #
-# On success the log directory is removed; on failure it is kept and its path
-# printed, so the full transcripts survive for inspection.
+# On success the log directory is removed; on failure -- or when a signal cuts
+# the run short -- it is kept and its path printed, so the full transcripts
+# survive for inspection.
 #
 # Requires: bash 5.1+ for `wait -n -p`
 # Reads:    DATABASE_SPECS
@@ -234,14 +245,25 @@ run_parallel_setups() {
 
   # shellcheck disable=SC2329 # Invoked by the INT/TERM trap.
   cleanup_parallel_jobs() {
-    local pid
+    local pid slot
     for pid in "${pids[@]}"; do
       # Negative PID targets the whole process group; fall back to the single
       # process if the group is already gone.
       kill -- -"$pid" >/dev/null 2>&1 || kill "$pid" >/dev/null 2>&1 || true
     done
     wait >/dev/null 2>&1 || true
-    rm -rf "$log_dir"
+    # The signal is usually CI's `timeout` giving up on a setup that hung, so
+    # the buffers of the setups still running are the only record of where it
+    # got stuck. Dump them and keep the directory instead of deleting both.
+    for ((slot = 0; slot < total; slot++)); do
+      [[ -n ${pids[slot]} ]] || continue
+      printf '\n===== [%d/%d] %s INTERRUPTED =====\n' \
+        "$((slot + 1))" "$total" "${DATABASE_SPECS[slot]}"
+      printf 'log: %s\n' "${logs[slot]}"
+      cat_setup_log "${logs[slot]}"
+      printf '===== END [%d/%d] %s =====\n' "$((slot + 1))" "$total" "${DATABASE_SPECS[slot]}"
+    done
+    printf '\nParallel setup logs kept at: %s\n' "$log_dir"
     exit 130
   }
   trap cleanup_parallel_jobs INT TERM

--- a/qa-integration/pmm_qa/pmm-framework/tests/integration.bats
+++ b/qa-integration/pmm_qa/pmm-framework/tests/integration.bats
@@ -305,7 +305,7 @@ EOF
 
   # Both setups must have written to their buffers before the signal, or the
   # test would pass on an empty dump.
-  until [[ $(grep -c -- '--- call ---' "$RECORD_FILE" 2>/dev/null || echo 0) -eq 2 ]]; do
+  until [[ $(grep -c -- '--- call ---' "$RECORD_FILE" 2>/dev/null) == 2 ]]; do
     ((waited += 1))
     [[ $waited -lt 100 ]] || { kill "$fw_pid" 2>/dev/null; return 1; }
     sleep 0.2
@@ -319,7 +319,7 @@ EOF
   [[ $fw_status -eq 130 ]]
   [[ $output == *'===== [1/2] ps=8.4 INTERRUPTED ====='* ]]
   [[ $output == *'===== [2/2] pgsql=16 INTERRUPTED ====='* ]]
-  [[ $output == *'setup is working'* ]]
+  [[ $(grep -c 'setup is working' "$out") -eq 2 ]]
   [[ $output == *'Parallel setup logs kept at:'* ]]
 
   local log_dir
@@ -341,7 +341,7 @@ EOF
       --database ps=8.4 >"$out" 2>&1 &
   fw_pid=$!
 
-  until [[ $(grep -c -- '--- call ---' "$RECORD_FILE" 2>/dev/null || echo 0) -eq 1 ]]; do
+  until [[ $(grep -c -- '--- call ---' "$RECORD_FILE" 2>/dev/null) == 1 ]]; do
     ((waited += 1))
     [[ $waited -lt 100 ]] || { kill "$fw_pid" 2>/dev/null; return 1; }
     sleep 0.2
@@ -354,7 +354,7 @@ EOF
 
   [[ $fw_status -eq 130 ]]
   [[ $output == *'===== [1/1] ps=8.4 INTERRUPTED ====='* ]]
-  [[ $output == *'setup is working'* ]]
+  [[ $(grep -c 'setup is working' "$out") -eq 1 ]]
 
   local log_dir
   log_dir=$(sed -n 's/^Parallel setup logs kept at: //p' "$out")

--- a/qa-integration/pmm_qa/pmm-framework/tests/integration.bats
+++ b/qa-integration/pmm_qa/pmm-framework/tests/integration.bats
@@ -327,3 +327,37 @@ EOF
   [[ -d $log_dir ]]
   rm -rf "$log_dir"
 }
+
+@test "a signalled single-setup parallel run dumps its buffer too" {
+  local out="$BATS_TEST_TMPDIR/signalled-one.out" waited=0 fw_pid fw_status=0
+
+  env \
+    PATH="$TEST_BIN:$PATH" \
+    RECORD_FILE="$RECORD_FILE" \
+    HANG_SECONDS=120 \
+    "$FRAMEWORK_DIR/pmm-framework" \
+      --parallel \
+      --pmm-server-ip 10.0.0.5 \
+      --database ps=8.4 >"$out" 2>&1 &
+  fw_pid=$!
+
+  until [[ $(grep -c -- '--- call ---' "$RECORD_FILE" 2>/dev/null || echo 0) -eq 1 ]]; do
+    ((waited += 1))
+    [[ $waited -lt 100 ]] || { kill "$fw_pid" 2>/dev/null; return 1; }
+    sleep 0.2
+  done
+  sleep 1
+
+  kill -TERM "$fw_pid"
+  wait "$fw_pid" || fw_status=$?
+  run cat "$out"
+
+  [[ $fw_status -eq 130 ]]
+  [[ $output == *'===== [1/1] ps=8.4 INTERRUPTED ====='* ]]
+  [[ $output == *'setup is working'* ]]
+
+  local log_dir
+  log_dir=$(sed -n 's/^Parallel setup logs kept at: //p' "$out")
+  [[ -d $log_dir ]]
+  rm -rf "$log_dir"
+}

--- a/qa-integration/pmm_qa/pmm-framework/tests/integration.bats
+++ b/qa-integration/pmm_qa/pmm-framework/tests/integration.bats
@@ -31,6 +31,10 @@ if [[ ${PARALLEL_TEST:-false} == true ]]; then
     echo 'PGSQL parallel log'
   fi
 fi
+if [[ -n ${HANG_SECONDS:-} ]]; then
+  echo 'setup is working'
+  sleep "$HANG_SECONDS"
+fi
 if [[ ${FAIL_PS:-false} == true && -n ${PS_VERSION:-} ]]; then
   echo 'PS failed as requested'
   exit 9
@@ -283,4 +287,43 @@ EOF
   [[ $output == *'FAILED (exit=1)'* ]]
   [[ $output == *'PGSQL parallel log'* ]]
   [[ $output == *'Parallel setup logs kept at:'* ]]
+}
+
+@test "a signalled parallel run dumps the buffered logs instead of deleting them" {
+  local out="$BATS_TEST_TMPDIR/signalled.out" waited=0 fw_pid fw_status=0
+
+  env \
+    PATH="$TEST_BIN:$PATH" \
+    RECORD_FILE="$RECORD_FILE" \
+    HANG_SECONDS=120 \
+    "$FRAMEWORK_DIR/pmm-framework" \
+      --parallel \
+      --pmm-server-ip 10.0.0.5 \
+      --database ps=8.4 \
+      --database pgsql=16 >"$out" 2>&1 &
+  fw_pid=$!
+
+  # Both setups must have written to their buffers before the signal, or the
+  # test would pass on an empty dump.
+  until [[ $(grep -c -- '--- call ---' "$RECORD_FILE" 2>/dev/null || echo 0) -eq 2 ]]; do
+    ((waited += 1))
+    [[ $waited -lt 100 ]] || { kill "$fw_pid" 2>/dev/null; return 1; }
+    sleep 0.2
+  done
+  sleep 1
+
+  kill -TERM "$fw_pid"
+  wait "$fw_pid" || fw_status=$?
+  run cat "$out"
+
+  [[ $fw_status -eq 130 ]]
+  [[ $output == *'===== [1/2] ps=8.4 INTERRUPTED ====='* ]]
+  [[ $output == *'===== [2/2] pgsql=16 INTERRUPTED ====='* ]]
+  [[ $output == *'setup is working'* ]]
+  [[ $output == *'Parallel setup logs kept at:'* ]]
+
+  local log_dir
+  log_dir=$(sed -n 's/^Parallel setup logs kept at: //p' "$out")
+  [[ -d $log_dir ]]
+  rm -rf "$log_dir"
 }

--- a/qa-integration/pmm_qa/pmm-framework/tests/preflight.bats
+++ b/qa-integration/pmm_qa/pmm-framework/tests/preflight.bats
@@ -44,7 +44,3 @@ parallel_decision() {
 @test "two SSL PSMDB setups fall back to sequential" {
   [[ $(parallel_decision ssl_psmdb ssl_psmdb) == false ]]
 }
-
-@test "a single setup runs sequentially so its output streams" {
-  [[ $(parallel_decision ps) == false ]]
-}

--- a/qa-integration/pmm_qa/pmm-framework/tests/preflight.bats
+++ b/qa-integration/pmm_qa/pmm-framework/tests/preflight.bats
@@ -44,3 +44,7 @@ parallel_decision() {
 @test "two SSL PSMDB setups fall back to sequential" {
   [[ $(parallel_decision ssl_psmdb ssl_psmdb) == false ]]
 }
+
+@test "a single setup runs sequentially so its output streams" {
+  [[ $(parallel_decision ps) == false ]]
+}


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://github.com/percona/pmm-qa/actions/runs/34232768031 (Nightly E2E tests Matrix, `INSTALLATION_TYPE=ami`)
- tests:
  - `.github/workflows/nightly-e2e-tests-matrix.yml` / `setup / ps-replication` (setup step, not a test)
  - cascade: `test execution / @nightly`, `test execution / @qan|@valkey-nightly|@permissions-nightly|@pt-summary-nightly|@pbm-nightly`, `test execution / playwright @annotations|@menu` — all three failed only because the wait-for-setup step saw a failed setup shard

## What happened

`setup / ps-replication` ran `timeout -k 30 19m ./pmm-framework --parallel … --database ps,SETUP_TYPE=replication` twice and hit the 19-minute wall both times (`Child_process exited with error code 124`). The **entire** job log for those 38 minutes is one line:

```
13:36:53  Starting [1/1] ps,SETUP_TYPE=replication
   (nothing)
14:15:08  ##[error]Final attempt failed. Child_process exited with error code 124
```

The other 13 setup shards in the same run finished in 2–8 minutes. The same signature, on a different shard each time, is in run [34232923771](https://github.com/percona/pmm-qa/actions/runs/34232923771) (`setup / ps-gr`) and run [34190484752](https://github.com/percona/pmm-qa/actions/runs/34190484752) (`setup / extra-pxc`).

## Why there was nothing to read

`run_parallel_setups()` buffers each setup's output to its own log file and prints it only when that setup finishes. Its INT/TERM trap then ran `rm -rf "$log_dir"`. So when the workflow's `timeout` gives up, the buffered transcript — the only record of where the setup got stuck — is deleted on the way out.

Reproduced on a throwaway Linode VM at `main`, running the nightly's own command under `timeout -k 30 60s`:

```
--- framework stdout:
Starting [1/1] ps,SETUP_TYPE=replication
--- log dir after SIGTERM:
NONE - buffered logs deleted
```

Byte-identical to the CI signature.

## The change

One behaviour change, in `qa-integration/pmm_qa/pmm-framework/lib/execution.sh`: **the INT/TERM trap dumps the buffered log of every setup still running and keeps the log directory**, instead of deleting it. `cat_setup_log()` is extracted for the "echo a log, guaranteeing a trailing newline" step the trap shares with `print_setup_log`'s two existing call sites. `README.md` and `ARCHITECTURE.md` record the new interrupt behaviour.

Exactly two callers wrap `pmm-framework` in a `timeout`, and they are the ones this bites for:

- `runner-e2e-tests-codeceptjs-remote-nightly-setup.yml:133` — `timeout -k 30 19m`, one `--database` per shard; the failure above.
- `ha-e2e-tests.yml:173` — the same `timeout -k 30 19m`, with a multi-`--database` `WIZARD_ARGS`, so the multi-slot dump matters there.

Every other `--parallel` caller (`runner-e2e-tests-codeceptjs.yml`, `-playwright.yml`, `-podman.yml`, `runner-integration-cli-tests.yml`, `PMM_PDPGSQL.yaml`, `PMM_PROXYSQL.yaml`) is unwrapped, so its INT/TERM path fires only on job cancellation.

Nothing about a green run changes: successful setups still print only their summary line, the log directory is still removed on a fully successful run, and CI still doesn't pass `--verbose`.

## Verification

On the VM, after `sync.sh` onto this branch, killing the nightly's own command shape at the timeout:

```
===== [1/2] ps,SETUP_TYPE=replication INTERRUPTED =====
…full ansible transcript…
===== [2/2] pgsql INTERRUPTED =====
…
Parallel setup logs kept at: /tmp/pmm-framework-parallel.NQ79cS   (189 KB + 5 KB, both kept)
```

- `bats tests` — 58/58, including two new signal tests: the multi-spec case and the **single-spec** case that the nightly setup shards actually run. Mutation-checked: making the trap dump only slot 0 fails both.
- `.claude/hooks/lint-changed.sh` on the changed files — clean.

⚠️ **No CI check runs this suite.** `helm-tests.yml` runs `helm-test.bats` only, and nothing invokes `make test` under `qa-integration/pmm_qa/pmm-framework`, so `Lint` (shellcheck) is the only check on this head that touches the diff and the local 58/58 is the sole evidence for the new tests. Pre-existing gap; see the follow-up note in the comments rather than a CI-policy change smuggled into this PR.

## What this does not fix

**The hang itself did not reproduce.** `ps,SETUP_TYPE=replication` completed 4/4 on a 6-vCPU Linode VM against a `3-dev-latest` PMM Server: once idle (~8 min, cold image cache) and three times under saturation (12 busy loops, load average ~15) at 306 s / 296 s / 294 s — all far inside the 19-minute budget. The run's own artifacts show the PMM Server was healthy through the hang window (4 `level=error` lines total between 13:34 and 14:15, all connection teardown).

So the shard failure stays classified as an infra flake, not root-caused. Nightly runs against an external PMM Server that is already gone, so the original job cannot be re-run to settle it. This PR makes the **next** occurrence diagnosable rather than guessing at this one: with the fix, that job log would have carried the transcript up to the task the setup was sitting in.

Two things I deliberately did **not** change, because nothing in the evidence supports them yet:

- The playbook's external fetches (`wget https://repo.percona.com/…`, `apt-get install pmm-client`) have no timeouts and `wget` defaults to 20 retries, so a stalled mirror could silently consume the whole 19-minute budget. That is a plausible mechanism for the hang, not a demonstrated one — the log that would have shown it is exactly what was deleted. Worth revisiting once a hang is captured with this fix in place.
- The 19-minute budget itself. A measured 5–8 minute setup leaves plenty of headroom; raising it without knowing what consumed 19 minutes would just make the next failure slower.

## Review round 1

An earlier revision also downgraded a single-spec `--parallel` run to sequential so its output streamed live. Review pointed out that this inverts a documented, deliberate property — `ARCHITECTURE.md:153`, *"The CI runners deliberately do not pass `--verbose`, so day-to-day runs stay quiet"* — by putting the full playbook transcript of all fourteen nightly setup shards into every green job log, silently. Verified and **removed**: the trap dump already covers the single-spec case, and there is now a test for exactly that shape. Also guarded `cat_setup_log` in the trap with `|| true` (under `-euo pipefail`, a signal landing between the fork and the child's redirect would otherwise abort the handler mid-dump and exit 1 instead of 130 — reproduced in a minimal snippet), hardened both signal tests to count occurrences rather than substring-match, and dropped the README pointer to `run_parallel_timing.sh`, which no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELLy8SXukZ6SCSLEYTtdCv