### PR TITLE
Convert MongoDB profiler test from MySQL to MongoDB commands

### DIFF
--- a/e2e_tests/tests/cli/mongo/mongoProfilerChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/mongo/mongoProfilerChangeAgent.test.ts
@@ -6,7 +6,6 @@ import fs from 'node:fs';
 pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality', () => {
   pmmTest.describe.configure({ mode: 'serial' });
 
-  const mysqlPassword = 'GRgrO9301RuF';
   const newUsername = 'new_pmmm_username';
   const newPassword = 'new_pmm_user_password';
   let containerName: string;
@@ -44,26 +43,30 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
   pmmTest(
     'PMM-T1001 - Verify Change agent username and password @psmdb-profiler-integration',
     async ({ cliHelper, grafanaHelper, page, servicesPage }) => {
+      const mongoUri = 'mongodb://root:root@localhost/?replicaSet=rs';
+      const monitoringRoles =
+        '[ { role: "explainRole", db: "admin" }, { role: "clusterMonitor", db: "admin" }, { role: "read", db: "local" } ]';
+
+      cliHelper
+        .execSilent(
+          `docker exec ${containerName} mongo "${mongoUri}" --quiet --eval 'db.getSiblingDB("admin").createUser({ user: "${newUsername}", pwd: "${newPassword}-wrong", roles: ${monitoringRoles} })'`,
+        )
+        .assertSuccess();
+
       let commands = [
-        `docker exec ${containerName} mysql -u root -p${mysqlPassword} -e "CREATE USER '${newUsername}'@'localhost' IDENTIFIED BY '${newPassword}-wrong'; GRANT ALL PRIVILEGES ON *.* TO '${newUsername}'@'localhost'; FLUSH PRIVILEGES;"`,
-      ];
-
-      commands.forEach((command) => cliHelper.execSilent(command).assertSuccess());
-
-      commands = [
         `docker exec ${containerName} pmm-admin inventory change agent mongodb-exporter ${mongoExporterId} --password=${newPassword} --username=${newUsername}`,
         `docker exec ${containerName} pmm-admin inventory change agent qan-mongodb-profiler-agent ${mongoProfilerAgentId} --password=${newPassword} --username=${newUsername}`,
       ];
 
-      commands.forEach((command) => cliHelper.execSilent(command).outContains('Access denied for user'));
+      commands.forEach((command) => cliHelper.execSilent(command).outContains('Authentication failed'));
 
       cliHelper.execSilent(
-        `docker exec ${containerName} mysql -u root -p${mysqlPassword} -e "ALTER USER '${newUsername}'@'localhost' IDENTIFIED BY '${newPassword}'; FLUSH PRIVILEGES;"`,
+        `docker exec ${containerName} mongo "${mongoUri}" --quiet --eval 'db.getSiblingDB("admin").changeUserPassword("${newUsername}", "${newPassword}")'`,
       );
 
       commands = [
-        `docker exec ${containerName} pmm-admin inventory change agent mysqld-exporter ${mysqldExporterId} --password=${newPassword} --username=${newUsername}`,
-        `docker exec ${containerName} pmm-admin inventory change agent qan-mysql-perfschema-agent ${mysqldPerfschemaAgentId} --password=${newPassword} --username=${newUsername}`,
+        `docker exec ${containerName} pmm-admin inventory change agent mongodb-exporter ${mongoExporterId} --password=${newPassword} --username=${newUsername}`,
+        `docker exec ${containerName} pmm-admin inventory change agent qan-mongodb-profiler-agent ${mongoProfilerAgentId} --password=${newPassword} --username=${newUsername}`,
       ];
 
       commands.forEach((command) => cliHelper.execSilent(command).assertSuccess());


### PR DESCRIPTION
Update the `mongoProfilerChangeAgent` test to use MongoDB commands instead of MySQL commands for user management operations.

**Summary**
The test was incorrectly using MySQL commands (`mysql` CLI) to set up test data for a MongoDB profiler integration test. This change converts all database operations to use the MongoDB shell (`mongo` CLI) with appropriate MongoDB syntax.

**Key changes**
- Removed hardcoded MySQL password constant that was no longer needed
- Replaced MySQL user creation with MongoDB `createUser()` command, including proper role assignments for monitoring (explainRole, clusterMonitor, read)
- Updated error message assertion from `'Access denied for user'` to `'Authentication failed'` to match MongoDB's authentication error format
- Replaced MySQL password update with MongoDB `changeUserPassword()` command
- Fixed the final verification step to test MongoDB agents (mongodb-exporter and qan-mongodb-profiler-agent) instead of MySQL agents

**Implementation details**
- Uses MongoDB URI with replica set configuration: `mongodb://root:root@localhost/?replicaSet=rs`
- Defines monitoring roles as a JSON array matching MongoDB's role structure
- All MongoDB commands execute via `docker exec` with `--quiet` and `--eval` flags for non-interactive execution

https://claude.ai/code/session_012h351U4CYjKSjFRNhoEytd