### PR TITLE
Unregister the remote PMM nodes a retried nightly setup leaves behind

### DIFF
--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -147,7 +147,8 @@ jobs:
               case $rc in
                 0) echo "unregistered PMM node of ${name#/}" ;;
                 124) echo "unregister timed out after 60s for ${name#/} - its node may stay on the server" ;;
-                *) echo "no PMM client to unregister in ${name#/} (rc=$rc)" ;;
+                126 | 127) echo "no PMM client to unregister in ${name#/} (rc=$rc)" ;;
+                *) echo "unregister failed in ${name#/} (rc=$rc) - its node may stay on the server" ;;
               esac
             done
             docker rm -f $(docker ps -a -q) || true

--- a/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
+++ b/.github/workflows/runner-e2e-tests-codeceptjs-remote-nightly-setup.yml
@@ -136,6 +136,20 @@ jobs:
               --client-version "${{ env.PMM_CLIENT_VERSION }}" \
               ${{ env.WIZARD_ARGS }}
           on_retry_command: |
+            # The remote PMM Server keeps whatever the failed attempt already
+            # registered, and the local wipe below cannot reach it. Left there,
+            # those nodes have no client, never reconnect, and the inventory and
+            # dashboard-count tests read them as real failures.
+            for c in $(docker ps -q); do
+              name=$(docker inspect -f '{{.Name}}' "$c" 2>/dev/null || echo "$c")
+              rc=0
+              timeout 60 docker exec "$c" pmm-admin unregister --force >/dev/null 2>&1 || rc=$?
+              case $rc in
+                0) echo "unregistered PMM node of ${name#/}" ;;
+                124) echo "unregister timed out after 60s for ${name#/} - its node may stay on the server" ;;
+                *) echo "no PMM client to unregister in ${name#/} (rc=$rc)" ;;
+              esac
+            done
             docker rm -f $(docker ps -a -q) || true
             docker volume rm -f $(docker volume ls -q) || true
             docker network rm -f $(docker network ls -q) || true


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://github.com/percona/pmm-qa/actions/runs/34381571744 (`Nightly E2E tests Matrix (remote PMM Server)`, `INSTALLATION_TYPE: docker`, server `3.10.0-v3-544973d86`)
- tests:
  - `codeceptjs-e2e/tests/configuration/verifyPMMInventory_test.js` / PMM-T2146 @nightly (nodes)
  - `codeceptjs-e2e/tests/configuration/verifyPMMInventory_test.js` / PMM-T2146 @nightly (services)
  - `codeceptjs-e2e/tests/configuration/verifyPMMInventory_test.js` / PMM-T554 @inventory @nightly
  - `codeceptjs-e2e/tests/dashboards/verifyHomeDashboards_test.js` / PMM-T2007 @nightly @dashboards
  - `codeceptjs-e2e/tests/verifyMysqlDashboards_test.js` / PMM-T68 + PMM-T2038 @nightly @dashboards

## What went wrong

The `setup` step of the nightly retries the whole `pmm-framework` run, and its
`on_retry_command` wiped only the runner's own Docker state. The PMM Server is
**remote and shared by all five shards**, so everything the failed attempt had
already registered stayed in its inventory with no client behind it.

In this run the `ps-gr-pxc-valkey` shard hit the 29-minute budget on attempt 1
**after its PXC member had already finished** (`[2/3] pxc: OK` at 17:37:08,
`Attempt 1 failed. Reason: Child_process exited with error code 124` at
17:44:17 — the `ps,SETUP_TYPE=gr` member was still inside
`TASK [Install Percona Server for MySQL]`). Attempt 2 re-provisioned from
scratch and registered a *second* PXC cluster. The server then held three PXC
clusters and three ProxySQL services where the suite expects two:

| node | services | status at 19:01 |
| --- | --- | --- |
| `client_container_5574` | `pxc_node__{1,2,3}_6855`, `my-new-proxysql_..._4666` | `STATUS_UP` |
| `client_container_7776` | `pxc_node__{1,2,3}_1507`, `my-new-proxysql_..._9769` | `STATUS_UP` |
| **`client_container_5581`** | **`pxc_node__{1,2,3}_6169`, `my-new-proxysql_..._6730`** | **`STATUS_UNKNOWN`** |

`client_container_5581` is attempt 1's orphan — it appears in no setup job's log,
and its pmm-agent `7d9fa9f6-5bea-437c-867d-4728d0443bc8` was created at
17:22:06 and never connected. All five failures are that one node:

- **PMM-T2146** — node `client_container_5581` and service
  `my-new-proxysql_pxc_proxysql_pmm_8.0_6730` reported in `Failed` status.
- **PMM-T554** — `"Not all pmm agents are connected"`, the agent being
  `7d9fa9f6` on that node.
- **PMM-T2007** — the test compares the inventory API's MySQL count against the
  *Monitored DB Services* panel. Inventory returned 16, the panel showed 13; the
  difference is exactly the three orphan `pxc_node__*_6169` services, which have
  no metrics.
- **PMM-T68 + PMM-T2038** — the *ProxySQL Instance* filter offered 3 options
  where the test asserts 2, the third being `my-new-proxysql_..._6730`.

The orphan defect is not new — `on_retry_command` has been local-only since
#1276. What changed is how often the retry fires: #1384 (PMM-15486) grouped the
fourteen setup shards onto five runners, so three setups now contend for one
runner and a shard can exceed its budget where a single-setup shard did not.
This run (`8fb7e39`) is the first Jenkins-dispatched nightly to carry that
grouping.

## The fix

Unregister from inside each running container before the local wipe.
`pmm-admin unregister --force` removes the node and every service and agent on
it, so the next attempt re-registers into a clean inventory. Each call is bound
by `timeout 60` and reports its own outcome, so nothing the loop does can hang
or fail the retry path.

Only **running** containers can be reached this way; one that has already
exited keeps its node, and the message names that case rather than hiding it.

## Verification

Reproduced and fixed on a throwaway Linode VM (PMM Server
`perconalab/pmm-server:3-dev-latest`), replaying the `on_retry_command` text
extracted verbatim from `main` and from this branch. The runner's local PMM
Server was hidden from `docker ps` so both scripts ran byte-for-byte as they
ship on a CI runner, which has no local server.

**Before (`main`)** — client registered, then the shipped command run:

```
  registered client_container_1111 + service orphan_mysql_client_container_1111
  -- running on_retry_old.sh:
     1ee025586fbd
  -- containers left:
     pmm-server
  -- inventory AFTER:
     node: container client_container_1111        <-- orphan
     svc : mysql orphan_mysql_client_container_1111
     agt : pmm_agent 110d7c9c-... status=''       <-- never connects
```

**After (this branch)**:

```
  registered client_container_2222 + service orphan_mysql_client_container_2222
  -- running on_retry_new.sh:
     unregistered PMM node of qa_client_b
     3309137bf041
  -- inventory AFTER:
     node: container client_container_1111        <-- the earlier orphan, untouched
     svc : mysql orphan_mysql_client_container_1111
     (no trace of client_container_2222, its service, or its agents)
```

The earlier orphan surviving is the point: the removal is scoped to what this
runner's own containers registered, not a sweep of the shared inventory.

Also exercised the no-client branch with two `busybox` containers —
`no PMM client to unregister in qa_plain (rc=127)` twice, script `rc=0`,
containers still wiped — so a container without `pmm-admin` (mongo, valkey,
haproxy, and the rest) cannot break the retry.

**Not proved here:** the `rc=124` timeout branch is an `echo` and was not
triggered. And `on_retry_command` runs only when an attempt actually fails, so
no PR check exercises it — the VM replay above is the direct evidence, and the
next nightly that retries a shard is what will show it in place.

## Out of scope, worth a look

- **The 29-minute setup budget is the trigger and is still too small.** Attempt 1
  needed more than 29m; attempt 2, with warm Docker and apt caches, took 21m50s
  (`ps,SETUP_TYPE=gr` 17:44:17 → 18:06:07). Raising it also means raising the
  job's `timeout-minutes: 120`, since this shard already spent 118 minutes
  end to end. That is PMM-15486's territory, not this fix's.
- **The `Setup PMM-Client against remote PMM Server` step has no
  `on_retry_command` at all**, so the same class of orphan is possible for the
  host node if that step's attempt 1 fails after `pmm-agent setup`. No run in
  this investigation exhibits it, so it is left alone.
- Nine nightly runs fired between 17:11 and 18:00 UTC on the same commit, which
  is the runner contention #1384 set out to reduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158PpNgHBc3XB5wDEJAEo7d

---
_Generated by [Claude Code](https://claude.ai/code/session_0158PpNgHBc3XB5wDEJAEo7d)_