### PR TITLE
Unregister a failed setup attempt's nodes before the retry wipes them

### DIFF
--- a/.github/workflows/ha-e2e-tests.yml
+++ b/.github/workflows/ha-e2e-tests.yml
@@ -176,6 +176,17 @@ jobs:
               --client-version "${PMM_CLIENT_VERSION}" \
               ${WIZARD_ARGS}
           on_retry_command: |
+            # The PMM Server is remote and outlives this runner, so the nodes and
+            # services the failed attempt registered survive the container wipe
+            # below and stay in its inventory as Failed/disconnected forever.
+            # Unregister each container's node before removing it. Names are
+            # per-attempt random for some setups, so the retry cannot reuse them.
+            for c in $(docker ps -a -q); do
+              docker start "$c" >/dev/null 2>&1 || true
+              timeout 60 docker exec "$c" bash -lc \
+                'command -v pmm-admin >/dev/null 2>&1 && pmm-admin unregister --force' \
+                || echo "no PMM Client to unregister in $c"
+            done
             docker rm -f $(docker ps -a -q) || true
             docker volume rm -f $(docker volume ls -q) || true
             docker network rm -f $(docker network ls -q) || true

--- a/.github/workflows/ha-e2e-tests.yml
+++ b/.github/workflows/ha-e2e-tests.yml
@@ -180,9 +180,11 @@ jobs:
             # failed attempt registered stay in its inventory as Failed forever.
             for c in $(docker ps -a -q); do
               docker start "$c" >/dev/null 2>&1 || true
-              timeout 60 docker exec "$c" bash -lc \
-                'command -v pmm-admin >/dev/null 2>&1 && pmm-admin unregister --force' \
-                || echo "no PMM Client to unregister in $c"
+              if ! timeout 60 docker exec "$c" bash -lc 'command -v pmm-admin' >/dev/null 2>&1; then
+                echo "no PMM Client in $c, nothing to unregister"
+              elif ! timeout 60 docker exec "$c" bash -lc 'pmm-admin unregister --force'; then
+                echo "WARNING: unregister failed in $c - its node may survive into the retry as Failed"
+              fi
             done
             docker rm -f $(docker ps -a -q) || true
             docker volume rm -f $(docker volume ls -q) || true

--- a/.github/workflows/ha-e2e-tests.yml
+++ b/.github/workflows/ha-e2e-tests.yml
@@ -176,11 +176,8 @@ jobs:
               --client-version "${PMM_CLIENT_VERSION}" \
               ${WIZARD_ARGS}
           on_retry_command: |
-            # The PMM Server is remote and outlives this runner, so the nodes and
-            # services the failed attempt registered survive the container wipe
-            # below and stay in its inventory as Failed/disconnected forever.
-            # Unregister each container's node before removing it. Names are
-            # per-attempt random for some setups, so the retry cannot reuse them.
+            # The PMM Server is remote and outlives this runner, so nodes the
+            # failed attempt registered stay in its inventory as Failed forever.
             for c in $(docker ps -a -q); do
               docker start "$c" >/dev/null 2>&1 || true
               timeout 60 docker exec "$c" bash -lc \

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -136,11 +136,8 @@ jobs:
               --client-version "${{ env.PMM_CLIENT_VERSION }}" \
               ${{ env.WIZARD_ARGS }}
           on_retry_command: |
-            # The PMM Server is remote and outlives this runner, so the nodes and
-            # services the failed attempt registered survive the container wipe
-            # below and stay in its inventory as Failed/disconnected forever.
-            # Unregister each container's node before removing it. Names are
-            # per-attempt random for some setups, so the retry cannot reuse them.
+            # The PMM Server is remote and outlives this runner, so nodes the
+            # failed attempt registered stay in its inventory as Failed forever.
             for c in $(docker ps -a -q); do
               docker start "$c" >/dev/null 2>&1 || true
               timeout 60 docker exec "$c" bash -lc \

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -140,9 +140,11 @@ jobs:
             # failed attempt registered stay in its inventory as Failed forever.
             for c in $(docker ps -a -q); do
               docker start "$c" >/dev/null 2>&1 || true
-              timeout 60 docker exec "$c" bash -lc \
-                'command -v pmm-admin >/dev/null 2>&1 && pmm-admin unregister --force' \
-                || echo "no PMM Client to unregister in $c"
+              if ! timeout 60 docker exec "$c" bash -lc 'command -v pmm-admin' >/dev/null 2>&1; then
+                echo "no PMM Client in $c, nothing to unregister"
+              elif ! timeout 60 docker exec "$c" bash -lc 'pmm-admin unregister --force'; then
+                echo "WARNING: unregister failed in $c - its node may survive into the retry as Failed"
+              fi
             done
             docker rm -f $(docker ps -a -q) || true
             docker volume rm -f $(docker volume ls -q) || true

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -136,6 +136,17 @@ jobs:
               --client-version "${{ env.PMM_CLIENT_VERSION }}" \
               ${{ env.WIZARD_ARGS }}
           on_retry_command: |
+            # The PMM Server is remote and outlives this runner, so the nodes and
+            # services the failed attempt registered survive the container wipe
+            # below and stay in its inventory as Failed/disconnected forever.
+            # Unregister each container's node before removing it. Names are
+            # per-attempt random for some setups, so the retry cannot reuse them.
+            for c in $(docker ps -a -q); do
+              docker start "$c" >/dev/null 2>&1 || true
+              timeout 60 docker exec "$c" bash -lc \
+                'command -v pmm-admin >/dev/null 2>&1 && pmm-admin unregister --force' \
+                || echo "no PMM Client to unregister in $c"
+            done
             docker rm -f $(docker ps -a -q) || true
             docker volume rm -f $(docker volume ls -q) || true
             docker network rm -f $(docker network ls -q) || true


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://github.com/percona/pmm-qa/actions/runs/34381455930 (Nightly E2E tests Matrix, remote PMM Server, `INSTALLATION_TYPE=docker`)
- tests:
  - `codeceptjs-e2e/tests/configuration/verifyPMMInventory_test.js` / `@nightly` — PMM-T2146 (nodes)
  - `codeceptjs-e2e/tests/configuration/verifyPMMInventory_test.js` / `@nightly` — PMM-T2146 (services)
  - `codeceptjs-e2e/tests/configuration/verifyPMMInventory_test.js` / `@inventory @nightly` — PMM-T554

## What went wrong

The nightly matrix points five setup runners at **one remote PMM Server that outlives them all**. When a setup attempt fails, `nick-fields/retry` runs `on_retry_command`, which removes every container on the runner and re-runs `pmm-framework` from scratch.

Nothing in that cleanup tells the PMM Server. The nodes and services the failed attempt registered stay in its inventory with no agent behind them, so they sit there as Failed/disconnected for the rest of the run — and the retry cannot adopt them, because several setups pick a fresh random service name each attempt (`external_setup.yml` → `nodeprocess_service_$RANDOM`) and a container node is named after its container id.

In run 34381455930 the `ps-myrocks-pdpgsql-patroni-external` shard timed out on attempt 1 at 17:43 (`Child_process exited with error code 124`, the `timeout -k 30 29m` wrapper) and succeeded on attempt 2. It left behind node `4aabb3b35e55`, service `nodeprocess_service_4906` and pmm-agent `7a379a26-4541-42b8-b07c-c5db0619ea33` (`is_connected: false`, created 17:29:28). The `@nightly` job then failed on exactly those rows:

| Test | Failure |
|---|---|
| PMM-T2146 (nodes) | `[{"serviceName":"4aabb3b35e55","status":"Failed"}, …×3]` |
| PMM-T2146 (services) | `[{"serviceName":"nodeprocess_service_4906","status":"Failed"}, …×2]` |
| PMM-T554 | `Not all pmm agents are connected` — agent `7a379a26…`, `is_connected: false` |

The same three failed in the two other nightly runs on this commit — [34381404678](https://github.com/percona/pmm-qa/actions/runs/34381404678) and [34381643225](https://github.com/percona/pmm-qa/actions/runs/34381643225) — whose setup logs show the same shards retrying (`ps-gr-pxc-valkey`, `ps-myrocks-pdpgsql-patroni-external`, `ps-replication-psmdb-sharded`). Each of those runs had its own dedicated PMM Server (`3.23.126.188`, `18.119.156.245`, `18.219.209.91`), so this is not cross-run interference — every run poisons its own server.

**The assertions are right and the product is fine.** The environment left rows the tests correctly refuse to accept, so the fix belongs in the setup, not in the test.

## The fix

Unregister each container's node from the server *before* removing the container. `pmm-admin unregister --force` inside the container drops that node with all its services and agents, and it autodetects the node name, so it stays correct for setups that do not name a node after its container.

- A container the failed attempt already exited is `docker start`ed first so it can be exec'd — `unregister` talks to the server directly and does not need the local agent up.
- The probe and the unregister are separate execs, each bounded at 60s, so the log can tell a container that never had a PMM Client (expected, harmless) apart from an unregister that actually failed (the orphan then survives into the retry — the state this change exists to prevent). The loop exits 0 either way, so it cannot abort the rest of the cleanup.

`ha-e2e-tests.yml` carries the identical cleanup against an equally external HA server, so it gets the same fix.

## Verification

Reproduced and fixed on a throwaway Linode VM running the **same server image as the failing run** — `perconalab/pmm-server:3-dev-latest`, image id `4e6ce1d97a59`, matching the Launchable build `sha256:4e6ce1d97a59…` recorded by that job — with `--client-version 3.9.1`, as the run used.

1. **Baseline** — `pmm-framework --database external` registered node `7804b7c77933` with `redis_external_service_4546` / `nodeprocess_service_4546`, all `STATUS_UP`, pmm-agent connected.
2. **Reproduced** — ran the *current* `on_retry_command` (containers only; the VM's PMM Server stands in for CI's remote one, so it was excluded, as it would be on a runner), then re-ran the setup. Result, once statuses settled:

   ```
   redis_external_service_4546  STATUS_UNSPECIFIED  pmm-agent connected=[False]   <- orphan
   nodeprocess_service_4546     STATUS_UNSPECIFIED  pmm-agent connected=[False]   <- orphan
   redis_external_service_7320  STATUS_UP           pmm-agent connected=[True]
   nodeprocess_service_7320     STATUS_UP           pmm-agent connected=[True]
   ```

   Both orphan node `7804b7c77933` and its old pmm-agent were still in inventory — the exact shape PMM-T2146 and PMM-T554 reported in CI.
3. **Fixed** — ran the cleanup body on the same box. It skipped `redis_container` (no PMM Client), unregistered the client container, and inventory dropped straight back to `pmm-server` alone:

   ```
   Node with ID 5d3f5b4e-7e20-4e7c-bfe4-b46a28aa825c and name 3af182ff39a6 unregistered.
   ```

   A fresh setup after it left exactly one external node and its two services, `NON-OK SERVICES: 0`, every pmm-agent connected — which is what both tests assert.
4. **Diagnostic branching** (added in ed3f9d7, after the VM was gone) — validated with a stubbed `docker` over the three cases, each producing its own line and the loop exiting 0 under `set -e`:

   ```
   no PMM Client in c_noclient, nothing to unregister
   Node with ID x and name c_ok unregistered.
   server unreachable
   WARNING: unregister failed in c_failing - its node may survive into the retry as Failed
   exit=0
   ```
5. **Repo lint gate** — `bash .claude/hooks/lint-changed.sh` on both changed files: `yamllint --strict` and `actionlint` (with its embedded shellcheck at the default severity this repo does not suppress) both clean, `EXIT=0`. This is what the `Lint` check on the PR runs.

### What this does *not* prove

`nightly-e2e-tests-matrix.yml` and `ha-e2e-tests.yml` are `workflow_dispatch`-only, so while the `Lint` check does statically check both files, no job on this head *executes* the `on_retry_command` block — and it only fires when a setup attempt actually fails. End-to-end confirmation needs a Jenkins-dispatched nightly with `PMM_QA_GIT_BRANCH=claude/eager-knuth-l2mjcz` — **worth running before merge**; I did not dispatch one unattended, since it provisions a remote PMM Server and eight runners.

The step-3 run exercised the earlier single-exec form; the split in step 4 is validated against a stub rather than a live PMM Server, since the box was already torn down. The unregister call itself is unchanged between the two.

## Left out on purpose

- **PMM-T2030 — "Verify QAN for PS Replica Instance"** also failed in this run (`locator.click: Timeout 20000ms exceeded` on the *Replication Set* → `filter-checkbox-ps-async-replication` control, after the locator had resolved and the element read visible/enabled/stable). It is unrelated to the orphaned inventory and it is intermittent: it passed in run 34381643225, and in 34381404678 it failed once and passed on the retry. Diagnosing it needs a loaded reproduction on a `ps-replication` environment; folding a timing fix into this PR would only blur what is being verified here.
- **The 29-minute setup budget.** Attempt 1 failing at all is a separate reliability question — `ps-myrocks-pdpgsql-patroni-external` took 22 minutes on its successful attempt, so the shard sits close to its `timeout -k 30 29m`. Not changed here; this PR only stops a failed attempt from poisoning the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rfJvxuQ8U1i8jWsXMtH47