### PR TITLE
PMM-15486 Unregister clients before wiping them on setup retry

### DIFF
--- a/.github/workflows/ha-e2e-tests.yml
+++ b/.github/workflows/ha-e2e-tests.yml
@@ -178,8 +178,9 @@ jobs:
           on_retry_command: |
             # Removing a container does not unregister its node from the remote server.
             for c in $(docker ps -q); do
-              timeout 60 docker exec "$c" pmm-admin unregister --force >/dev/null 2>&1 ||
-                echo "pmm-admin unregister skipped for container $c"
+              docker exec "$c" sh -c 'command -v pmm-admin' >/dev/null 2>&1 || continue
+              timeout 60 docker exec "$c" pmm-admin unregister --force ||
+                echo "pmm-admin unregister FAILED for $c - its node may still be registered"
             done
             docker rm -f $(docker ps -a -q) || true
             docker volume rm -f $(docker volume ls -q) || true

--- a/.github/workflows/ha-e2e-tests.yml
+++ b/.github/workflows/ha-e2e-tests.yml
@@ -176,6 +176,15 @@ jobs:
               --client-version "${PMM_CLIENT_VERSION}" \
               ${WIZARD_ARGS}
           on_retry_command: |
+            # Each client container registered its own node, services and agents
+            # on the remote PMM Server. Removing the container does not undo that,
+            # so unregister first -- otherwise attempt 1's registrations survive as
+            # permanently disconnected agents and duplicate services that the
+            # inventory and dashboard tests then fail on.
+            for c in $(docker ps -q); do
+              timeout 60 docker exec "$c" pmm-admin unregister --force >/dev/null 2>&1 ||
+                echo "pmm-admin unregister skipped for container $c"
+            done
             docker rm -f $(docker ps -a -q) || true
             docker volume rm -f $(docker volume ls -q) || true
             docker network rm -f $(docker network ls -q) || true

--- a/.github/workflows/ha-e2e-tests.yml
+++ b/.github/workflows/ha-e2e-tests.yml
@@ -176,11 +176,7 @@ jobs:
               --client-version "${PMM_CLIENT_VERSION}" \
               ${WIZARD_ARGS}
           on_retry_command: |
-            # Each client container registered its own node, services and agents
-            # on the remote PMM Server. Removing the container does not undo that,
-            # so unregister first -- otherwise attempt 1's registrations survive as
-            # permanently disconnected agents and duplicate services that the
-            # inventory and dashboard tests then fail on.
+            # Removing a container does not unregister its node from the remote server.
             for c in $(docker ps -q); do
               timeout 60 docker exec "$c" pmm-admin unregister --force >/dev/null 2>&1 ||
                 echo "pmm-admin unregister skipped for container $c"

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -136,6 +136,15 @@ jobs:
               --client-version "${{ env.PMM_CLIENT_VERSION }}" \
               ${{ env.WIZARD_ARGS }}
           on_retry_command: |
+            # Each client container registered its own node, services and agents
+            # on the remote PMM Server. Removing the container does not undo that,
+            # so unregister first -- otherwise attempt 1's registrations survive as
+            # permanently disconnected agents and duplicate services that the
+            # inventory and dashboard tests then fail on.
+            for c in $(docker ps -q); do
+              timeout 60 docker exec "$c" pmm-admin unregister --force >/dev/null 2>&1 ||
+                echo "pmm-admin unregister skipped for container $c"
+            done
             docker rm -f $(docker ps -a -q) || true
             docker volume rm -f $(docker volume ls -q) || true
             docker network rm -f $(docker network ls -q) || true

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -138,8 +138,9 @@ jobs:
           on_retry_command: |
             # Removing a container does not unregister its node from the remote server.
             for c in $(docker ps -q); do
-              timeout 60 docker exec "$c" pmm-admin unregister --force >/dev/null 2>&1 ||
-                echo "pmm-admin unregister skipped for container $c"
+              docker exec "$c" sh -c 'command -v pmm-admin' >/dev/null 2>&1 || continue
+              timeout 60 docker exec "$c" pmm-admin unregister --force ||
+                echo "pmm-admin unregister FAILED for $c - its node may still be registered"
             done
             docker rm -f $(docker ps -a -q) || true
             docker volume rm -f $(docker volume ls -q) || true

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -136,11 +136,7 @@ jobs:
               --client-version "${{ env.PMM_CLIENT_VERSION }}" \
               ${{ env.WIZARD_ARGS }}
           on_retry_command: |
-            # Each client container registered its own node, services and agents
-            # on the remote PMM Server. Removing the container does not undo that,
-            # so unregister first -- otherwise attempt 1's registrations survive as
-            # permanently disconnected agents and duplicate services that the
-            # inventory and dashboard tests then fail on.
+            # Removing a container does not unregister its node from the remote server.
             for c in $(docker ps -q); do
               timeout 60 docker exec "$c" pmm-admin unregister --force >/dev/null 2>&1 ||
                 echo "pmm-admin unregister skipped for container $c"


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://github.com/percona/pmm-qa/actions/runs/34381404678
- tests:
  - `codeceptjs-e2e/tests/configuration/verifyPMMInventory_test.js` / @inventory @nightly — PMM-T554
  - `codeceptjs-e2e/tests/configuration/verifyPMMInventory_test.js` / @nightly — PMM-T2146 (`graph/inventory/services`)
  - `codeceptjs-e2e/tests/configuration/verifyPMMInventory_test.js` / @nightly — PMM-T2146 (`graph/inventory/nodes`)
  - `codeceptjs-e2e/tests/dashboards/verifyHomeDashboards_test.js` / @nightly @dashboards — PMM-T2007
  - `codeceptjs-e2e/tests/verifyMysqlDashboards_test.js` / @nightly @dashboards — PMM-T68 + PMM-T2038
  - `codeceptjs-e2e/tests/QAN/details_explain_test.js` / @qan — PMM-T13

## What

`runner-e2e-tests-codeceptjs-remote-nightly-setup.yml` wraps `pmm-framework` in `nick-fields/retry` with an `on_retry_command` of `docker rm -f $(docker ps -a -q)`. Each client container has already registered its own node, services and agents on the **remote** PMM Server, and removing the container does not undo that — so every database a timed-out attempt 1 did finish stays behind on the server as a node whose pmm-agent can never reconnect. Attempt 2 then registers a second copy of everything.

The fix runs `pmm-admin unregister --force` inside each container before the containers go away. That drops exactly the node the container owns, with its services and agents, and nothing else: the runner's own client (set up in an earlier, non-retried step) is untouched, and so are the other shards sharing the same server. The exec is bounded at 60s so an unresponsive container cannot park the cleanup.

Not every container `pmm-framework` starts carries `pmm-admin` — `external_setup.yml:44-50` runs a stock `redis` image as `redis_container` next to the client container, in `ps-myrocks-pdpgsql-patroni-external`, one of the shards that actually retried. So the loop probes for the client first and skips those quietly, and lets the real error text through for anything that has one: a `pmm-admin unregister` that runs and *fails* is the case where the leak survives, and it must not read like a benign skip.

`ha-e2e-tests.yml` carries the same `on_retry_command` against a remote server and gets the same fix.

## Why

Run [34381404678](https://github.com/percona/pmm-qa/actions/runs/34381404678) went red on six tests. Three of the five setup shards hit the 29m `timeout` on attempt 1 (`Child_process exited with error code 124`) after some of their databases had already registered, retried, and left **13 permanently disconnected pmm-agents** plus duplicate services on the server:

| Test | Assertion | Explained by |
|---|---|---|
| PMM-T554 | "Not all pmm agents are connected" | 13 orphaned agents, `is_connected: false` |
| PMM-T2146 (services) | 17 services in `Failed` | orphaned services |
| PMM-T2146 (nodes) | 15 nodes in `Failed` | orphaned nodes |
| PMM-T2007 | 17 MySQL services from the API vs 13 on the panel | orphans counted by the API, no live metrics |
| PMM-T68 + PMM-T2038 | 3 ProxySQL options where 2 are expected | an orphaned attempt-1 ProxySQL |
| PMM-T13 | QAN Explain never renders | Explain needs a live agent; the PS service it picked was orphaned |

Sibling run [34381455930](https://github.com/percona/pmm-qa/actions/runs/34381455930) shows the same shard timeouts and the same three Inventory failures.

## Verification

On throwaway Linode VMs against `perconalab/pmm-server:3-dev-latest`.

**Reproduced first, with the current code.** After `pmm-framework --database ps`, removing the client container the way `on_retry_command` does left the node `e84554b295f9`, the service `ps_pmm_8_0_1_59604` and its pmm-agent at `connected: false` on the server. Re-running the setup added `2ef527c7d5bc` / `ps_pmm_8_0_1_24956` alongside them — two container nodes, two MySQL services, one dead agent. That is the T554 and T2007 shape.

**With the fix**, the same attempt-1 → retry → attempt-2 cycle ends clean:

```
== attempt 1 ==
nodes:    d6aacc8656ed, pmm-server
services: ps_pmm_8_0_1_66744
== fixed on_retry_command ==
after retry-cleanup nodes:    pmm-server
after retry-cleanup services: (none)
== attempt 2 ==
FINAL nodes:      b3fc85055a8b, pmm-server
FINAL services:   ps_pmm_8_0_1_18028
FINAL pmm-agents: connected=true, connected=true
```

**The probe and reporting branches**, exercised on a second VM with three real containers — a stock `redis` with no `pmm-admin`, a client whose `unregister` exits 1 writing to stderr, and a client that succeeds:

```
Node with ID abc and name ok_client unregistered.
Failed to unregister node: connection refused
pmm-admin unregister FAILED for 768d636db6d3 - its node may still be registered
loop exit=0
```

The `redis` container is skipped with no output; without the probe it instead prints `OCI runtime exec failed: … "pmm-admin": executable file not found in $PATH` and gets reported as a possible leak.

`bash -n` on the extracted input and a YAML parse are clean; `shellcheck -s bash` is clean on the added lines (the three SC2046 warnings on the `docker rm`/`volume`/`network` lines are pre-existing and untouched).

What this does **not** prove: the fix is a GitHub Actions workflow change, so only a real nightly run that actually times out a shard and retries will exercise it end to end. What was proved here is the mechanism — that the retry leaks registrations today, and that unregister-before-remove leaves the server in the state the tests expect.

## Not addressed

**The 29m setup timeouts themselves.** They came from several nightly runs racing on the same runners (nine were dispatched between 17:11 and 18:00 on 2026-09-09, six of which failed); the retry is the intended response to one timeout, and leaking registrations on that retry is the defect. If the shard timeouts keep recurring on quiet nights, the 29m budget from #1384 is worth revisiting separately.

**No CI gate covers shell in an action input.** `lint-changed.sh` sends workflows to `actionlint`, which shellchecks `run:` blocks only, and sends just `*.sh` to `shellcheck` — so `on_retry_command` was already ungated before this PR. Closing that means linting shell-bearing action inputs repo-wide and first fixing the pre-existing SC2046 lines it would flag; that's a lint-tooling change and wants its own PR. Details and a sketch in [this comment](https://github.com/percona/pmm-qa/pull/1394#issuecomment-5607887817).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrgGVk8VyxKPqd74JNikMy