### PR TITLE
Retry the client package operations in the upgrade playbooks

### DIFF
--- a/package_tests/pmm3-client_integration_upgrade.yml
+++ b/package_tests/pmm3-client_integration_upgrade.yml
@@ -87,10 +87,18 @@
   - name: Install PMM client old deb packages
     when: ansible_os_family == "Debian"
     apt: name={{ pmm_client_old }} update_cache=yes state=present
+    register: apt_install_result
+    retries: 3
+    delay: 30
+    until: apt_install_result is succeeded
 
   - name: Install PMM client old rpm packages
     when: ansible_os_family == "RedHat"
     yum: name={{ pmm_client_old }} state=present
+    register: yum_install_result
+    retries: 3
+    delay: 30
+    until: yum_install_result is succeeded
 
 ### Setup PMM Client
   - name: Use "pmm-admin config" to connect pmm client to server
@@ -218,10 +226,18 @@
   - name: Upgrade PMM client to the latest deb packages
     when: ansible_os_family == "Debian"
     apt: name=pmm-client update_cache=yes state=latest
+    register: apt_upgrade_result
+    retries: 3
+    delay: 30
+    until: apt_upgrade_result is succeeded
 
   - name: Upgrade PMM client to the latest rpm packages
     when: ansible_os_family == "RedHat"
     yum: name=pmm-client state=latest
+    register: yum_upgrade_result
+    retries: 3
+    delay: 30
+    until: yum_upgrade_result is succeeded
 
 ### Verifications after upgrade
   - name: Perform standard verifications set for PMM Client

--- a/package_tests/pmm3-client_integration_upgrade.yml
+++ b/package_tests/pmm3-client_integration_upgrade.yml
@@ -94,7 +94,7 @@
 
   - name: Install PMM client old rpm packages
     when: ansible_os_family == "RedHat"
-    yum: name={{ pmm_client_old }} state=present
+    yum: name={{ pmm_client_old }} state=present update_cache=yes
     register: yum_install_result
     retries: 3
     delay: 30
@@ -233,7 +233,7 @@
 
   - name: Upgrade PMM client to the latest rpm packages
     when: ansible_os_family == "RedHat"
-    yum: name=pmm-client state=latest
+    yum: name=pmm-client state=latest update_cache=yes
     register: yum_upgrade_result
     retries: 3
     delay: 30

--- a/package_tests/pmm3-client_integration_upgrade_custom_port.yml
+++ b/package_tests/pmm3-client_integration_upgrade_custom_port.yml
@@ -104,7 +104,7 @@
 
   - name: Install PMM client old rpm packages
     when: ansible_os_family == "RedHat"
-    yum: name={{ pmm_client_old }} state=present
+    yum: name={{ pmm_client_old }} state=present update_cache=yes
     register: yum_install_result
     retries: 3
     delay: 30
@@ -262,7 +262,7 @@
 
   - name: Upgrade PMM client to the latest rpm packages
     when: ansible_os_family == "RedHat"
-    yum: name=pmm-client state=latest
+    yum: name=pmm-client state=latest update_cache=yes
     register: yum_upgrade_result
     retries: 3
     delay: 30

--- a/package_tests/pmm3-client_integration_upgrade_custom_port.yml
+++ b/package_tests/pmm3-client_integration_upgrade_custom_port.yml
@@ -97,10 +97,18 @@
   - name: Install PMM client old deb packages
     when: ansible_os_family == "Debian"
     apt: name={{ pmm_client_old }} update_cache=yes state=present
+    register: apt_install_result
+    retries: 3
+    delay: 30
+    until: apt_install_result is succeeded
 
   - name: Install PMM client old rpm packages
     when: ansible_os_family == "RedHat"
     yum: name={{ pmm_client_old }} state=present
+    register: yum_install_result
+    retries: 3
+    delay: 30
+    until: yum_install_result is succeeded
 
 ### Setup PMM Client
   - name: Use "pmm-admin config" to connect pmm client to server
@@ -247,10 +255,18 @@
   - name: Upgrade PMM client to the latest deb packages
     when: ansible_os_family == "Debian"
     apt: name=pmm-client update_cache=yes state=latest
+    register: apt_upgrade_result
+    retries: 3
+    delay: 30
+    until: apt_upgrade_result is succeeded
 
   - name: Upgrade PMM client to the latest rpm packages
     when: ansible_os_family == "RedHat"
     yum: name=pmm-client state=latest
+    register: yum_upgrade_result
+    retries: 3
+    delay: 30
+    until: yum_upgrade_result is succeeded
 
 ### Verifications after upgrade
   - name: Perform standard verifications set for PMM Client


### PR DESCRIPTION
`pmm3-nightly-orchestrator` #4 lost two arm64 package lanes to `repo.percona.com` serving a **partially written** `.deb`.

## What happened

```
E: Failed to fetch http://repo.percona.com/pmm3-client/apt/pool/experimental/p/pmm-client/pmm-client_3.10.0-1.bookworm_arm64.deb
   File has unexpected size (164430918 != 164430924). Mirror sync in progress? [IP: 15.204.182.114 80]
   Hashes of expected file:
    - SHA256:6f8cdf6a2fc27c4d1bdb105d82f83e4cbebeb2a4c0a834e4290a2e70d49449e0
    - Filesize:164430924 [weak]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

The `Packages` index promises one size and the mirror serves another — 6, 126 and 128 bytes apart across three occurrences, all under `pool/experimental`, which is republished continuously for dev builds. Oracle Linux 8 hit the same thing through `dnf` as an irrecoverable `dnf.exceptions.DownloadError`. Every occurrence in #4 fell between 19:21 and 19:27 from the same mirror IP.

This is the archive changing under the client, not a test defect and not something the playbook can prevent — only survive.

## Why these two playbooks

The three `Install PMM client new {deb,rpm} packages` playbooks — `pmm3-client_integration.yml`, `..._auth_config.yml`, `..._auth_register.yml` — have carried `retries: 3` / `delay: 30` on these operations all along. The two upgrade playbooks had **no retry on any of their four package tasks each**:

| playbook | package tasks | retry |
|---|---|---|
| `pmm3-client_integration.yml` | 2 | `until`, 3× |
| `pmm3-client_integration_auth_config.yml` | 2 | `until`, 3× |
| `pmm3-client_integration_auth_register.yml` | 2 | `until`, 3× |
| **`pmm3-client_integration_upgrade.yml`** | 4 | **none** |
| **`pmm3-client_integration_upgrade_custom_port.yml`** | 4 | **none** |

The correlation in #4 is exact. Of the eight arm64 package lanes, the two that failed this way are `pkg arm64 / upgrade` (#31, `pmm3-client_integration_upgrade.yml`) and `pkg arm64 / upgrade custom port` (#33, `..._custom_port.yml`) — precisely the two playbooks without the retry. Every lane whose playbook carried it passed.

`pkg arm64 / upgrade custom path` (#32) also failed but is **not** this: that lane installs from a tarball after Percona-Lab/jenkins-pipelines#4428, so it has no apt/yum client task at all, and a log search for these two error strings does not match it. `pkg amd64 / integration` (#26) failed too and its playbook already has the retry, so that is also something else. Both remain open — this PR does not claim them.

## The change

The same `register` / `retries: 3` / `delay: 30` / `until` the working playbooks use, applied to all eight unprotected package tasks (four per playbook: install-old and upgrade-to-latest, apt and yum).

One deliberate difference from the working playbooks: those use `shell:` and test `result.rc == 0`. These use the `apt:` and `yum:` **modules**, which do not reliably return an `rc`, so the condition is `until: <result> is succeeded` — the module-appropriate form.

The four yum tasks also carry `update_cache=yes`, added after review, so that a second or third attempt refetches the metadata instead of re-requesting the package against the index the first attempt already had. The apt tasks already had it.

## Verification

### Dispatched on this head

Two `package-test-single` runs on `66e0924e`, one per changed playbook, over the full `pt_os` fan-out:

| playbook | run |
|---|---|
| `pmm3-client_integration_upgrade` | [#296](https://github.com/percona/pmm-qa/actions/runs/34288585315) |
| `pmm3-client_integration_upgrade_custom_port` | [#297](https://github.com/percona/pmm-qa/actions/runs/34288590742) |

All 14 legs are now decided — 6 green, 8 red:

| OS | `..._upgrade` | `..._upgrade_custom_port` | cause when red |
|---|---|---|---|
| `noble` | ✅ 22m | ✅ 25m | — |
| `jammy` | ✅ 7m31s | ✅ 9m10s | — |
| `ol-8` | ✅ 31m | ✅ 32m | — |
| `bookworm` | ❌ | ❌ | ansible PPA key ignored → `NO_PUBKEY` |
| `bullseye` | ❌ | ❌ | Debian 11 EOL, security `Release` expired |
| `ol-9` | ❌ | ❌ | Vagrant guest lost SSH mid-play, no `PLAY RECAP` |
| `ol-10` | ❌ | ❌ | 512 MB / 1 CPU domain — `mysqld` OOM-killed on one, 60-min job timeout on the other |

**All four changed tasks ran and are green, on both package managers and in both playbooks:**

| changed task | covered by | result |
|---|---|---|
| `Install PMM client old deb packages` | `jammy`, `noble` | ran, `attempts: 1` |
| `Upgrade PMM client to the latest deb packages` | `jammy`, `noble` | ran, leg completed |
| `Install PMM client old rpm packages` | `ol-8`, and on `ol-9`/`ol-10` before they died | `attempts: 1`, `rc: 0` |
| `Upgrade PMM client to the latest rpm packages` | `ol-8` | ran, leg completed |

`ol-8` is the leg that closes the rpm half — the only RPM leg that ran to completion, so the only evidence that `update_cache=yes` on the yum upgrade task behaves. Both `ol-8` legs are green.

**What a green run does and does not show.** It shows the retry did not break the happy path, on apt and on yum, on install-old and on upgrade-to-latest. It cannot show the retry *firing*: that needs `repo.percona.com` mid-sync, and the window in #4 was 19:21–19:27, not reproducible on demand.

The eight red legs are four pre-existing environment breakages of `package-test-single`, none of them in `package_tests/**` logic and none of them this diff: Debian 11 EOL; an ASCII-armored GPG key written to a `.gpg` filename in `pmm3_client_test_prepare.yml:10`; a Vagrant/libvirt guest losing SSH; and a 512 MB / 1 CPU domain that Percona Server 8.4 cannot be installed and started in. Checked explicitly across every failing log — **no `File has unexpected size`, no `Mirror sync in progress`, no `DownloadError`, no `Unable to fetch some archives`**; every `repo.percona.com` line in all 14 legs is a clean `Hit:`/`Get:`/`Metadata cache created.` None of the four affects `pmm3-nightly-orchestrator`, which runs on EC2 images with no `bullseye`, no Vagrant, and adequately sized instances. Full per-leg breakdown in [this comment](https://github.com/percona/pmm-qa/pull/1373#issuecomment-5593409757).

### The `until` idiom itself

- **Exercised against real `ansible-core`, not assumed.** A `command:` module task backed by a script that fails twice then succeeds: with `register`/`retries: 3`/`until: r is succeeded` it logs `FAILED - RETRYING … (3 retries left)`, then `(2 retries left)`, then `ok`, reporting `attempts=3` and `failed=0`. The control — the identical task with those four lines deleted — gives `fatal: … "rc": 1` and `failed=1`. That is the before/after of this diff on a reproduction of the actual failure mode.
- **The same construct firing in a real run**, from `ol-9`'s log — `enable_repo.yml:22`, the sibling task, not one of mine:
  ```
  FAILED - RETRYING: Clean and update package cache (5 retries left).
  → attempts: 2, rc: 0, Metadata cache created.
  ```
- **`when:` + `until:` was checked separately**, since every one of these tasks is guarded by `ansible_os_family`. A task skipped by `when: false` that carries `register`/`retries`/`until` logs `skipping` once and reports `skipped=1 failed=0` — no retry loop, no evaluation of the condition.
- **Register names follow the existing convention** and collide with nothing: `apt_install_result` is the exact name `pmm3-client_integration.yml` already uses, and each of the four names appears once per playbook.
- `yamllint --strict` clean on both files; `ansible-playbook --syntax-check` passes on both.
- The failure evidence is quoted from the builds, not paraphrased: `nightly-package-testing-arm64` #31 and #33.

## What this does not fix

The mirror serving a half-written file is the actual problem, and it belongs to whoever owns `repo.percona.com` — a reader can see a `.deb` mid-write, which will bite anything installing from `pool/experimental`, not only these tests. A retry makes the suites survive it; it does not make the archive consistent. Worth raising separately with the packaging team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh)_