### PR TITLE
Unregister a retried setup's nodes, and give the grouped shard a budget

### DIFF
--- a/.github/scripts/reset-runner-clients.sh
+++ b/.github/scripts/reset-runner-clients.sh
@@ -1,20 +1,9 @@
 #!/usr/bin/env bash
 # reset-runner-clients.sh
 #
-# Cleanup between attempts of the "Run setup for E2E tests" step, for the
-# workflows that point pmm-framework at a PMM Server this runner does not own.
-#
-# Wiping the runner's Docker state is not enough on its own. The PMM Server
-# outlives the retry, so nodes a failed attempt already registered stay in its
-# inventory with no agent behind them, and the next attempt registers fresh
-# ones under new random names (start-sharded.sh suffixes every node with
-# $RANDOM). The leftovers then show up as services in "Failed" state and
-# inflate the inventory counts the dashboard panels are compared against.
-#
-# So unregister every container-hosted node first, then wipe.
-#
-# Usage:
-#   reset-runner-clients.sh
+# The PMM Server outlives the retry, so nodes a failed attempt already
+# registered stay in its inventory with no agent behind them: unregister
+# before wiping.
 #
 # Environment:
 #   UNREGISTER_TIMEOUT_SECONDS  per-container bound, default 60
@@ -23,12 +12,17 @@ set -uo pipefail
 
 timeout_seconds=${UNREGISTER_TIMEOUT_SECONDS:-60}
 
-for container in $(docker ps --format '{{.Names}}'); do
+for container in $(docker ps -a --format '{{.Names}}'); do
     # The PMM Server's own container carries pmm-admin too, and unregistering
     # it would delete the server's self-monitoring node.
     case "$container" in
         pmm-server | watchtower) continue ;;
     esac
+
+    if [ "$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null)" != true ]; then
+        echo "${container} is not running, so its node cannot be unregistered from inside it and may remain in the inventory"
+        continue
+    fi
 
     if ! docker exec "$container" sh -c 'command -v pmm-admin' >/dev/null 2>&1; then
         continue

--- a/.github/scripts/reset-runner-clients.sh
+++ b/.github/scripts/reset-runner-clients.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# reset-runner-clients.sh
+#
+# Cleanup between attempts of the "Run setup for E2E tests" step, for the
+# workflows that point pmm-framework at a PMM Server this runner does not own.
+#
+# Wiping the runner's Docker state is not enough on its own. The PMM Server
+# outlives the retry, so nodes a failed attempt already registered stay in its
+# inventory with no agent behind them, and the next attempt registers fresh
+# ones under new random names (start-sharded.sh suffixes every node with
+# $RANDOM). The leftovers then show up as services in "Failed" state and
+# inflate the inventory counts the dashboard panels are compared against.
+#
+# So unregister every container-hosted node first, then wipe.
+#
+# Usage:
+#   reset-runner-clients.sh
+#
+# Environment:
+#   UNREGISTER_TIMEOUT_SECONDS  per-container bound, default 60
+
+set -uo pipefail
+
+timeout_seconds=${UNREGISTER_TIMEOUT_SECONDS:-60}
+
+for container in $(docker ps --format '{{.Names}}'); do
+    # The PMM Server's own container carries pmm-admin too, and unregistering
+    # it would delete the server's self-monitoring node.
+    case "$container" in
+        pmm-server | watchtower) continue ;;
+    esac
+
+    if ! docker exec "$container" sh -c 'command -v pmm-admin' >/dev/null 2>&1; then
+        continue
+    fi
+
+    timeout "$timeout_seconds" docker exec "$container" pmm-admin unregister --force >/dev/null 2>&1
+    case $? in
+        0) echo "unregistered the node hosted by ${container}" ;;
+        124) echo "timed out after ${timeout_seconds}s unregistering the node hosted by ${container}" ;;
+        *) echo "could not unregister the node hosted by ${container} — it may be left in the inventory" ;;
+    esac
+done
+
+docker ps -a -q | xargs -r docker rm -f || true
+docker volume ls -q | xargs -r docker volume rm -f || true
+docker network ls -q | xargs -r docker network rm -f || true

--- a/.github/workflows/ha-e2e-tests.yml
+++ b/.github/workflows/ha-e2e-tests.yml
@@ -175,10 +175,7 @@ jobs:
               --pmm-server-password "${ADMIN_PASSWORD}" \
               --client-version "${PMM_CLIENT_VERSION}" \
               ${WIZARD_ARGS}
-          on_retry_command: |
-            docker rm -f $(docker ps -a -q) || true
-            docker volume rm -f $(docker volume ls -q) || true
-            docker network rm -f $(docker network ls -q) || true
+          on_retry_command: bash pmm-qa/.github/scripts/reset-runner-clients.sh
 
       - name: Install playwright
         working-directory: ./pmm-qa/e2e_tests/

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -40,7 +40,7 @@ jobs:
   setup:
     name: "setup / ${{ inputs.shard_name }}"
     runs-on: ubuntu-22.04
-    timeout-minutes: 120
+    timeout-minutes: 150
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       ADMIN_PASSWORD: ${{ inputs.admin_password || 'admin' }}
@@ -122,23 +122,20 @@ jobs:
       - name: Run setup for E2E tests (start client services on this runner)
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 30
+          timeout_minutes: 45
           retry_wait_seconds: '10'
           max_attempts: 2
           retry_on: 'any'
           command: |
             cd pmm-qa/qa-integration/pmm_qa
             mkdir -m 777 -p /tmp/backup_data || true
-            timeout -k 30 29m ./pmm-framework/pmm-framework \
+            timeout -k 30 44m ./pmm-framework/pmm-framework \
               --parallel \
               --pmm-server-ip "${SERVER_IP}" \
               --pmm-server-password "${{ env.ADMIN_PASSWORD }}" \
               --client-version "${{ env.PMM_CLIENT_VERSION }}" \
               ${{ env.WIZARD_ARGS }}
-          on_retry_command: |
-            docker rm -f $(docker ps -a -q) || true
-            docker volume rm -f $(docker volume ls -q) || true
-            docker network rm -f $(docker network ls -q) || true
+          on_retry_command: bash pmm-qa/.github/scripts/reset-runner-clients.sh
 
       - name: Waiting for tests execution
         uses: actions/github-script@v7

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-tests.yml
@@ -57,7 +57,7 @@ jobs:
   tests:
     name: "test execution / ${{ inputs.tags_for_tests }}"
     runs-on: ubuntu-22.04
-    timeout-minutes: 120
+    timeout-minutes: 180
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       ADMIN_PASSWORD: ${{ inputs.admin_password || 'admin' }}

--- a/.github/workflows/runner-e2e-tests-playwright-remote-nightly-tests.yml
+++ b/.github/workflows/runner-e2e-tests-playwright-remote-nightly-tests.yml
@@ -55,7 +55,7 @@ jobs:
   tests:
     name: "test execution / ${{ inputs.tags_for_tests }}"
     runs-on: ubuntu-22.04
-    timeout-minutes: 120
+    timeout-minutes: 180
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       ADMIN_PASSWORD: ${{ inputs.admin_password || 'admin' }}


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://github.com/percona/pmm-qa/actions/runs/34381821186 (`Nightly E2E tests Matrix`, `INSTALLATION_TYPE=docker`)
- tests:
  - `codeceptjs-e2e/tests/configuration/verifyPMMInventory_test.js` / PMM-T554 @nightly
  - `codeceptjs-e2e/tests/configuration/verifyPMMInventory_test.js` / PMM-T2146 @nightly (services and nodes)
  - `codeceptjs-e2e/tests/dashboards/verifyHomeDashboards_test.js` / PMM-T2007 @nightly

## What happened

Nightly's setup step points `pmm-framework` at a PMM Server the runner does not own. When
`nick-fields/retry` retries that step, its `on_retry_command` wipes the runner's Docker state — but
the PMM Server outlives the retry, so every node attempt 1 had already registered stays in that
server's inventory with no agent behind it. Attempt 2 then registers *fresh* nodes under new names
(`start-sharded.sh` suffixes each one with `$RANDOM`), so nothing overwrites the leftovers.

In run [34381821186](https://github.com/percona/pmm-qa/actions/runs/34381821186), shard
`ps-replication-psmdb-sharded`:

| time (UTC) | event |
| --- | --- |
| 17:34:03 | attempt 1 starts both setups under `timeout -k 30 29m` |
| 17:55:36–17:56:12 | psmdb sharding registers its 10 nodes (9 replica-set members + mongos) |
| 17:56:47 | `[2/2] psmdb,SETUP_TYPE=sharding: OK` |
| 18:02:59 | `[1/2] ps,SETUP_TYPE=replication INTERRUPTED` — the 29m bound fires, step exits 124 |
| 18:03:12 | `on_retry_command` destroys every container, volume and network, the healthy sharded cluster included |
| 18:03:13–18:09:21 | attempt 2 re-provisions both, registering 10 *new* mongo nodes |

The 10 nodes stranded at 18:03:12 are exactly the run's four failures:

- **PMM-T554** — 10 `pmm-agent`s with `is_connected: false`, `created_at` 17:55:36–17:56:12, i.e. inside
  attempt 1's psmdb window. (The reported payload lists each twice, hence "20" in the log.)
- **PMM-T2146** — `mongos_32107` `Failed`, on both the services and the nodes tab.
- **PMM-T2007** — 23 MongoDB services in the inventory against 13 on the Monitored DB Services panel.
  23 − 13 = the same 10; the panel counts services with live metrics, the assertion counts the inventory.

Not a one-off. Sibling run [34381643225](https://github.com/percona/pmm-qa/actions/runs/34381643225)
hit the same 29m bound in three shards and failed with a superset (T554, T2146, T2007 plus T1565,
T2079 and Nodes Compare empty-panel counts). Both runs are `INSTALLATION_TYPE=docker`.

**Not a product bug, and not a bad assertion.** T2007 is doing its job: it is detecting inventory
entries with no metrics behind them. Loosening it would switch off a real "PMM shows no data here"
signal, so the fix is in the setup.

## The fix

**1. `on_retry_command` unregisters before it wipes** (`.github/scripts/reset-runner-clients.sh`).
For each container that carries `pmm-admin`, `pmm-admin unregister --force` removes that node and its
dependencies from the server first. Without `--node-name` the command resolves the node from the local
agent's own `NodeID` (`admin/commands/management/unregister.go`), so it removes `mongos_32107` rather
than guessing from the hostname. `pmm-server`/`watchtower` are skipped — the server's container carries
`pmm-admin` too, and unregistering it would delete the server's self-monitoring node. Each `docker exec`
is bounded (`UNREGISTER_TIMEOUT_SECONDS`, default 60) with a distinct message when the bound is hit; the
wipe then runs as before. The runner's own host node, registered by `pmm3-client-setup.sh` in an earlier
step and not wiped, is untouched because only containers are iterated.

**2. The grouped shard gets a budget that fits.** `timeout_minutes: 30`/`29m` → `45`/`44m`, and the
job's `timeout-minutes` 120 → 150 so two attempts still fit. #1384 sized 29m from run
[34342981867](https://github.com/percona/pmm-qa/actions/runs/34342981867) — one nightly, on its own,
whose slowest shard member measured 4:00–8:33. A Jenkins dispatch runs several nightlies at once
(**eight** today, 17:11–18:00 UTC), and on a cold runner the grouped setups contend rather than costing
only their slowest member: psmdb sharding alone took **22:43** in run 34381821186, and that same shard's
attempt 2 needed **6:08** once the images were warm.

**3. The consumers get headroom to match.** Both nightly test-execution workflows block on setup
readiness *inside* their own `timeout-minutes: 120`, so the setup's larger bound spends their budget too.
In run 34381821186 the `test execution / @nightly` job started 17:15:51 (cap 19:15:51), saw readiness at
18:18:21, ran the suite 18:19:21–19:13:04 and finished 19:13:16 — **2m35s of slack**. A ~15-minute shift
would have GitHub kill it mid-suite and the three tests this PR fixes would never report, so
`runner-e2e-tests-codeceptjs-remote-nightly-tests.yml` and
`runner-e2e-tests-playwright-remote-nightly-tests.yml` go 120 → 180.

That covers one retry with headroom; it does not cover a setup burning both 44m framework attempts *and*
both client-setup attempts, a tail that outlived 120 as well (the wait loop's own
`WAIT_TIMEOUT_SECONDS: 10800` has always been looser than the job cap). Growing the cap further is the
wrong lever — a waiting consumer holds a runner, and runner scarcity is what PMM-15486 set out to fix.
Bounding the wait, or polling more often than every 600s (readiness was detected at 18:18:21 for a setup
that finished 18:09:21, so this run lost 10 minutes to bucket quantization alone), is the durable fix and
is left out of this PR.

`ha-e2e-tests.yml` carries a byte-identical `on_retry_command` against an external `SERVER_IP`, so it
gets the same script. No failing HA run is claimed here — only that it is the same code path. Its own
19m/20m budget is left alone.

## Verified

On a provisioned Linode VM (`perconalab/pmm-server:3-dev-latest`, client 3.8.0), running the same shard
the failing job ran (`--parallel --database ps,SETUP_TYPE=replication --database psmdb,SETUP_TYPE=sharding`)
and measuring through the endpoints the tests themselves use (`/v1/management/services` for T554,
`/v1/inventory/services?service_type=…` for T2007):

| stage | T554 (`/v1/management/services`) | T2007 (MongoDB services in inventory) |
| --- | --- | --- |
| **A** — clean attempt 1 | 13 pmm-agents, **0** not connected; 37 other agents, 0 not running | **10** (`*_13001`) |
| **B** — **old** cleanup + attempt 2 | 25 pmm-agents, **12** not connected | **20** — attempt 1's `*_13001` *and* attempt 2's `*_16176` |
| **C** — **new** cleanup on attempt 2's containers | 13 pmm-agents, **12** not connected (the same 12 from B, no new ones) | **10** — attempt 2's `*_16176` removed from the server |
| **D** — inventory purged, then a full attempt with the new cleanup in front | 13 pmm-agents, **0** not connected; 37 other agents, 0 not running | **10** (`*_10092`) |

**B is the CI failure, reproduced.** 12 stranded pmm-agents and an inventory carrying 10 services with no
metrics behind them is precisely what T554, T2146 and T2007 reported in run 34381821186 — the same
`$RANDOM`-suffixed duplication (`rs101_13001` *and* `rs101_16176`), and the same arithmetic
(20 in the inventory, 10 with live metrics).

**C is the fix, on the same box, differing from B in one thing only** — the unregister phase. The 12
nodes attempt 2 had registered are gone from the server rather than left disconnected, and the 12
still showing are the ones **B's old cleanup** stranded. The removed set covers the MySQL containers as
well as the mongo ones, so this is not psmdb-specific. `reset-runner-clients.sh` exits 0 with nothing to
do, so `on_retry_command` does not turn a retry into a step failure.

**D is the end state a retried shard now reaches** — identical to A on every number. All three
assertions would pass on it: nothing disconnected for T554, nothing `Failed` for T2146, and an inventory
count that matches what has metrics for T2007.

**Scope the verification does not cover:** every measurement above used *running* containers. An
exited container cannot be `docker exec`'d, so its node is now reported as possibly left behind rather
than skipped in silence; removing it for real means resolving the node server-side from the stopped
container's agent config, which wants its own PR and a live VM to confirm the config path across images.

The stand-in server runs on the same VM (nightly's is remote and is never wiped), so the wipe was run
through a four-line `docker` shim that keeps the `pmm-server` container and `pmm-data` volume out of it.
The shim is a test harness — it is not in this diff, and the shipped script is unchanged between B and C.

## Notes

- Nightly cannot be re-run: `nightly-e2e-tests-matrix.yml` takes a `pmm_server_address` and its runners
  open with a reachability check, so run 34381821186's external PMM Server was already gone. The
  reproduction above stands in for it; a fresh nightly on this branch (the Jenkins job takes
  `PMM_QA_GIT_BRANCH`) is the end-to-end confirmation.
- PMM-15486 is still In Progress, so whoever is working on the nightly grouping may want to fold the
  budget change in rather than carry it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVoxbkTbfjDY2SvRAmvCjE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVoxbkTbfjDY2SvRAmvCjE)_


---
_Generated by [Claude Code](https://claude.ai/code)_