### PR TITLE
Deregister a timed-out setup's nodes before the nightly retry

### DIFF
--- a/.github/scripts/deregister-local-pmm-nodes.sh
+++ b/.github/scripts/deregister-local-pmm-nodes.sh
@@ -54,7 +54,10 @@ for cid in "${containers[@]}"; do
   if is_pmm_server "$cid"; then
     continue
   fi
-  if docker exec "$cid" pmm-admin unregister >/dev/null 2>&1; then
+  # --force is missing from `pmm-admin unregister --help`, but it is required
+  # and it works: without it the command refuses a node that still has agents
+  # ("Node with ID ... has agents", rc=1), which is every node a setup creates.
+  if docker exec "$cid" pmm-admin unregister --force >/dev/null 2>&1; then
     echo "deregister: container ${cid} unregistered its own node"
   else
     leftovers+=("$cid")

--- a/.github/scripts/deregister-local-pmm-nodes.sh
+++ b/.github/scripts/deregister-local-pmm-nodes.sh
@@ -8,44 +8,65 @@
 # with no agent behind them, and every later test that walks the inventory or a
 # node dashboard fails on them.
 #
-# Scoped deliberately to this runner's own containers: the candidate names come
-# from the local Docker state, never from the server's node list, so a shard can
-# never delete another shard's nodes.
+# Each container is asked to unregister itself, which needs no name matching at
+# all and so cannot reach another runner's node. Only what that misses is
+# matched by name, and then only against container ids: a container name or a
+# configured hostname is unique to one Docker daemon, not to the fleet --
+# docker-compose-rs.yaml and docker-compose-sharded.yaml both pin rs101..rs203
+# and those setups run on different runners against the same server, so matching
+# on those would force-delete a live node belonging to another shard.
 
 set -uo pipefail
 
 : "${SERVER_IP:?SERVER_IP must be set}"
 : "${ADMIN_PASSWORD:?ADMIN_PASSWORD must be set}"
 
+# The PMM Server presents a self-signed certificate, as every other curl against
+# it in this workflow assumes (the readyz sanity check and the server-log
+# download both pass -k), so verification is off here for the same reason.
 CURL_OPTS=(--silent --show-error --insecure --connect-timeout 10 --max-time 60)
 AUTH=(--user "admin:${ADMIN_PASSWORD}")
 BASE="https://${SERVER_IP}"
 
-candidates_file=$(mktemp)
-trap 'rm -f "$candidates_file"' EXIT
-
-# Container id, container name and configured hostname all show up as node names
-# depending on how a setup registers its client, so collect all three.
-{
-  docker ps -a --format '{{.ID}}'
-  docker ps -a --format '{{.Names}}'
-  docker ps -aq | while read -r cid; do
-    docker inspect -f '{{.Config.Hostname}}' "$cid" 2>/dev/null || true
-  done
-} 2>/dev/null | sed '/^$/d' | sort -u >"$candidates_file"
-
-if [ ! -s "$candidates_file" ]; then
+mapfile -t containers < <(docker ps -aq 2>/dev/null)
+if [ "${#containers[@]}" -eq 0 ]; then
   echo "deregister: no local containers, nothing to deregister"
   exit 0
 fi
 
-# Never delete the runner's own node: the client-setup step registers it once and
-# the retried attempt reuses it. The PMM Server's own node is always node_id
-# "pmm-server" and is refused with a 403 anyway; it is only a candidate at all
-# when the server runs as a local container, which is not the nightly's layout
-# but is how a reproduction box is built.
-runner_node=$(hostname)
+# A PMM Server running as a local container carries pmm-admin too, and asking it
+# to unregister would remove the server's own node. That is not the nightly's
+# layout -- there the server is remote -- but it is how a reproduction box is
+# built, so skip it explicitly rather than relying on the difference.
+is_pmm_server() {
+  local name image
+  name=$(docker inspect -f '{{.Name}}' "$1" 2>/dev/null)
+  image=$(docker inspect -f '{{.Config.Image}}' "$1" 2>/dev/null)
+  case "${name}#${image}" in
+    */pmm-server#* | *pmm-server:*) return 0 ;;
+  esac
+  return 1
+}
 
+leftovers=()
+for cid in "${containers[@]}"; do
+  if is_pmm_server "$cid"; then
+    continue
+  fi
+  if docker exec "$cid" pmm-admin unregister --force >/dev/null 2>&1; then
+    echo "deregister: container ${cid} unregistered its own node"
+  else
+    leftovers+=("$cid")
+  fi
+done
+
+if [ "${#leftovers[@]}" -eq 0 ]; then
+  echo "deregister: every container unregistered itself"
+  exit 0
+fi
+
+# Fall back to the server's inventory for containers that could not be reached
+# (stopped, or no pmm-admin inside), matching container ids only.
 nodes_json=$(curl "${CURL_OPTS[@]}" "${AUTH[@]}" "${BASE}/v1/management/nodes")
 rc=$?
 if [ "$rc" -ne 0 ] || [ -z "$nodes_json" ]; then
@@ -53,21 +74,25 @@ if [ "$rc" -ne 0 ] || [ -z "$nodes_json" ]; then
   exit 0
 fi
 
+ids_file=$(mktemp)
+trap 'rm -f "$ids_file"' EXIT
+printf '%s\n' "${leftovers[@]}" >"$ids_file"
+
 mapfile -t doomed < <(
   printf '%s' "$nodes_json" |
-    jq -r --arg runner "$runner_node" --rawfile names "$candidates_file" '
-      ($names | split("\n") | map(select(length > 0))) as $local
+    jq -r --rawfile ids "$ids_file" '
+      ($ids | split("\n") | map(select(length > 0))) as $local
       | [.. | objects | select(has("node_id") and has("node_name"))]
       | unique_by(.node_id)
       | .[]
-      | select(.node_id != "pmm-server" and .node_name != $runner)
+      | select(.node_id != "pmm-server")
       | select(.node_name as $n | $local | index($n))
       | "\(.node_id)\t\(.node_name)"
     ' 2>/dev/null
 )
 
 if [ "${#doomed[@]}" -eq 0 ]; then
-  echo "deregister: no stale nodes for this runner's containers"
+  echo "deregister: ${#leftovers[@]} container(s) could not unregister themselves and match no node by container id"
   exit 0
 fi
 

--- a/.github/scripts/deregister-local-pmm-nodes.sh
+++ b/.github/scripts/deregister-local-pmm-nodes.sh
@@ -40,7 +40,10 @@ if [ ! -s "$candidates_file" ]; then
 fi
 
 # Never delete the runner's own node: the client-setup step registers it once and
-# the retried attempt reuses it.
+# the retried attempt reuses it. The PMM Server's own node is always node_id
+# "pmm-server" and is refused with a 403 anyway; it is only a candidate at all
+# when the server runs as a local container, which is not the nightly's layout
+# but is how a reproduction box is built.
 runner_node=$(hostname)
 
 nodes_json=$(curl "${CURL_OPTS[@]}" "${AUTH[@]}" "${BASE}/v1/management/nodes")
@@ -57,7 +60,7 @@ mapfile -t doomed < <(
       | [.. | objects | select(has("node_id") and has("node_name"))]
       | unique_by(.node_id)
       | .[]
-      | select(.node_name != $runner)
+      | select(.node_id != "pmm-server" and .node_name != $runner)
       | select(.node_name as $n | $local | index($n))
       | "\(.node_id)\t\(.node_name)"
     ' 2>/dev/null

--- a/.github/scripts/deregister-local-pmm-nodes.sh
+++ b/.github/scripts/deregister-local-pmm-nodes.sh
@@ -8,8 +8,9 @@
 # with no agent behind them, and every later test that walks the inventory or a
 # node dashboard fails on them.
 #
-# Each container is asked to unregister itself, which needs no name matching at
-# all and so cannot reach another runner's node. Only what that misses is
+# Each container is asked to unregister itself (`pmm-admin unregister`, whose
+# only subject is the node that container's own agent registered), which needs
+# no name matching at all and so cannot reach another runner's node. Only what that misses is
 # matched by name, and then only against container ids: a container name or a
 # configured hostname is unique to one Docker daemon, not to the fleet --
 # docker-compose-rs.yaml and docker-compose-sharded.yaml both pin rs101..rs203
@@ -53,7 +54,7 @@ for cid in "${containers[@]}"; do
   if is_pmm_server "$cid"; then
     continue
   fi
-  if docker exec "$cid" pmm-admin unregister --force >/dev/null 2>&1; then
+  if docker exec "$cid" pmm-admin unregister >/dev/null 2>&1; then
     echo "deregister: container ${cid} unregistered its own node"
   else
     leftovers+=("$cid")

--- a/.github/scripts/deregister-local-pmm-nodes.sh
+++ b/.github/scripts/deregister-local-pmm-nodes.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Remove from a PMM Server the nodes registered by containers that live on this
+# runner, so a retried setup does not leave a dead half-registration behind.
+#
+# The nightly matrix points several runners at one long-lived remote PMM Server.
+# When a setup attempt times out, the retry wipes the runner's Docker state but
+# the nodes, services and agents it had already registered stay on the server
+# with no agent behind them, and every later test that walks the inventory or a
+# node dashboard fails on them.
+#
+# Scoped deliberately to this runner's own containers: the candidate names come
+# from the local Docker state, never from the server's node list, so a shard can
+# never delete another shard's nodes.
+
+set -uo pipefail
+
+: "${SERVER_IP:?SERVER_IP must be set}"
+: "${ADMIN_PASSWORD:?ADMIN_PASSWORD must be set}"
+
+CURL_OPTS=(--silent --show-error --insecure --connect-timeout 10 --max-time 60)
+AUTH=(--user "admin:${ADMIN_PASSWORD}")
+BASE="https://${SERVER_IP}"
+
+candidates_file=$(mktemp)
+trap 'rm -f "$candidates_file"' EXIT
+
+# Container id, container name and configured hostname all show up as node names
+# depending on how a setup registers its client, so collect all three.
+{
+  docker ps -a --format '{{.ID}}'
+  docker ps -a --format '{{.Names}}'
+  docker ps -aq | while read -r cid; do
+    docker inspect -f '{{.Config.Hostname}}' "$cid" 2>/dev/null || true
+  done
+} 2>/dev/null | sed '/^$/d' | sort -u >"$candidates_file"
+
+if [ ! -s "$candidates_file" ]; then
+  echo "deregister: no local containers, nothing to deregister"
+  exit 0
+fi
+
+# Never delete the runner's own node: the client-setup step registers it once and
+# the retried attempt reuses it.
+runner_node=$(hostname)
+
+nodes_json=$(curl "${CURL_OPTS[@]}" "${AUTH[@]}" "${BASE}/v1/management/nodes")
+rc=$?
+if [ "$rc" -ne 0 ] || [ -z "$nodes_json" ]; then
+  echo "deregister: could not read the node inventory from ${SERVER_IP} (curl rc=${rc}); leaving it alone" >&2
+  exit 0
+fi
+
+mapfile -t doomed < <(
+  printf '%s' "$nodes_json" |
+    jq -r --arg runner "$runner_node" --rawfile names "$candidates_file" '
+      ($names | split("\n") | map(select(length > 0))) as $local
+      | [.. | objects | select(has("node_id") and has("node_name"))]
+      | unique_by(.node_id)
+      | .[]
+      | select(.node_name != $runner)
+      | select(.node_name as $n | $local | index($n))
+      | "\(.node_id)\t\(.node_name)"
+    ' 2>/dev/null
+)
+
+if [ "${#doomed[@]}" -eq 0 ]; then
+  echo "deregister: no stale nodes for this runner's containers"
+  exit 0
+fi
+
+failed=0
+for entry in "${doomed[@]}"; do
+  node_id=${entry%%$'\t'*}
+  node_name=${entry#*$'\t'}
+  code=$(curl "${CURL_OPTS[@]}" "${AUTH[@]}" -o /dev/null -w '%{http_code}' \
+    -X DELETE "${BASE}/v1/management/nodes/${node_id}?force=true")
+  if [ "$code" = "200" ]; then
+    echo "deregister: removed node ${node_name} (${node_id})"
+  else
+    echo "deregister: failed to remove node ${node_name} (${node_id}), http=${code}" >&2
+    failed=$((failed + 1))
+  fi
+done
+
+if [ "$failed" -gt 0 ]; then
+  echo "deregister: ${failed} node(s) left on the server; the next attempt starts from a dirty inventory" >&2
+fi
+
+exit 0

--- a/.github/scripts/deregister-local-pmm-nodes.sh
+++ b/.github/scripts/deregister-local-pmm-nodes.sh
@@ -2,20 +2,13 @@
 # Remove from a PMM Server the nodes registered by containers that live on this
 # runner, so a retried setup does not leave a dead half-registration behind.
 #
-# The nightly matrix points several runners at one long-lived remote PMM Server.
-# When a setup attempt times out, the retry wipes the runner's Docker state but
-# the nodes, services and agents it had already registered stay on the server
-# with no agent behind them, and every later test that walks the inventory or a
-# node dashboard fails on them.
-#
-# Each container is asked to unregister itself (`pmm-admin unregister`, whose
-# only subject is the node that container's own agent registered), which needs
-# no name matching at all and so cannot reach another runner's node. Only what that misses is
-# matched by name, and then only against container ids: a container name or a
+# Several runners share one PMM Server, so what this deletes has to be scoped to
+# this runner and nothing else. Each container is asked to unregister itself,
+# which names no node but its own; only what that misses falls back to matching
+# the inventory, and then against container ids alone. A container name or a
 # configured hostname is unique to one Docker daemon, not to the fleet --
-# docker-compose-rs.yaml and docker-compose-sharded.yaml both pin rs101..rs203
-# and those setups run on different runners against the same server, so matching
-# on those would force-delete a live node belonging to another shard.
+# docker-compose-rs.yaml and docker-compose-sharded.yaml both pin rs101..rs203,
+# and those setups run on different runners against the same server.
 
 set -uo pipefail
 
@@ -36,9 +29,7 @@ if [ "${#containers[@]}" -eq 0 ]; then
 fi
 
 # A PMM Server running as a local container carries pmm-admin too, and asking it
-# to unregister would remove the server's own node. That is not the nightly's
-# layout -- there the server is remote -- but it is how a reproduction box is
-# built, so skip it explicitly rather than relying on the difference.
+# to unregister would remove the server's own node.
 is_pmm_server() {
   local name image
   name=$(docker inspect -f '{{.Name}}' "$1" 2>/dev/null)
@@ -71,7 +62,10 @@ fi
 
 # Fall back to the server's inventory for containers that could not be reached
 # (stopped, or no pmm-admin inside), matching container ids only.
-nodes_json=$(curl "${CURL_OPTS[@]}" "${AUTH[@]}" "${BASE}/v1/management/nodes")
+# --fail so an HTTP error takes the branch below: without it curl exits 0 on a
+# 401 or a 502, jq finds no node_id in the error body, and a server this script
+# could not actually read reports "no stale nodes" and looks like it worked.
+nodes_json=$(curl "${CURL_OPTS[@]}" "${AUTH[@]}" --fail "${BASE}/v1/management/nodes")
 rc=$?
 if [ "$rc" -ne 0 ] || [ -z "$nodes_json" ]; then
   echo "deregister: could not read the node inventory from ${SERVER_IP} (curl rc=${rc}); leaving it alone" >&2

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -136,6 +136,7 @@ jobs:
               --client-version "${{ env.PMM_CLIENT_VERSION }}" \
               ${{ env.WIZARD_ARGS }}
           on_retry_command: |
+            pmm-qa/.github/scripts/deregister-local-pmm-nodes.sh || true
             docker rm -f $(docker ps -a -q) || true
             docker volume rm -f $(docker volume ls -q) || true
             docker network rm -f $(docker network ls -q) || true


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://github.com/percona/pmm-qa/actions/runs/34381643225 (Nightly E2E tests Matrix, `INSTALLATION_TYPE: docker`, server `18.119.156.245`, `perconalab/pmm-server:3-dev-latest`, client 3.9.0)
- tests:
  - `codeceptjs-e2e/tests/configuration/verifyPMMInventory_test.js` / PMM-T554 @nightly
  - `codeceptjs-e2e/tests/configuration/verifyPMMInventory_test.js` / PMM-T2146 @nightly (services and nodes, 2 cases)
  - `codeceptjs-e2e/tests/dashboards/verifyHomeDashboards_test.js` / PMM-T1565 @nightly @dashboards (3 panel cases)
  - `codeceptjs-e2e/tests/dashboards/verifyHomeDashboards_test.js` / PMM-T2007 @nightly @dashboards
  - `codeceptjs-e2e/tests/verifyMysqlDashboards_test.js` / PMM-T2079 @dashboards @nightly
  - `codeceptjs-e2e/tests/verifyOSDashboards_test.js` / Nodes Compare @nightly @dashboards
  - `codeceptjs-e2e/tests/QAN/details_explain_test.js` / PMM-T13 @qan
  - `codeceptjs-e2e/tests/QAN/details_explain_test.js` / PMM-T1790 @qan

## What happened

Three of the five setup shards (`ps-myrocks-pdpgsql-patroni-external`, `ps-replication-psmdb-sharded`, `ps-gr-pxc-valkey`) hit the 29m timeout on attempt 1 — `exit status 1` / `Attempt 1 failed. Reason: Child_process exited with error code 124`. `nick-fields/retry` then ran `on_retry_command`, which wipes the runner's containers, volumes and networks but says nothing to the PMM Server. Attempt 2 registered a second, live set of containers alongside the first set, which was still in the server's inventory with no agent behind it.

The nightly is where this bites: its PMM Server is remote and shared by all five shards, so nothing clears the leftovers before the test jobs run.

Every failure in the run is one of those orphans:

| Test | Evidence in the run |
|---|---|
| PMM-T554 | `Not all pmm agents are connected` |
| PMM-T2146 | node `1a9f12514b84` Failed ×16; service `mongos_28088` Failed ×13 |
| PMM-T1565 | Nodes Overview, `var-node_name=1a9f12514b84`, 7 empty panels vs 3 tolerated |
| PMM-T2007 | 14 MySQL services from the inventory API, 13 on the Monitored DB Services panel |
| PMM-T2079 | MySQL MyRocks Details, `var-node_name=283b18d7a01f`, 42 empty panels |
| Nodes Compare | `var-node_name=1a9f12514b84`, 19 empty panels |
| PMM-T13 / PMM-T1790 | Explain shows `<pre data-testid="json-explain-error">Pmm-agent with ID aa9cd8f2-…` |

The assertions are right and PMM itself is fine — the environment carried a dead half-registration, so no assertion is loosened here.

## The change

`on_retry_command` now clears those registrations before wiping the runner.

Each container is asked to **unregister itself** — `docker exec <c> pmm-admin unregister --force`, whose only subject is the node that container's own agent registered. There is no name matching in that path, so it cannot reach a node this runner did not create.

Only containers that can't be reached — stopped, or with no `pmm-admin` inside — fall back to the server's inventory, and that fallback matches **container ids only**. Container names and configured hostnames are deliberately *not* matched: they are unique to one Docker daemon, not to the fleet. `docker-compose-rs.yaml` and `docker-compose-sharded.yaml` both pin `hostname: rs101` … `rs203`, and those two setups run on different runners against the same server, so matching on them could force-delete another shard's live node (caught in review — thanks, see [thread](https://github.com/percona/pmm-qa/pull/1392#discussion_r3972353653)).

A PMM Server running as a local container carries `pmm-admin` too, so it is skipped by name and image — that is the reproduction box's layout rather than the nightly's, but the script should not depend on the difference. Every `curl` is bounded (`--connect-timeout 10 --max-time 60`) and the script always exits 0: a server it cannot reach leaves the inventory alone and says so, rather than turning a retry into a failed job.

## Verification

On a throwaway Linode VM with the real `pmm-framework --database ps` against a PMM Server on the box:

1. **The orphan reproduces.** The container registers node `19f232793e6c` — node name is the container short id, the same shape as the run's `1a9f12514b84`. Running the *existing* `on_retry_command` wipe leaves that node registered, `STATUS_UNKNOWN` with 3 agents against `STATUS_UP` for a live one, which is what the inventory page renders as "Failed". A second framework run then registers a node alongside it: exactly the two-node state the failing run was in.
2. **The self-unregister path clears it.** Against a freshly registered node:
   ```
   deregister: container c7057cd417f8 unregistered its own node
   deregister: every container unregistered itself
   ```
   Node and service gone afterwards; the `pmm-server` node untouched.
3. **The fallback path works and is scoped.** When the `docker exec` fails, the container-id match removes the node through the API (`deregister: removed node 5e2a3a0c2230 (f5308341-…)`), and a pre-existing orphan whose container no longer exists is left alone.
4. **Unreachable server** (`SERVER_IP=127.0.0.1:9`): `could not read the node inventory … leaving it alone`, exit 0, within the bound.

Two things only the box could tell me, both now recorded in the script:

- `--force` is missing from `pmm-admin unregister --help`, but it is required. The plain form answers `Node with ID "025cdea4-…" has agents.` and exits 1 — true of every node a setup creates — so without it the primary path would silently degrade to the id-only fallback for all of them.
- A local PMM Server container has `pmm-admin`, so an unguarded loop would unregister the server's own node. It got a 403 in an earlier revision; it is now skipped outright.

**What this does not prove:** nothing here re-runs the nightly. `nightly-e2e-tests-matrix.yml` is dispatched by Jenkins against an external PMM Server, so no check on this branch exercises the changed path, and the original run cannot be re-run — its server is already gone. The end-to-end effect is only visible on the next Jenkins-dispatched nightly, or a dispatch with `PMM_QA_GIT_BRANCH` set to this branch.

## Worth a separate look

Three of five shards needing a second attempt at all says the 29m/30m setup budget is tight for a grouped shard's cold image pulls (the grouping landed in a4d8fe7, PMM-15486). This change makes that retry harmless rather than making it rarer; raising the budget is a separate trade-off, since the test jobs already wait ~50 minutes for setup.

Also raised in review: this script uses `curl --insecure`, as every other request to the PMM Server in the same job already does (the readyz sanity check, the server-log download, and the `PMM_URL` the suites are handed). Giving the runner a CA it can actually verify against is a change to the nightly's credential handling as a whole rather than to this step — [thread left open](https://github.com/percona/pmm-qa/pull/1392#discussion_r3972353644) for the team to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDYRAgbsx5LooJzMJp8BPf