### PR TITLE
[duplicate of #1392/#1394/#1396] Unregister client nodes before the nightly setup retry wipes them

### DIFF
--- a/.github/workflows/ha-e2e-tests.yml
+++ b/.github/workflows/ha-e2e-tests.yml
@@ -176,6 +176,14 @@ jobs:
               --client-version "${PMM_CLIENT_VERSION}" \
               ${WIZARD_ARGS}
           on_retry_command: |
+            # Every container here has registered itself with the remote PMM
+            # Server. Removing one without unregistering leaves its node,
+            # services and agents in the server's inventory for the rest of the
+            # run, where the suite sees them as Failed services and a
+            # disconnected pmm-agent.
+            for c in $(docker ps -q); do
+              timeout 30 docker exec "$c" pmm-admin unregister --force || true
+            done
             docker rm -f $(docker ps -a -q) || true
             docker volume rm -f $(docker volume ls -q) || true
             docker network rm -f $(docker network ls -q) || true

--- a/.github/workflows/ha-e2e-tests.yml
+++ b/.github/workflows/ha-e2e-tests.yml
@@ -176,11 +176,8 @@ jobs:
               --client-version "${PMM_CLIENT_VERSION}" \
               ${WIZARD_ARGS}
           on_retry_command: |
-            # Every container here has registered itself with the remote PMM
-            # Server. Removing one without unregistering leaves its node,
-            # services and agents in the server's inventory for the rest of the
-            # run, where the suite sees them as Failed services and a
-            # disconnected pmm-agent.
+            # The remote PMM Server keeps a node per container, and the wipe
+            # below never tells it those containers are gone (PMM-15486).
             for c in $(docker ps -q); do
               timeout 30 docker exec "$c" pmm-admin unregister --force || true
             done

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -136,6 +136,14 @@ jobs:
               --client-version "${{ env.PMM_CLIENT_VERSION }}" \
               ${{ env.WIZARD_ARGS }}
           on_retry_command: |
+            # Every container here has registered itself with the remote PMM
+            # Server. Removing one without unregistering leaves its node,
+            # services and agents in the server's inventory for the rest of the
+            # run, where the suite sees them as Failed services and a
+            # disconnected pmm-agent.
+            for c in $(docker ps -q); do
+              timeout 30 docker exec "$c" pmm-admin unregister --force || true
+            done
             docker rm -f $(docker ps -a -q) || true
             docker volume rm -f $(docker volume ls -q) || true
             docker network rm -f $(docker network ls -q) || true

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -136,11 +136,8 @@ jobs:
               --client-version "${{ env.PMM_CLIENT_VERSION }}" \
               ${{ env.WIZARD_ARGS }}
           on_retry_command: |
-            # Every container here has registered itself with the remote PMM
-            # Server. Removing one without unregistering leaves its node,
-            # services and agents in the server's inventory for the rest of the
-            # run, where the suite sees them as Failed services and a
-            # disconnected pmm-agent.
+            # The remote PMM Server keeps a node per container, and the wipe
+            # below never tells it those containers are gone (PMM-15486).
             for c in $(docker ps -q); do
               timeout 30 docker exec "$c" pmm-admin unregister --force || true
             done


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://github.com/percona/pmm-qa/actions/runs/34381557594 (and the whole 2026-09-09 batch: runs 34381404678, 34381455930, 34381571744, 34381583621, 34381643225)
- tests:
  - `codeceptjs-e2e/tests/configuration/verifyPMMInventory_test.js` / PMM-T2146 @nightly (nodes + services)
  - `codeceptjs-e2e/tests/configuration/verifyPMMInventory_test.js` / PMM-T554 @inventory @nightly
  - `codeceptjs-e2e/tests/dashboards/verifyHomeDashboards_test.js` / PMM-T2007 @nightly @dashboards
  - `codeceptjs-e2e/tests/dashboards/verifyPostgresqlDashboards_test.js` / PMM-T2048, PMM-T2050, PMM-T394 @nightly @dashboards
  - `codeceptjs-e2e/tests/verifyMysqlDashboards_test.js` / PMM-T317, PMM-T319, PMM-T68 + PMM-T2038 @nightly @dashboards
  - `codeceptjs-e2e/tests/QAN/details_explain_test.js` / PMM-T13 @qan
  - `codeceptjs-e2e/tests/verifyPTSummaryPanels_test.js` / PMM-T666 @pt-summary-nightly

## What broke

The nightly setup step retries once on failure, and its `on_retry_command` removes **every** container on the runner. Those containers have already registered themselves with the *remote* PMM Server, and nothing tells the server they are gone — so their nodes, services and agents stay in the inventory for the rest of the run.

Since #1384 (PMM-15486) grouped fourteen setups onto five runners, one shard runs two or three setups under a single 29-minute budget, so the timeout is reached regularly. When it is, the wipe destroys the siblings that had **already finished and registered**. Attempt 2 re-registers everything under new container IDs, leaving the run with both the dead entries and the live ones.

That is exactly what run [34381557594](https://github.com/percona/pmm-qa/actions/runs/34381557594) shows. The `extra-pxc-pdpgsql-haproxy` shard timed out on `pxc` while `pdpgsql` and `haproxy` had both reported `OK`; the retry cleanup then printed container ids `2826bfaf8d01` and `0d6af774b376` — and the suite went on to fail on:

- node `0d6af774b376` in `Failed` state (PMM-T2146)
- service `haproxy_pmm_service_1881` in `Failed` state (PMM-T2146)
- `pmm-agent b9f862dc` "Not all pmm agents are connected" (PMM-T554)
- 16 MySQL services in inventory vs 13 on the Monitored DB Services panel (PMM-T2007)
- 86 empty panels for `pdpgsql_pmm_17_1_2826` — the service belonging to the destroyed `2826bfaf8d01` (PMM-T2048)

### Before/after in CI's own history

| Run | Layout | Shard retries | T2146 / T554 / T2007 |
| --- | --- | --- | --- |
| [34293591936](https://github.com/percona/pmm-qa/actions/runs/34293591936) (last nightly before the grouping) | 14 shards | 0 of 28 setups | none |
| 34381404678, 34381455930, 34381557594, 34381571744, 34381583621, 34381643225 | 5 shards | 1–3 per run | all failing, every run |

The same four tests fail across every run of that batch regardless of `pmm_client_version` (3-dev-latest, 3.7.1, 3.8.1, 3.9.0), and every one of those runs has at least one shard retry.

## The fix

`pmm-admin unregister --force` removes the node with all its dependencies, so running it in each container before the wipe leaves both sides consistent and attempt 2 starts clean. Bounded with `timeout 30` and `|| true`: a container that never got as far as installing pmm-client must not stall or break the retry hook.

`ha-e2e-tests.yml` carries the same hook against the same kind of remote server, so it gets the same fix.

## Verification

On a throwaway Linode VM against `perconalab/pmm-server:3-dev-latest`, with the PMM Server kept off the "runner" side so the wipe matches CI's (where the server is remote):

**Reproduced the reported failure.** Register `pdpgsql`, then remove its container with the current `on_retry_command`, then run attempt 2:

```
NODE container a59b39b0fecd      <- destroyed, still in inventory
NODE container 9a795d621cae      <- live
SVC  pdpgsql_pmm_17_1_108        <- orphan
SVC  socket_pdpgsql_pmm_17_1_108 <- orphan
SVC  pdpgsql_pmm_17_1_8293       <- live
SVC  socket_pdpgsql_pmm_17_1_8293
AGT  pmm_agent c0ec7603  connected=False   <- PMM-T554
AGT  pmm_agent e9308933  connected=True
```

**With the patched hook** (extracted from the workflow file on the synced branch, not retyped), the same cycle leaves nothing behind:

```
Node with ID c3100289-... and name d0d183be6fdd unregistered.
===== AFTER patched hook =====
NODE container pmm-server        <- only the server's own node
SVC  pmm-server-postgresql
```

and attempt 2 then lands clean — one client node, one service pair, agent connected:

```
NODE container 3b8c9972d2af
SVC  pdpgsql_pmm_17_1_8938 / socket_pdpgsql_pmm_17_1_8938
AGT  pmm_agent eca809de  connected=True
```

### What this does not prove

The reproduction drove the hook directly rather than waiting for a real 29-minute shard timeout, and used one `pdpgsql` setup rather than a full three-setup shard. The mechanism is identical and the CI logs supply the timeout half, but **only the next Jenkins-dispatched nightly can confirm the end-to-end effect** — the nightly's PMM Server is external and its runs cannot be re-executed. A nightly can be pointed at this branch with `PMM_QA_GIT_BRANCH=claude/eager-knuth-rkmdjx` if someone wants that confirmation before merge.

This also does not address *why* the 29-minute budget is being exceeded — that is PMM-15486's own tuning question. This PR only stops a retry from corrupting the server's inventory when it happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRc2Fk3ipRFtUMx4bUVSbq

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRc2Fk3ipRFtUMx4bUVSbq)_