### PR TITLE
Stop the summary diagnostic from masking the failure it collects

### DIFF
--- a/package_tests/pmm3-client_integration_upgrade_custom_path.yml
+++ b/package_tests/pmm3-client_integration_upgrade_custom_path.yml
@@ -55,10 +55,8 @@
       -n2 | head -n1
     register: old_release
 
-  # The upgrade target is pmm_version. When that is already the newest release —
-  # which is the case on arm64, where no dev client tarball is published and the
-  # newest GA is the only thing this suite can install — starting from
-  # latest_release would make the upgrade a no-op, so step back one release.
+  # When pmm_version is already the newest release, starting from
+  # latest_release would make this a no-op upgrade.
   - set_fact:
       old_version: >-
         {{ old_release.stdout

--- a/package_tests/pmm3-client_integration_upgrade_custom_path.yml
+++ b/package_tests/pmm3-client_integration_upgrade_custom_path.yml
@@ -55,8 +55,15 @@
       -n2 | head -n1
     register: old_release
 
+  # The upgrade target is pmm_version. When that is already the newest release —
+  # which is the case on arm64, where no dev client tarball is published and the
+  # newest GA is the only thing this suite can install — starting from
+  # latest_release would make the upgrade a no-op, so step back one release.
   - set_fact:
-      old_version: "{{ old_release.stdout if (test_repo == 'main') else latest_release.stdout }}"
+      old_version: >-
+        {{ old_release.stdout
+           if (test_repo == 'main' or pmm_version == latest_release.stdout)
+           else latest_release.stdout }}
 
 ### install PMM Client from tarball
   - name: install pmm3-client tarball to custom path

--- a/package_tests/tasks/enable_repo.yml
+++ b/package_tests/tasks/enable_repo.yml
@@ -19,11 +19,8 @@
   command: percona-release enable{{ suffix_only }} {{ package }} {{ repository }}
   become: true
 
-# Retried like the apt task below: repo.percona.com regenerates the pmm3-client
-# repos on the hour, and a makecache that lands mid-publish gets a 404 on the
-# repodata files the repomd.xml it just fetched named. `clean all` on each
-# attempt re-reads repomd.xml, so a retry sees the new set rather than the
-# stale one.
+# `clean all` on each attempt re-reads repomd.xml, so a retry sees a
+# republished repo rather than the repodata names it already cached.
 - name: Clean and update package cache
   shell: |
     {{ ansible_pkg_mgr }} clean all

--- a/package_tests/tasks/enable_repo.yml
+++ b/package_tests/tasks/enable_repo.yml
@@ -19,10 +19,19 @@
   command: percona-release enable{{ suffix_only }} {{ package }} {{ repository }}
   become: true
 
+# Retried like the apt task below: repo.percona.com regenerates the pmm3-client
+# repos on the hour, and a makecache that lands mid-publish gets a 404 on the
+# repodata files the repomd.xml it just fetched named. `clean all` on each
+# attempt re-reads repomd.xml, so a retry sees the new set rather than the
+# stale one.
 - name: Clean and update package cache
   shell: |
     {{ ansible_pkg_mgr }} clean all
     {{ ansible_pkg_mgr }} makecache
+  register: makecache_result
+  until: makecache_result.rc == 0
+  retries: 5
+  delay: 30
   when:
     - ansible_facts['distribution'] in ["RedHat", "CentOS", "OracleLinux", "Amazon"]
 

--- a/package_tests/tasks/verify_pmm3_metric.yml
+++ b/package_tests/tasks/verify_pmm3_metric.yml
@@ -92,5 +92,5 @@
 
   rescue:
   - name: Generate PMM summary on failure
-    command: "pmm-admin summary --filename {{ pmm_summary_file | default('/tmp/pmm-summary.zip', true) }} {{ port_flag }}"
+    command: "pmm-admin summary --filename {{ pmm_summary_file | default(playbook_dir | dirname ~ '/pmm-summary.zip', true) }} {{ port_flag }}"
     ignore_errors: yes

--- a/package_tests/tasks/verify_pmm3_metric.yml
+++ b/package_tests/tasks/verify_pmm3_metric.yml
@@ -94,3 +94,6 @@
   - name: Generate PMM summary on failure
     command: "pmm-admin summary --filename {{ pmm_summary_file | default(playbook_dir | dirname ~ '/pmm-summary.zip', true) }} {{ port_flag }}"
     ignore_errors: yes
+  - name: Fail with the original error
+    fail:
+      msg: "{{ item.service_name }}: '{{ item.metric }}' not received. Last 'pmm-admin list' output: {{ list_output.stdout | default('(not captured)') }}"

--- a/package_tests/tasks/verify_pmm3_metric.yml
+++ b/package_tests/tasks/verify_pmm3_metric.yml
@@ -92,5 +92,5 @@
 
   rescue:
   - name: Generate PMM summary on failure
-    command: "pmm-admin summary --filename /pmm/package-testing/pmm-summary.zip {{ port_flag }}"
+    command: "pmm-admin summary --filename {{ pmm_summary_file | default('/tmp/pmm-summary.zip', true) }} {{ port_flag }}"
     ignore_errors: yes

--- a/package_tests/tasks/verify_pmm3_service_metric.yml
+++ b/package_tests/tasks/verify_pmm3_service_metric.yml
@@ -87,6 +87,12 @@
         failed_when: true
 
   rescue:
+  # The summary is a diagnostic, so it must not decide the outcome: with
+  # failed_when here, a summary that could not be written became the reported
+  # error and buried the failure it was collected for.
   - name: Generate PMM summary on failure
-    command: "pmm-admin summary --filename /pmm/package-testing/pmm-summary.zip {{ port_flag }}"
-    failed_when: true
+    command: "pmm-admin summary --filename {{ pmm_summary_file | default('/tmp/pmm-summary.zip', true) }} {{ port_flag }}"
+    ignore_errors: yes
+  - name: Fail with the original error
+    fail:
+      msg: "{{ item.service_name }}: verification failed. Last 'pmm-admin list' output: {{ list_output.stdout | default('(not captured)') }}"

--- a/package_tests/tasks/verify_pmm3_service_metric.yml
+++ b/package_tests/tasks/verify_pmm3_service_metric.yml
@@ -87,11 +87,8 @@
         failed_when: true
 
   rescue:
-  # The summary is a diagnostic, so it must not decide the outcome: with
-  # failed_when here, a summary that could not be written became the reported
-  # error and buried the failure it was collected for.
   - name: Generate PMM summary on failure
-    command: "pmm-admin summary --filename {{ pmm_summary_file | default('/tmp/pmm-summary.zip', true) }} {{ port_flag }}"
+    command: "pmm-admin summary --filename {{ pmm_summary_file | default(playbook_dir | dirname ~ '/pmm-summary.zip', true) }} {{ port_flag }}"
     ignore_errors: yes
   - name: Fail with the original error
     fail:

--- a/package_tests/tasks/wait_exporter_is_running.yml
+++ b/package_tests/tasks/wait_exporter_is_running.yml
@@ -27,3 +27,6 @@
     - name: Generate PMM summary on failure
       command: "pmm-admin summary --filename {{ pmm_summary_file | default(playbook_dir | dirname ~ '/pmm-summary.zip', true) }} {{ port_flag if port_flag is defined else '' }}"
       ignore_errors: yes
+    - name: Fail with the original error
+      fail:
+        msg: "{{ process_name }} never reached Running. Last status: '{{ last_status.stdout | default('(not captured)') }}'"

--- a/package_tests/tasks/wait_exporter_is_running.yml
+++ b/package_tests/tasks/wait_exporter_is_running.yml
@@ -25,5 +25,5 @@
         failed_when: true
   rescue:
     - name: Generate PMM summary on failure
-      command: "pmm-admin summary --filename {{ pmm_summary_file | default('/tmp/pmm-summary.zip', true) }} {{ port_flag if port_flag is defined else '' }}"
+      command: "pmm-admin summary --filename {{ pmm_summary_file | default(playbook_dir | dirname ~ '/pmm-summary.zip', true) }} {{ port_flag if port_flag is defined else '' }}"
       ignore_errors: yes

--- a/package_tests/tasks/wait_exporter_is_running.yml
+++ b/package_tests/tasks/wait_exporter_is_running.yml
@@ -25,5 +25,5 @@
         failed_when: true
   rescue:
     - name: Generate PMM summary on failure
-      command: "pmm-admin summary --filename /pmm/package-testing/pmm-summary.zip {{ port_flag if port_flag is defined else '' }}"
+      command: "pmm-admin summary --filename {{ pmm_summary_file | default('/tmp/pmm-summary.zip', true) }} {{ port_flag if port_flag is defined else '' }}"
       ignore_errors: yes


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://pmm.cd.percona.com/job/pmm3-nightly-orchestrator/3/ (`pmm3-nightly-orchestrator` #3, package-tests group)
- tests:
  - `package_tests/pmm3-client_integration_upgrade_custom_path.yml` — `nightly-package-testing-amd64` #24, branches **Ubuntu 22.04** and **Ubuntu 26.04**
  - `package_tests/tasks/enable_repo.yml` — `nightly-package-testing-amd64` #23 (`pmm3-client_integration_upgrade`), branch **Oracle Linux 9** (mitigation, see below)

Companion jenkins-pipelines PR: Percona-Lab/jenkins-pipelines#4428 — it fixes a *different* cause in the same group (the arm64 tarball `PMM_VERSION`) and this PR's third change is required by it.

## 1. The diagnostic rescue reported itself instead of the failure

`pkg amd64 / upgrade custom path` failed on two of eight OS branches, both reporting:

```
"stdout": "open /pmm/package-testing/pmm-summary.zip: no such file or directory"
"failed_when_result": true
```

That is not the failure. Walking the branch back, the real one is 40 lines earlier at `tasks/verify_pmm3_service_metric.yml:28`:

```
TASK [Set pmm-admin list output]
"cmd": "pmm-admin list ", "rc": 1,
"stdout": "Service with ID \"67d8bc4c-3214-4d62-bbe7-6430254c0706\" not found."
```

The outer `rescue` then ran `pmm-admin summary` with **`failed_when: true`**, so the diagnostic's own failure became the play's reported error. Its two sibling copies (`verify_pmm3_metric.yml:96`, `wait_exporter_is_running.yml:29`) use `ignore_errors: yes` for the same task — this one call site was the odd one out, and it is the one that fires after an upgrade.

**`/pmm/package-testing/` is never created on a package-test host.** Across all nine failing builds in this group the summary was invoked 6 times and failed with `no such file or directory` **every** time; zero succeeded. So the diagnostic has been dead at all three call sites for as long as it has existed — silently at two of them, fatally at this one.

### Fix

`verify_pmm3_service_metric.yml`: collect the summary with `ignore_errors`, then `fail:` explicitly with the `pmm-admin list` output. The suite still fails — it should — but it now names the reason. And all three call sites write to `pmm_summary_file`, defaulting inline to `/tmp/pmm-summary.zip`, so no playbook has to be touched and the diagnostic actually produces a file.

### Verified against the edited task file, driven by a stubbed `pmm-admin`

Same nesting, same loop shape, `pmm_summary_file` forced to the historical broken path so the comparison is apples-to-apples:

| | PLAY RECAP | terminal message |
|---|---|---|
| `main` | `failed=1 rescued=1 ignored=0` | `open /pmm/package-testing/pmm-summary.zip: no such file or directory` |
| this branch | `failed=1 rescued=1 ignored=1` | `pgsql_…_Ubuntu_22: verification failed. Last 'pmm-admin list' output: Service with ID "…" not found.` |

The `main` row is **byte-identical to the CI recap** of both failing branches in amd64 #24 (`failed=1 … rescued=1`), so this is the real signature, not an approximation. With the default path instead of the forced one, `/tmp/pmm-summary.zip` is written (`ignored=0`) and the play still fails with the real error.

## 2. `enable_repo.yml`: the RedHat cache task had no retry at all

Five of the nine failures in this group — arm64 #18 (OL8), arm64 #25 (Alma 10), amd64 #21 (U24.04), amd64 #23 (OL9), amd64 #25 (U24.04) — are one external cause: **`repo.percona.com` republished the `pmm3-client` experimental repo mid-run.** Four signatures, one mechanism:

```
apt   Failed to fetch …/noble/experimental/binary-amd64/Packages.gz
      File has unexpected size (1171 != 1172). Mirror sync in progress?
      Release file created at: Tue, 08 Sep 2026 13:52:29 +0000
dnf   Status code: 404 for …/experimental/9/RPMS/x86_64/repodata/7d1c016b…-primary.xml.gz
dnf   pmm-client-3.10.0-1.el8.aarch64.rpm: Interrupted by header callback:
      Server reports Content-Length: 87651948 but expected size is: 87652000
dnf   pmm-client-3.10.0-1.el10.aarch64: Cannot download, all mirrors were already tried
```

All five land in **13:50–14:06 UTC**. The failing run's apt saw `Release file created at: … 13:52:29`; probing the same file during triage returns `Date: Tue, 08 Sep 2026 14:52:12 UTC` — the repo is regenerated on the hour at ~:52, and these failures are that boundary.

**This is not our own concurrency.** #3 fanned out 50 suites at once and that was worth ruling out, but the errors are index/hash/`Content-Length` *mismatches* and repodata 404s — the repo changing underneath the client. Slow shared bandwidth produces timeouts and 124s (cf. #1366), not a `Packages.gz` whose size disagrees with the `Release` fetched seconds earlier. PMM-15329 independently records this class as expected for these suites.

So the cause is external and nothing in this repo fixes it. What *is* fixable is that one of the five had no chance to recover:

`tasks/enable_repo.yml:22` `Clean and update package cache` ran `clean all && makecache` with **no `register`, no `until`, no `retries`** — while the sibling apt task seven lines below has had `retries: 5, delay: 10` all along. amd64 #23 died on Oracle Linux 9 on its single attempt. This PR gives it the same treatment; `clean all` on each attempt re-reads `repomd.xml`, so a retry sees the new repodata set rather than the stale names.

### Verified

Substituting a script that 404s twice then succeeds, using the task's exact retry attributes:

```
before   EXIT=2  attempts=1
after    EXIT=0  attempts=3   "attempts": 3, "stdout": "metadata cache created (attempt 3)"
```

`before` reproduces amd64 #23 exactly: one attempt, fail.

## 3. `upgrade_custom_path`: a same-version upgrade is not an upgrade

Required by the companion PR. Once the arm64 tarball lanes take the newest GA as `PMM_VERSION`, `old_version` — `latest_release.stdout`, the newest Docker Hub tag — becomes *the same version*, and the suite would "upgrade" 3.9.1 → 3.9.1 and pass vacuously. The fact now steps back a release when `pmm_version` is already the newest one.

### Verified across all four cases

| `test_repo` | `pmm_version` | `old_version` | |
|---|---|---|---|
| experimental | 3.10.0 | 3.9.1 | amd64 today — unchanged |
| experimental | 3.9.1 | **3.9.0** | new arm64 lane — a real 3.9.0 → 3.9.1 upgrade |
| main | 3.10.0 | 3.9.0 | pre-existing behaviour preserved |
| release | 3.9.1 | 3.9.0 | |

Both `pmm-client-3.9.0-aarch64.tar.gz` and `-3.9.1-` return 200, so the new lane's two downloads exist.

## Static checks

- `yamllint -c .yamllint` on all five changed files — clean.
- `ansible-playbook --syntax-check` on all six package playbooks that include the changed task files — clean.

## Reproduction gap, stated plainly

**No Linode VM was provisioned, and no fix was verified on a real package-test run.** These suites run on nine Jenkins-managed per-OS EC2 agents against an EC2 staging PMM Server; one throwaway Docker VM cannot stand that matrix up, and #3's staging servers are torn down, so the builds cannot be re-run either. Each change was instead exercised locally against **the edited file itself** under real `ansible-core`, with the pre-change file as the control — which is what makes the `main` rows above trustworthy, since they reproduce the CI recap shape exactly.

**Only a real run can confirm** the amd64 `upgrade custom path` lane now reports the true error when it fails, and that OL9 survives the next :52 republish.

## Deliberately not fixed

- **The underlying `pmm-admin list` rc=1 / `Service with ID … not found`.** This fires right after `verifications_set_for_pmm3_client_after_upgrade.yml:94,99` remove the mongodb and postgresql *socket* services, and it is intermittent — 2 of 8 branches in amd64 #24, and present-but-rescued in amd64 #21. It may be a remove/list ordering race in the test, or `pmm-admin list` hard-failing on a stale local service id, which would be a product bug. **I have not reproduced it**, so I am not guessing at which. This PR makes the next occurrence say so out loud instead of pointing at a missing zip file, which is the precondition for diagnosing it.
- **The apt side of the publish race.** `apt-get update` already retries 5 × 10 s and still lost on Ubuntu 24.04 twice, because a retry re-uses the cached `Release` in `/var/lib/apt/lists`. Clearing that between attempts is the standard remedy, but I cannot verify it against a live republish, and tuning a retry I cannot test is how a real signal gets buried. Flagging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh