### PR TITLE
PMM-T1011 Restore default pmm-agent port after listen-port test

### DIFF
--- a/e2e_tests/tests/cli/externalExporterChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/externalExporterChangeAgent.test.ts
@@ -210,19 +210,42 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
   pmmTest(
     'PMM-T1011 - Verify Change agent pmm agent listen port @external-integration',
     async ({ cliHelper }) => {
-      let commands = [
-        `docker exec ${containerName} sed -i 's/listen-port: 7777/listen-port: 7778/' /usr/local/percona/pmm/config/pmm-agent.yaml`,
-        `docker restart ${containerName}`,
-        `docker exec -d ${containerName} pmm-agent --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml`,
-      ];
+      const configFile = '/usr/local/percona/pmm/config/pmm-agent.yaml';
 
-      commands.forEach((command) => cliHelper.execSilent(command).assertSuccess());
+      try {
+        let commands = [
+          `docker exec ${containerName} sed -i 's/listen-port: 7777/listen-port: 7778/' ${configFile}`,
+          `docker restart ${containerName}`,
+          `docker exec -d ${containerName} pmm-agent --config-file=${configFile}`,
+        ];
 
-      commands = [
-        `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --pmm-agent-listen-port=7778`,
-      ];
+        commands.forEach((command) => cliHelper.execSilent(command).assertSuccess());
 
-      commands.forEach((command) => cliHelper.execSilent(command).assertSuccess());
+        commands = [
+          `docker exec ${containerName} pmm-admin inventory change agent external-exporter ${externalExporterId} --pmm-agent-listen-port=7778`,
+        ];
+
+        commands.forEach((command) => cliHelper.execSilent(command).assertSuccess());
+      } finally {
+        // Restore the default port so the following serial tests can reach the local pmm-agent
+        // on 7777. pmm-agent runs as a bare background process, so a restart drops it until it
+        // is relaunched; wait for it to reconnect before handing over to the next test.
+        const restoreCommands = [
+          `docker exec ${containerName} sed -i 's/listen-port: 7778/listen-port: 7777/' ${configFile}`,
+          `docker restart ${containerName}`,
+          `docker exec -d ${containerName} pmm-agent --config-file=${configFile}`,
+        ];
+
+        restoreCommands.forEach((command) => cliHelper.execSilent(command).assertSuccess());
+
+        await expect(async () => {
+          cliHelper
+            .execSilent(
+              `docker exec ${containerName} sh -c 'pmm-admin status 2>/dev/null | grep -Eq "Connected[[:space:]]*: true"'`,
+            )
+            .assertSuccess();
+        }).toPass({ intervals: [Timeouts.TWO_SECONDS], timeout: Timeouts.TWO_MINUTES });
+      }
     },
   );
 


### PR DESCRIPTION
## Summary

`PMM-T1011` changes the local pmm-agent `listen-port` from 7777 to 7778, restarts the container, and never restores it. Because pmm-agent runs as a bare `nohup` background process here (not a managed service), every later serial test that reaches the local agent on the default port 7777 **without** `--server-url` fails:

```
Failed to get PMM Server parameters from local pmm-agent:
Post "http://127.0.0.1:7777/local/Status": dial tcp 127.0.0.1:7777: connect: connection refused
```

`PMM-T1014` is the first affected test (`PMM-T99103` in between uses `--server-url`, so it survives); `PMM-T1015/1016/1017` hit the same issue.

## Changes

- Wrapped `PMM-T1011`'s port change in `try/finally`.
- The `finally` restores `listen-port` back to 7777, relaunches pmm-agent, and polls `pmm-admin status` until it reports `Connected : true` (mirroring the qa-integration provisioning readiness check) before the test hands over.
- The suite is now order-independent again — later tests reliably find a working local agent on 7777.

## Testing

- `eslint` clean and `tsc --noEmit` clean for the changed file.
- Full e2e execution requires a live PMM Server with the `external_pmm` container, which isn't available in this environment; validated statically and against the known-good provisioning readiness pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHPE2wX9K4ixjk8epenh4A

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHPE2wX9K4ixjk8epenh4A)_