### PR TITLE
Accept a client tarball URL as the expected version

### DIFF
--- a/support_scripts/check_client_upgrade.py
+++ b/support_scripts/check_client_upgrade.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 import sys
 
@@ -132,6 +133,14 @@ if len(errors) > 0:
   raise RuntimeError("Some errors in pmm-admin status: ".join(errors))
 
 expected_version=arguments[1].replace("\\r\\n", "").replace("-rc", "")
+
+# CLIENT_VERSION may be a client tarball URL instead of a bare version: the upgrade
+# matrix uses one for releases whose client deb is no longer in the apt repo.
+if expected_version.startswith("http"):
+  tarball_version = re.search(r"pmm-client-(\d+\.\d+\.\d+)", expected_version)
+  if not tarball_version:
+    raise RuntimeError(f"Cannot determine expected version from client tarball URL: {expected_version}")
+  expected_version = tarball_version.group(1)
 
 
 if not admin_version.startswith(expected_version):


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://pmm.cd.percona.com/job/pmm3-nightly-orchestrator/3/ — `pmm3-upgrade-test-runner` [#23452](https://pmm.cd.percona.com/job/pmm3-upgrade-test-runner/23452/), [#23453](https://pmm.cd.percona.com/job/pmm3-upgrade-test-runner/23453/), [#23454](https://pmm.cd.percona.com/job/pmm3-upgrade-test-runner/23454/) (upgrade from 3.7.0)
- tests: none — the runs died in setup before any test ran; this is the companion fix
- primary PR: Percona-Lab/jenkins-pipelines#4430 (**land together**)

## Why

The 3.7.0 upgrade variants failed because `pmm-client 3.7.0` is no longer in the pmm3-client apt repo, so the pool URL `pmm3-client-setup.sh` builds by hand 404s. The fix (jenkins-pipelines#4430) installs such sources from their published client tarball instead, passing `CLIENT_VERSION` as a URL — a route `pmm3-client-setup.sh` already supports and `pmm3-upgrade-test-runner.groovy` already special-cases.

`check_client_upgrade.py` does not. It compares the installed version against `arguments[1]` verbatim:

```python
if not admin_version.startswith(expected_version):
```

so a URL can never match and `Check Client before Upgrade` fails even though the client is correct. That branch of the upgrade matrix has been unreachable since it was written (`v3-old` and the iterated versions are exact complements — see #4430), which is why this has never surfaced.

## Verified

On a throwaway Linode VM against `percona/pmm-server:3.7.0`, with a real registered `pdpgsql_pgsm_ssl_17` container:

| argument | before | after |
|---|---|---|
| 3.7.0 tarball URL | exit 1 — `expected: https://…/pmm-client-3.7.0-x86_64.tar.gz actual: 3.7.0` | **exit 0** |
| `3.7.0` | exit 0 | exit 0 (unchanged) |
| `3.8.1` (genuinely wrong) | exit 1 | exit 1 (still fails, as it must) |
| URL with no version in it | exit 1 (misleading) | exit 1 — `Cannot determine expected version from client tarball URL: …` |

The wrong-version case is the one that matters: the check still rejects a mismatched client, it just compares against the version in the tarball name rather than the whole URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh)_