### PR TITLE
Add UI upgrade path to PMM upgrade workflow

### DIFF
--- a/.github/workflows/upgrade-pmm.yml
+++ b/.github/workflows/upgrade-pmm.yml
@@ -40,6 +40,7 @@ jobs:
       ui_versions: ${{ steps.set.outputs.ui_versions }}
       rc_version:  ${{ steps.set.outputs.rc_version }}
       matrix:  ${{ steps.set.outputs.matrix }}
+      ui_matrix:  ${{ steps.set.outputs.ui_matrix }}
       DEV_LATEST_VERSION: ${{ steps.set.outputs.DEV_LATEST_VERSION }}
     steps:
       - name: Compute version range (latest -> 5 minors back)
@@ -67,8 +68,11 @@ jobs:
 
 
           echo "ui_versions=$UI_VERSIONS" >> "$GITHUB_OUTPUT"
+          UI_MATRIX=$(jq -cn --argjson versions "$UI_VERSIONS" '[$versions[] | { version: ., docker_tag: ("percona/pmm-server:" + .) }]')
+          echo "ui_matrix=$UI_MATRIX" >> "$GITHUB_OUTPUT"
           echo "CLIENT versions: $VERSIONS"
           echo "UI versions:     $UI_VERSIONS"
+          echo "UI matrix:       $UI_MATRIX"
           RC_VERSION=$(curl -s "https://hub.docker.com/v2/repositories/perconalab/pmm-server/tags?page_size=100&name=rc&ordering=last_updated" | jq -r '.results[].name | select(test("-rc$"))' | head -1)
           echo "Latest RC: $RC_VERSION"
           echo "rc_version=perconalab/pmm-server:$RC_VERSION" >> "$GITHUB_OUTPUT"
@@ -101,4 +105,19 @@ jobs:
     with:
       docker_tag: ${{ matrix.docker_tag }}
       version: ${{ matrix.version }}
+      upgrade_type: docker
+      pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
+
+  upgrade-ui:
+    name: UI way upgrade for PMM
+    uses: ./.github/workflows/upgrade-pmm-runner.yml
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.prepare.outputs.ui_matrix) }}
+    with:
+      docker_tag: ${{ matrix.docker_tag }}
+      version: ${{ matrix.version }}
+      upgrade_type: ui
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}


### PR DESCRIPTION
## Summary
Extends the PMM upgrade workflow to support UI-based upgrades in addition to the existing Docker-based upgrade path. This allows testing upgrade scenarios through both upgrade mechanisms.

## Changes
- Added `ui_matrix` output to the prepare job that structures UI versions with their corresponding Docker tags
- Created new `upgrade-ui` job that runs UI-based upgrades using the same version matrix as Docker upgrades
- Both upgrade paths now run in parallel with `fail-fast: false` to ensure comprehensive testing coverage
- UI upgrade job uses `upgrade_type: ui` parameter to differentiate from Docker upgrades in the runner workflow

## Implementation Details
The `ui_matrix` is constructed using `jq` to transform the UI versions list into a matrix format compatible with GitHub Actions' `strategy.matrix.include`, pairing each version with its corresponding `percona/pmm-server:` Docker tag. This allows the upgrade-ui job to iterate over the same version set as the Docker upgrade job while maintaining the upgrade type distinction.

https://claude.ai/code/session_01MWbpB14LhUXkdaYh5LA777