### PR TITLE
Fix UI upgrade matrix to use objects so jobs run in parallel

### DIFF
--- a/.github/workflows/upgrade-pmm.yml
+++ b/.github/workflows/upgrade-pmm.yml
@@ -40,6 +40,7 @@ jobs:
       ui_versions: ${{ steps.set.outputs.ui_versions }}
       rc_version:  ${{ steps.set.outputs.rc_version }}
       matrix:  ${{ steps.set.outputs.matrix }}
+      ui_matrix:  ${{ steps.set.outputs.ui_matrix }}
       DEV_LATEST_VERSION: ${{ steps.set.outputs.DEV_LATEST_VERSION }}
     steps:
       - name: Compute version range (latest -> 5 minors back)
@@ -67,6 +68,9 @@ jobs:
 
 
           echo "ui_versions=$UI_VERSIONS" >> "$GITHUB_OUTPUT"
+          UI_MATRIX=$(jq -cn --argjson versions "$UI_VERSIONS" '[$versions[] | { version: ., docker_tag: ("percona/pmm-server:" + .) }]')
+          echo "ui_matrix=$UI_MATRIX" >> "$GITHUB_OUTPUT"
+          echo "UI matrix: $UI_MATRIX"
           RC_VERSION=$(curl -s "https://hub.docker.com/v2/repositories/perconalab/pmm-server/tags?page_size=100&name=rc&ordering=last_updated" | jq -r '.results[].name | select(test("-rc$"))' | head -1)
           echo "Latest RC: $RC_VERSION"
           echo "rc_version=perconalab/pmm-server:$RC_VERSION" >> "$GITHUB_OUTPUT"
@@ -109,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.prepare.outputs.ui_versions) }}
+        include: ${{ fromJSON(needs.prepare.outputs.ui_matrix) }}
     with:
       docker_tag: ${{ matrix.docker_tag }}
       version: ${{ matrix.version }}


### PR DESCRIPTION
The upgrade-ui job fed prepare.outputs.ui_versions (a JSON array of plain version strings) into strategy.matrix.include, which expects a list of objects. Matrix entries had no version/docker_tag, so the UI jobs could not schedule and stalled at 'Waiting for pending jobs' instead of running alongside the Docker upgrade jobs.

Build a ui_matrix output pairing each UI version with its percona/pmm-server:<version> tag, and point the upgrade-ui job at it.


Claude-Session: https://claude.ai/code/session_01MWbpB14LhUXkdaYh5LA777