### PR TITLE
PMM-T1016 Make redis_exporter restart reliable

### DIFF
--- a/e2e_tests/tests/cli/externalExporterChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/externalExporterChangeAgent.test.ts
@@ -33,6 +33,10 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
         `docker exec ${containerName} pmm-admin list | grep ${serviceId} | grep external-exporter | awk -F' ' '{print $4}'`,
       )
       .stdout.trim();
+
+    // Capture the redis_exporter argv while it is guaranteed to be running, so PMM-T1016/T1017
+    // can relaunch it even after PMM-T1011 restarts the container (which kills the exporter).
+    captureRedisExporterCmd(cliHelper);
   });
 
   // The external exporter is a redis_exporter serving http /metrics on :42200 (see
@@ -46,10 +50,14 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
         `docker exec ${containerName} bash -c 'for p in /proc/[0-9]*; do if [ "$(cat "$p/comm" 2>/dev/null)" = "redis_exporter" ]; then tr "\\0" " " < "$p/cmdline" > /redis_orig_cmd; break; fi; done'`,
       )
       .assertSuccess();
+  // Force-kill the exporter and wait until it is really gone, so the port is free before the
+  // next start; a plain SIGTERM + fixed sleep raced the relaunch and left :42200 unbound.
   const stopRedisExporter = (cliHelper: CliHelper) =>
-    cliHelper.execSilent(
-      `docker exec ${containerName} bash -c 'for p in /proc/[0-9]*; do [ "$(cat "$p/comm" 2>/dev/null)" = "redis_exporter" ] && kill "$(basename "$p")"; done; sleep 2'`,
-    );
+    cliHelper
+      .execSilent(
+        `docker exec ${containerName} bash -c 'for p in /proc/[0-9]*; do [ "$(cat "$p/comm" 2>/dev/null)" = "redis_exporter" ] && kill -9 "$(basename "$p")"; done; for i in $(seq 30); do r=0; for p in /proc/[0-9]*; do [ "$(cat "$p/comm" 2>/dev/null)" = "redis_exporter" ] && r=1; done; [ "$r" = 0 ] && break; sleep 1; done'`,
+      )
+      .assertSuccess();
   const startRedisExporter = (cliHelper: CliHelper, extraFlags: string) =>
     cliHelper
       .execSilent(


### PR DESCRIPTION
## Summary

Two problems surfaced in the external-exporter change-agent suite once it ran past `PMM-T1014`/`T1015`:

1. **`PMM-T1016` `finally` raced.** The `try` serves the redis_exporter over TLS on `:42200`; the `finally` kills it and relaunches it plain. The stop used `SIGTERM` + a fixed `sleep 2`, which didn't reliably kill the TLS instance before the plain one was relaunched — the new process failed to bind `:42200`, so the http metrics wait timed out (exit 124).
2. **redis_exporter didn't survive `PMM-T1011`.** It runs as a bare `nohup` background process (see `qa-integration/pmm_qa/external_setup.yml`), so `PMM-T1011`'s `docker restart` kills it for the rest of the serial suite, leaving `PMM-T1016`/`T1017` with nothing to capture or restart.

## Changes

- `stopRedisExporter` now force-kills (`SIGKILL`) and waits until the process is really gone, so `:42200` is free before the next start.
- Capture the redis_exporter argv in `beforeAll` (while it is guaranteed running), so `PMM-T1016`/`T1017` can relaunch it regardless of `PMM-T1011`'s container restart.

## Testing

- `eslint` clean and `tsc --noEmit` clean for the changed file.
- Full e2e execution requires a live PMM Server with the `external_pmm` container, which isn't available in this environment; validated statically and against the exporter lifecycle in the qa-integration provisioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHPE2wX9K4ixjk8epenh4A

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHPE2wX9K4ixjk8epenh4A)_