### PR TITLE
Poll for external exporter Running status after reconfiguration

### DIFF
--- a/e2e_tests/tests/cli/externalExporterChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/externalExporterChangeAgent.test.ts
@@ -179,9 +179,18 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
           `docker exec ${containerName} cat /var/log/pmm-agent.log | grep vmagent | tail -20 | grep error`,
         )
         .outEquals('');
-      await cliHelper
-        .execSilent(`docker exec ${containerName} pmm-admin list | grep ${externalExporterId}`)
-        .outContains('Running');
+      // The agent briefly reports "Unknown" while it re-registers after the push-metrics
+      // reconfiguration, so poll until it settles on "Running".
+      await expect(async () => {
+        const status = cliHelper.execSilent(
+          `docker exec ${containerName} pmm-admin list | grep ${externalExporterId}`,
+        ).stdout;
+
+        expect(status, 'External exporter should report Running status').toContain('Running');
+      }).toPass({
+        intervals: [Timeouts.TWO_SECONDS],
+        timeout: Timeouts.ONE_MINUTE,
+      });
     },
   );
 


### PR DESCRIPTION
## Summary
Updated the external exporter status verification to poll until the agent settles on "Running" status, rather than asserting immediately. This accounts for a brief "Unknown" state that occurs while the agent re-registers after push-metrics reconfiguration.

## Changes
- Replaced synchronous status check with a polling loop using `expect().toPass()`
- Added 2-second polling intervals with a 1-minute timeout to allow the agent time to stabilize
- Included explanatory comment documenting the transient "Unknown" state behavior

## Implementation Details
The agent briefly reports "Unknown" status during re-registration after configuration changes. The previous immediate assertion could fail intermittently. The new polling approach waits for the status to settle on "Running" before proceeding, making the test more resilient to timing variations in agent startup.

https://claude.ai/code/session_01QHPE2wX9K4ixjk8epenh4A