### PR TITLE
PMM-15486 Unregister nodes before the nightly setup retry wipes them

### DIFF
--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -139,8 +139,8 @@ jobs:
             # The remote PMM Server is shared with the other shards, so wiping this
             # runner's containers does not remove what they registered on it.
             for c in $(docker ps -aq); do
-              timeout 60 docker exec "$c" pmm-admin unregister --force >/dev/null 2>&1 \
-                || echo "unregister skipped for container $c"
+              err=$(timeout 60 docker exec "$c" pmm-admin unregister --force 2>&1) \
+                || echo "unregister skipped for container $c: $err"
             done
             docker rm -f $(docker ps -a -q) || true
             docker volume rm -f $(docker volume ls -q) || true

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -136,6 +136,15 @@ jobs:
               --client-version "${{ env.PMM_CLIENT_VERSION }}" \
               ${{ env.WIZARD_ARGS }}
           on_retry_command: |
+            # The PMM Server is remote and shared with the other shards, so removing this
+            # runner's containers does not remove what they registered on it. Unregister
+            # each node first, or the failed attempt's services and agents stay in the
+            # inventory for the whole run as permanently disconnected entries that the
+            # whole-inventory tests (PMM-T554, PMM-T2146, PMM-T2007) count and assert on.
+            for c in $(docker ps -aq); do
+              timeout 60 docker exec "$c" pmm-admin unregister --force >/dev/null 2>&1 \
+                || echo "unregister skipped for container $c"
+            done
             docker rm -f $(docker ps -a -q) || true
             docker volume rm -f $(docker volume ls -q) || true
             docker network rm -f $(docker network ls -q) || true

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -136,11 +136,8 @@ jobs:
               --client-version "${{ env.PMM_CLIENT_VERSION }}" \
               ${{ env.WIZARD_ARGS }}
           on_retry_command: |
-            # The PMM Server is remote and shared with the other shards, so removing this
-            # runner's containers does not remove what they registered on it. Unregister
-            # each node first, or the failed attempt's services and agents stay in the
-            # inventory for the whole run as permanently disconnected entries that the
-            # whole-inventory tests (PMM-T554, PMM-T2146, PMM-T2007) count and assert on.
+            # The remote PMM Server is shared with the other shards, so wiping this
+            # runner's containers does not remove what they registered on it.
             for c in $(docker ps -aq); do
               timeout 60 docker exec "$c" pmm-admin unregister --force >/dev/null 2>&1 \
                 || echo "unregister skipped for container $c"


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://github.com/percona/pmm-qa/actions/runs/34381583621 (`Nightly E2E tests Matrix`, run 338, `INSTALLATION_TYPE=docker`, `SERVER_IP=13.59.24.106`, server `3.10.0-v3-544973d86`)
- tests:
  - `codeceptjs-e2e` Inventory page / `PMM-T554` @inventory @nightly
  - `codeceptjs-e2e` Inventory page / `PMM-T2146` @nightly (both `graph/inventory/services` and `graph/inventory/nodes`)
  - `codeceptjs-e2e` Folders / `PMM-T2007` @nightly @dashboards
  - `codeceptjs-e2e` MySQL Folder / `PMM-T317` @nightly @dashboards (`pxc_service`)
  - `codeceptjs-e2e` MySQL Folder / `PMM-T319` @nightly @dashboards (`pxc_service`)
  - `codeceptjs-e2e` MySQL Folder / `PMM-T68` + `PMM-T2038` @nightly @dashboards
  - `codeceptjs-e2e` MySQL Folder / `PMM-T2079` @dashboards @nightly
  - `codeceptjs-e2e` QAN details / `PMM-T1790` @qan

## What went wrong

The five nightly setup shards register their nodes, services and agents on a **remote PMM Server that the whole run shares**, so nothing a shard removes locally is removed from that server. `on_retry_command` deleted every container, volume and network on the runner — and left everything the failed attempt had already registered stranded on the server for the rest of the run, with no client left to answer for it.

Run 338 is the first nightly on `main` after the five-shard regrouping (a4d8fe7, #1384), and two of the five shards hit the 29-minute budget on attempt 1:

| shard | attempt 1 | attempt 2 |
|---|---|---|
| `ps-myrocks-pdpgsql-patroni-external` | `external` OK 12m32s, `ps,MY_ROCKS` OK 20m43s, **killed (rc 124)** with `pdpgsql,patroni` running | all three OK, slowest 11m08s |
| `ps-gr-pxc-valkey` | `pxc` OK 15m52s, **killed (rc 124)** with the other two running | all three OK, slowest 17m44s |

Both retried successfully, but the server ended up carrying attempt 1's finished setups too — three pmm-agents with `is_connected: false`:

| agent | node | registered | shard |
|---|---|---|---|
| `adfa4010` | `client_container_36` | 17:24:38 | `ps-gr-pxc-valkey` (attempt 1 `pxc`) |
| `12c7c4f7` | `2f1f16a9afe0` | 17:36:22 | `ps-myrocks-…` |
| `cebc3789` | `27ee8f5165b8` | 17:43:49 | `ps-myrocks-…` (`ps,MY_ROCKS`) |

plus their nodes (`258c54b16e30` among them) and services. The setup log for shard 3 shows the wipe directly — `docker rm -f` echoing `27ee8f5165b8`, `2f1f16a9afe0`, `258c54b16e30` at 17:53:30, seconds after `Attempt 1 failed. Reason: Child_process exited with error code 124`.

Every one of the nine failures is that stranded inventory, not a product fault:

- **PMM-T554** — the three disconnected pmm-agents, by id.
- **PMM-T2146** — orphan node `258c54b16e30` and service `my-new-proxysql_pxc_proxysql_pmm_8.0_5589` reported `Failed`.
- **PMM-T2007** — 17 MySQL services in the API against 13 on the Monitored DB Services panel; the 4 orphans have no metrics.
- **PMM-T317 / PMM-T319** — the pxc dashboards resolved to attempt 1's `pxc_node__2_3875` on the destroyed node `client_container_36`: 38 and 72 panels without data.
- **PMM-T2079** — MyRocks dashboard on orphan node `27ee8f5165b8` / service `ps_pmm_8_0_1_11377`: 42 panels without data.
- **PMM-T68 + PMM-T2038** — the ProxySQL service picker offered 3 options where the test expects 2; the orphan proxysql service is the third.
- **PMM-T1790** — QAN Explain returned `Pmm-agent with ID cebc3789…`, the orphan agent.

## The fix

`on_retry_command` now unregisters each container's node from the server before removing anything — one `pmm-admin unregister --force` per container, which drops the node with its services and agents.

- **Bounded and best-effort.** `timeout 60` per container; a container with no client, or one already dead, prints a skip line instead of failing the hook.
- **The skip line carries the underlying error**, so a refused unregister — the case where an orphan is still stranded — is distinguishable in the log from a container that simply never had a client. A successful unregister stays quiet.
- **Only this shard's own containers.** Nothing sweeps the server by name — that would risk another shard's inventory.
- **The runner's host agent is untouched**, since it is not a container.

## Verification

Reproduced and verified on a throwaway Linode VM against `perconalab/pmm-server:3-dev-latest` — `3.10.0-v3-544973d86`, the same server build as the failed run — with `pmm-framework --parallel --database mysql --database pgsql`, client `3-dev-latest`. The only deviation: the container list excludes the local `pmm-server` container, which does not exist on a real runner.

**Current hook** — two live setups registered, then the hook ran:

```
BEFORE  NODES(4): 05cb419aba03, client_container_6121, client_container_9957, pmm-server
        DISCONNECTED pmm-agents: 1
AFTER   NODES(4): 05cb419aba03, client_container_6121, client_container_9957, pmm-server
        DISCONNECTED pmm-agents: 3
        SERVICES(3): mysql_pmm_9_7_1_34607, pgsql_pgss_pmm_17_service_2001, pmm-server-postgresql
```

Nodes, agents and services all survive the wipe as permanently disconnected entries. Re-running the setup (the attempt-2 equivalent) then produced the run-338 signature exactly — 6 nodes and 5 services for 3 live containers, **3 disconnected pmm-agents**, and duplicated services (`mysql_pmm_9_7_1_4505` + `mysql_pmm_9_7_1_34607` for one live MySQL), which is what PMM-T2007's count mismatch and PMM-T68's extra picker option are.

**Fixed hook** — same state, hook ran, both unregisters succeeded (no skip lines):

```
AFTER   NODES(4): 05cb419aba03, client_container_6121, client_container_9957, pmm-server
        DISCONNECTED pmm-agents: 3
        SERVICES(3): mysql_pmm_9_7_1_34607, pgsql_pgss_pmm_17_service_2001, pmm-server-postgresql
```

The two nodes wiped this round (`88d2d0ae7acb`, `client_container_5438`), their agents (`3c211fab`, `458b3e43`) and their services (`mysql_pmm_9_7_1_4505`, `pgsql_pgss_pmm_17_service_7898`) are gone from the inventory instead of stranded. The three entries that remain are the orphans the **unfixed** hook created earlier in the same experiment — the fix prevents new orphans, it does not retroactively clean ones already stranded.

**Edge cases** — a running container without `pmm-admin` and a stopped container: both printed `unregister skipped for container …`, hook exited 0, whole hook took 0.5s (no hang; `docker exec` fails fast well inside the `timeout 60`).

> **Evidence provenance.** Everything above was measured on the VM with the original `>/dev/null 2>&1` form of the skip line, and that VM has been torn down. Review feedback since changed what the skip path *logs* (it now appends the error text); the unregister and wipe behaviour those runs measured is unchanged, so the inventory before/after still holds, but the "both printed `unregister skipped for container …`" line above under-describes the shipped output. The new logging was exercised separately against a stubbed `docker` covering both arms — a succeeding unregister prints nothing, a failing one prints `Error response from daemon: container … is not running` after the container id, hook exits 0 — rather than by re-provisioning.

`actionlint`, `yamllint` and `bash -n` clean on the changed file. `shellcheck` on the extracted hook reports only the three pre-existing `SC2046` warnings on the unquoted `$(docker … -q)` expansions, which are deliberate word splitting; the added lines are clean.

## What this does not cover

- **The 29m budget is left alone.** Attempt 2 of both shards needed up to 17m44s with warm caches while attempt 1 exceeded 29m cold, so the budget looks short for a three-setup shard — but that is a tuning question for more than one run's data, and the suite passes either way once a retry stops poisoning the inventory. Worth a follow-up with a few runs behind it.
- **No CI check on this branch exercises the change.** The push does trigger the full `E2E tests Matrix` / `FB E2E tests` suites, but none of those jobs reach this file: it is a `workflow_call` target used only by the Jenkins-dispatched nightly matrix, and `on_retry_command` fires only when an attempt fails — so even a nightly dispatched on this branch would only exercise it if a shard happened to time out again. A deterministic run of the hook against a real PMM Server (above) is the stronger evidence available here.
- **Sibling hook not touched.** `ha-e2e-tests.yml` has the same shape but provisions its own cluster rather than sharing a remote server, so it does not have this failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiqEr7KmtG3JrhLPr2s42F