### PR TITLE
Change Azure exporter test setup from beforeAll to beforeEach

### DIFF
--- a/e2e_tests/tests/cli/azureExporterChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/azureExporterChangeAgent.test.ts
@@ -3,7 +3,7 @@ import pmmTest from '@fixtures/pmmTest';
 pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality', () => {
   pmmTest.describe.configure({ mode: 'serial' });
 
-  pmmTest.beforeAll(async ({ api }) => {
+  pmmTest.beforeEach(async ({ api }) => {
     await api.settingsApi.enableAzureMonitoring();
   });
 


### PR DESCRIPTION
## Summary
Updated the Azure exporter change agent test to run setup logic before each test case instead of once before all tests.

## Changes
- Changed `pmmTest.beforeAll()` to `pmmTest.beforeEach()` in the Azure monitoring setup hook
- This ensures Azure monitoring is enabled fresh for each test case, improving test isolation and reliability

## Details
The setup that enables Azure monitoring now runs before each individual test rather than once at the beginning of the entire test suite. This prevents test interdependencies and ensures consistent initial state for each test case.

https://claude.ai/code/session_01JghjboR4rPo2U5GY1S9ySw