### PR TITLE
Record PMM-T2138 as covered by the T2145 HA node status test

### DIFF
--- a/e2e_tests/tests/ha/nodeInventoryStatus.test.ts
+++ b/e2e_tests/tests/ha/nodeInventoryStatus.test.ts
@@ -8,7 +8,7 @@ pmmTest.beforeEach(async ({ api, grafanaHelper, haClusterHelper }) => {
 });
 
 pmmTest(
-  'PMM-T2145 Verify the node status of PMM HA nodes on the Inventory Nodes page @pmm-ha',
+  'PMM-T2145 + PMM-T2138 - Verify the node status of PMM HA nodes on the Inventory Nodes page @pmm-ha',
   async ({ api, haClusterHelper, k8sHelper, nodesPage, page }) => {
     await pmmTest.step('Verify HA mode is enabled', async () => {
       expect(await api.haApi.getStatus()).toEqual('Enabled');


### PR DESCRIPTION
PMM-T2138 ("Verify PMM UI is accessible if leader pod goes down") sat on `Needs Automation` in Zephyr, but the behaviour it describes is already exercised by the T2145 HA node status test. This attaches its key to that test rather than adding a second five-minute failover test, and flips the case to `Automated`.

## Why it is already covered

| PMM-T2138 step | Its stated expected result | `nodeInventoryStatus.test.ts` |
|---|---|---|
| 1. Log in to PMM UI via the public URL | "User is able to login on public URL" | `grafanaHelper.authorize()` posts to `{baseURL}graph/login`; every later `page.goto` renders authenticated |
| 2. Verify the leader pod from the API | `/v1/ha/nodes` shows one leader and two alive followers | Leader read per-pod — the test avoids `/v1/ha/nodes` on purpose, since that is what the page under test renders — plus `haApi.getStatus()` through the public URL. The endpoint itself is covered by PMM-T2131 |
| 3. Restart the leader pod | "Pod gets restarted successfully" | `k8sHelper.deletePod(initialLeader).assertSuccess()`, then polls the pod back to `ready` |
| 4. Verify the PMM UI stays up | "PMM UI is up and running" | `page.reload()` followed by `nodeStatusCell` → `Up` and `nodeRoleLabel` → `Leader`/`Follower` for every pod, served through the public URL |

The case's precondition is also just how the suite is provisioned: `k8s/install_pmm_ha.sh` patches `pmm-ha-haproxy` to a `LoadBalancer` and exports its external address as the URL the whole `@pmm-ha` suite runs against. If the UI did not come back after the leader was killed, this test fails — as does PMM-T2233, which reloads the HA badge after the same failover.

## Known gap

Step 4's description says the UI "never goes down", which is stricter than its own expected result. This test reloads with a two-minute timeout, and `ha.api.ts` deliberately tolerates HAProxy 5xx-ing while it re-points at the new leader, so what is proven is "recovers and serves correct content", not "no request ever failed". Measuring true continuity needs a polling availability sampler that bypasses the retry-tolerant helpers, and a decision on what tolerance is correct. That is also what PMM-T2141 ("scaling up and down does not affect the end user", still `Draft`) would need, so it is worth doing once for both rather than folding a weaker version into this test.

## Title convention

`PMM-T2145 + PMM-T2138 - ` follows the ` + ` … ` - ` form used by every multi-key title in the repo, including the existing Playwright one in `dockerConfiguration/srvFolder.test.ts`. The single-key `@pmm-ha` titles omit the dash, but the key-block separator is consistent across all of them.

Note that `e2e_tests` has no Zephyr reporter — only `codeceptjs-e2e` posts test executions — so the key is traceability against PMM-14744, not a cycle result.

## Testing

- `npm run lint` in `e2e_tests` (eslint + `tsc --noEmit`) — passes
- `npx playwright test --list --grep "@pmm-ha"` — 7 tests in 7 files, the retitled test listed with both keys and its tag intact
- Zephyr PMM-T2138 re-read after the status change: `objective`, `precondition`, `Version of the Product` and `Assignee` all preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG1cMe36CDM7EVAYmN1agY

---
_Generated by [Claude Code](https://claude.ai/code/session_01FG1cMe36CDM7EVAYmN1agY)_