### PR TITLE
Precompute upgrade target in matrix and wire runner to it

### DIFF
--- a/.github/workflows/upgrade-pmm-runner.yml
+++ b/.github/workflows/upgrade-pmm-runner.yml
@@ -19,6 +19,10 @@ on:
         description: 'PMM Server docker tag to upgrade to'
         default: 'perconalab/pmm-server:3-dev-latest'
         type: string
+      upgrade_version:
+        description: 'Expected PMM version after upgrade'
+        default: ''
+        type: string
       upgrade_type:
         description: "Type of upgrade Docker or UI"
         required: true
@@ -50,6 +54,11 @@ on:
       upgrade_tag:
         description: 'PMM Server docker tag to upgrade to'
         default: 'perconalab/pmm-server:3-dev-latest'
+        type: string
+        required: true
+      upgrade_version:
+        description: 'Expected PMM version after upgrade'
+        default: ''
         type: string
         required: true
       upgrade_type:
@@ -87,7 +96,6 @@ jobs:
           ver="${RC_VERSION##*:}"
           ver="${ver%-rc*}"
           ver="${ver%.}"
-          echo "PMM_SERVER_LATEST=$ver" >> "$GITHUB_OUTPUT"
           echo "Version: ${{ inputs.version }}"
           echo "Docker Tag: ${{ inputs.docker_tag }}"
           # 1. all X.Y.Z versions available in the apt pool
@@ -133,14 +141,8 @@ jobs:
           ref: ${{ env.PMM_QA_BRANCH }}
           path: pmm-qa
       - name: Start PMM Server (old image)
-        env:
-          PMM_SERVER_LATEST: ${{ steps.resolve.outputs.PMM_SERVER_LATEST }}
         run: |
-          if [[ "${{ inputs.docker_tag }}" == *-rc* ]]; then
-            export UPGRADE_TAG="perconalab/pmm-server:3-dev-latest"
-          else
-            export UPGRADE_TAG="${{ needs.prepare.outputs.rc_version }}"
-          fi
+          export UPGRADE_TAG="${{ inputs.upgrade_tag }}"
           docker network create pmm-qa || true
           docker volume create pmm-volume
           if [[ "${{ inputs.upgrade_type }}" == "ui" ]]; then
@@ -256,11 +258,7 @@ jobs:
       - name: Docker upgrade (swap server image, keep volume)
         if: ${{ inputs.upgrade_type == 'docker' }}
         run: |
-          if [[ "${{ inputs.docker_tag }}" == *-rc* ]]; then
-            export UPGRADE_TAG="perconalab/pmm-server:3-dev-latest"
-          else
-            export UPGRADE_TAG="${{ needs.prepare.outputs.rc_version }}"
-          fi
+          export UPGRADE_TAG="${{ inputs.upgrade_tag }}"
           docker stop pmm-server
           docker pull "$UPGRADE_TAG"
           docker rename pmm-server pmm-server-old
@@ -276,38 +274,25 @@ jobs:
         if: ${{ inputs.upgrade_type == 'ui' }}
         working-directory: pmm-qa/e2e_tests
         run: |
-          if [[ "${{ inputs.docker_tag }}" == *-rc* ]]; then
-            export UPGRADE_TAG="perconalab/pmm-server:3-dev-latest"
-          else
-            export UPGRADE_TAG="${{ needs.prepare.outputs.rc_version }}"
-          fi
+          export UPGRADE_TAG="${{ inputs.upgrade_tag }}"
           npx playwright test --grep "@pmm-upgrade"
 
       - name: Post-server-upgrade UI tests
         working-directory: pmm-qa/e2e_tests
         env:
-          PMM_SERVER_LATEST: ${{ steps.resolve.outputs.PMM_SERVER_LATEST }}
-          DEV_LATEST_VERSION: ${{ needs.prepare.outputs.DEV_LATEST_VERSION }}
+          PMM_SERVER_LATEST: ${{ inputs.upgrade_version }}
         run: |
-          if [[ "${{ inputs.docker_tag }}" == *-rc* ]]; then
-            export PMM_SERVER_LATEST="$DEV_LATEST_VERSION"
-          else
-            export PMM_SERVER_LATEST="$PMM_SERVER_LATEST"
-          fi
           echo "Latest PMM Version is: $PMM_SERVER_LATEST"
           npx playwright test --grep "@post-server-upgrade"
 
       - name: Upgrade PMM client in every client container to show logs only if error occurs
         env:
-          PMM_SERVER_LATEST: ${{ steps.resolve.outputs.PMM_SERVER_LATEST }}
-          DEV_LATEST_VERSION: ${{ steps.resolve.outputs.DEV_LATEST_VERSION }}
+          LATEST_VERSION: ${{ inputs.upgrade_version }}
         run: |
           if [[ "$CLIENT_INSTALL_VERSION" == "pmm3-rc" ]]; then
             export CLIENT_REPOSITORY=experimental
-            export LATEST_VERSION=$DEV_LATEST_VERSION
           else
             export CLIENT_REPOSITORY=testing
-            export LATEST_VERSION=$PMM_SERVER_LATEST
           fi
           for c in $(docker ps --format '{{.Names}}' | grep -Ev '^(pmm-server|pmm-server-old|watchtower|ldap-server|kerberos|minio|redis_container)$'); do
             echo "== upgrading client in $c =="
@@ -340,10 +325,10 @@ jobs:
               else
                 echo "FAIL: expected $LATEST_VERSION, got $UPGRADE_VERSION"
               fi
-              if [[ "$CLIENT_UPGRADE_VERSION" == *"$PMM_SERVER_LATEST"* ]]; then
-                echo "OK: version contains $PMM_SERVER_LATEST ($CLIENT_UPGRADE_VERSION)"
+              if [[ "$CLIENT_UPGRADE_VERSION" == *"$LATEST_VERSION"* ]]; then
+                echo "OK: version contains $LATEST_VERSION ($CLIENT_UPGRADE_VERSION)"
               else
-                echo "FAIL: expected $PMM_SERVER_LATEST, got $CLIENT_UPGRADE_VERSION"
+                echo "FAIL: expected $LATEST_VERSION, got $CLIENT_UPGRADE_VERSION"
               fi
               echo "== upgrade succeeded in $c == ($CLIENT_UPGRADE_VERSION)"
             rm -f "$log"
@@ -351,27 +336,15 @@ jobs:
 
       - name: Check client after upgrade
         env:
-          PMM_SERVER_LATEST: ${{ steps.resolve.outputs.PMM_SERVER_LATEST }}
-          DEV_LATEST_VERSION: ${{ steps.resolve.outputs.DEV_LATEST_VERSION }}
+          LATEST_VERSION: ${{ inputs.upgrade_version }}
         run: |
-          if [[ "$CLIENT_INSTALL_VERSION" == "pmm3-rc" ]]; then
-            export LATEST_VERSION=$DEV_LATEST_VERSION
-          else
-            export LATEST_VERSION=$PMM_SERVER_LATEST
-          fi
           python3 pmm-qa/support_scripts/check_client_upgrade.py "$LATEST_VERSION"
 
       - name: Post-client-upgrade UI tests
         working-directory: pmm-qa/e2e_tests
         env:
-          PMM_SERVER_LATEST: ${{ steps.resolve.outputs.PMM_SERVER_LATEST }}
-          DEV_LATEST_VERSION: ${{ needs.prepare.outputs.DEV_LATEST_VERSION }}
+          PMM_SERVER_LATEST: ${{ inputs.upgrade_version }}
         run: |
-          if [[ "${{ inputs.docker_tag }}" == *-rc* ]]; then
-            export PMM_SERVER_LATEST="$DEV_LATEST_VERSION"
-          else
-            export PMM_SERVER_LATEST="$PMM_SERVER_LATEST"
-          fi
           echo "Latest PMM Version is: $PMM_SERVER_LATEST"
           npx playwright test --grep "@post-upgrade|@rta"
 

--- a/.github/workflows/upgrade-pmm.yml
+++ b/.github/workflows/upgrade-pmm.yml
@@ -68,15 +68,18 @@ jobs:
 
 
           echo "ui_versions=$UI_VERSIONS" >> "$GITHUB_OUTPUT"
-          UI_MATRIX=$(jq -cn --argjson versions "$UI_VERSIONS" '[$versions[] | { version: ., docker_tag: ("percona/pmm-server:" + .) }]')
-          echo "ui_matrix=$UI_MATRIX" >> "$GITHUB_OUTPUT"
-          echo "UI matrix: $UI_MATRIX"
           RC_VERSION=$(curl -s "https://hub.docker.com/v2/repositories/perconalab/pmm-server/tags?page_size=100&name=rc&ordering=last_updated" | jq -r '.results[].name | select(test("-rc$"))' | head -1)
           echo "Latest RC: $RC_VERSION"
           echo "rc_version=perconalab/pmm-server:$RC_VERSION" >> "$GITHUB_OUTPUT"
+          RC_SERVER_VERSION="${RC_VERSION%-rc*}"
           DEV_LATEST_VERSION=$(curl https://raw.githubusercontent.com/Percona-Lab/pmm-submodules/refs/heads/v3/VERSION)
           echo "dev latest version: $DEV_LATEST_VERSION"
           echo "DEV_LATEST_VERSION=$DEV_LATEST_VERSION" >> "$GITHUB_OUTPUT"
+          UI_MATRIX=$(jq -cn --argjson versions "$UI_VERSIONS" \
+            --arg rc_tag "perconalab/pmm-server:$RC_VERSION" --arg rc_ver "$RC_SERVER_VERSION" \
+            '[$versions[] | { version: ., docker_tag: ("percona/pmm-server:" + .), upgrade_tag: $rc_tag, upgrade_version: $rc_ver }]')
+          echo "ui_matrix=$UI_MATRIX" >> "$GITHUB_OUTPUT"
+          echo "UI matrix: $UI_MATRIX"
           export VERSION_LIST=$(echo "$VERSIONS" | tr -d '[]"' | tr ',' ' ')
           DOCKER_TAGS=()
           DOCKER_TAGS+=(perconalab/pmm-server:$RC_VERSION)
@@ -90,7 +93,7 @@ jobs:
           echo "versions=$VERSIONS" >> "$GITHUB_OUTPUT"
           DOCKER_TAGS_JSON=$(printf '%s\n' "${DOCKER_TAGS[@]}" | jq -Rsc 'split("\n")[:-1]')
           MATRIX=$(jq -cn --argjson versions "$VERSIONS" --argjson tags "$DOCKER_TAGS_JSON" \
-            --arg rc_tag "perconalab/pmm-server:$RC_VERSION" --arg rc_ver "$RC_VERSION" --arg dev_ver "$DEV_LATEST_VERSION" \
+            --arg rc_tag "perconalab/pmm-server:$RC_VERSION" --arg rc_ver "$RC_SERVER_VERSION" --arg dev_ver "$DEV_LATEST_VERSION" \
             '[range(0; ($versions | length)) as $i
               | ($tags[$i] | test("-rc")) as $is_rc
               | { version: $versions[$i],
@@ -110,6 +113,8 @@ jobs:
     with:
       docker_tag: ${{ matrix.docker_tag }}
       version: ${{ matrix.version }}
+      upgrade_tag: ${{ matrix.upgrade_tag }}
+      upgrade_version: ${{ matrix.upgrade_version }}
       upgrade_type: docker
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}
 
@@ -124,5 +129,7 @@ jobs:
     with:
       docker_tag: ${{ matrix.docker_tag }}
       version: ${{ matrix.version }}
+      upgrade_tag: ${{ matrix.upgrade_tag }}
+      upgrade_version: ${{ matrix.upgrade_version }}
       upgrade_type: ui
       pmm_qa_branch: ${{ inputs.pmm_qa_branch || 'main' }}

--- a/.github/workflows/upgrade-pmm.yml
+++ b/.github/workflows/upgrade-pmm.yml
@@ -89,7 +89,14 @@ jobs:
           echo $VERSIONS
           echo "versions=$VERSIONS" >> "$GITHUB_OUTPUT"
           DOCKER_TAGS_JSON=$(printf '%s\n' "${DOCKER_TAGS[@]}" | jq -Rsc 'split("\n")[:-1]')
-          MATRIX=$(jq -cn --argjson versions "$VERSIONS" --argjson tags "$DOCKER_TAGS_JSON" '[range(0; ($versions | length)) as $i | { version: $versions[$i], docker_tag: $tags[$i]}]')
+          MATRIX=$(jq -cn --argjson versions "$VERSIONS" --argjson tags "$DOCKER_TAGS_JSON" \
+            --arg rc_tag "perconalab/pmm-server:$RC_VERSION" --arg rc_ver "$RC_VERSION" --arg dev_ver "$DEV_LATEST_VERSION" \
+            '[range(0; ($versions | length)) as $i
+              | ($tags[$i] | test("-rc")) as $is_rc
+              | { version: $versions[$i],
+                  docker_tag: $tags[$i],
+                  upgrade_tag: (if $is_rc then "perconalab/pmm-server:3-dev-latest" else $rc_tag end),
+                  upgrade_version: (if $is_rc then $dev_ver else $rc_ver end) }]')
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
   upgrade-docker:


### PR DESCRIPTION
## Summary

Precomputes the upgrade target for every upgrade job in the `prepare` step and passes it into the reusable runner as inputs, so the runner no longer derives it inline. This also fixes a latent bug: the runner's inline logic read `needs.prepare.outputs.*`, but the reusable runner has no `prepare` job, so those values were **empty** inside it.

## Changes

**`upgrade-pmm.yml` (`prepare`)**
- Docker `matrix` and `ui_matrix` each entry now carries:
  - **`upgrade_tag`** — image to upgrade *to*: RC start → `perconalab/pmm-server:3-dev-latest`; non-RC start → latest RC container `perconalab/pmm-server:$RC_VERSION`.
  - **`upgrade_version`** — expected version after upgrade: RC start → `$DEV_LATEST_VERSION`; non-RC → the **stripped** RC version `$RC_SERVER_VERSION` (e.g. `3.9.1`, not `3.9.1-rc`).
- `ui_matrix` construction moved after `RC_VERSION`/`DEV_LATEST_VERSION` are computed (all UI entries are non-RC, so they target the latest RC).
- Both `upgrade-docker` and `upgrade-ui` jobs pass `upgrade_tag` and `upgrade_version` to the runner.

**`upgrade-pmm-runner.yml`**
- Added `upgrade_version` input (both `workflow_dispatch` and `workflow_call`); `upgrade_tag` already existed.
- Replaced every inline computation with the inputs:
  - `UPGRADE_TAG` (Start / Docker upgrade / UI Upgrade steps) → `inputs.upgrade_tag`.
  - `PMM_SERVER_LATEST` / `LATEST_VERSION` (post-server-upgrade, client upgrade + checks, post-client-upgrade) → `inputs.upgrade_version`.
- Removed the now-dead `PMM_SERVER_LATEST` step output and the `docker_tag == *-rc*` branches these values depended on.

## Why `upgrade_version` is stripped (no `-rc`)

The runner's old `PMM_SERVER_LATEST` was the RC version with `-rc` stripped (e.g. `3.9.1`), and the post-upgrade version checks compare the reported `pmm-admin` / server version against it. Passing `3.9.1-rc` would make those substring checks fail, so `upgrade_version` mirrors the stripped value. If the actual reported version does include `-rc`, this is a one-line change.

## Out of scope / follow-up

The `Resolve PMM client source` step still reads `RC_VERSION: ${{ needs.prepare.outputs.rc_version }}` (empty in the runner) to derive the **starting** client version for the `pmm3-rc` case. That's a separate pre-existing issue from the upgrade-target wiring; happy to fix it in a follow-up by passing the starting RC version in as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWbpB14LhUXkdaYh5LA777