### PR TITLE
Harden the nightly against a slow mongod restart and a mid-publish mirror

### DIFF
--- a/codeceptjs-e2e/tests/backup/inventory_test.js
+++ b/codeceptjs-e2e/tests/backup/inventory_test.js
@@ -95,22 +95,26 @@ Before(async ({
 
   await I.verifyCommand('docker exec rs101 systemctl start mongod');
 
-  const c = await I.mongoGetCollection('test', 'test');
-
-  for (let attempt = 0; attempt < 3; attempt += 1) {
+  // mongod can take minutes to accept connections again after a restart, and a
+  // client that was connected before it never recovers on its own.
+  /* eslint-disable no-await-in-loop */
+  for (let attempt = 1; attempt <= 10; attempt += 1) {
     try {
-      // eslint-disable-next-line no-await-in-loop
+      await I.mongoDisconnect();
+      await I.mongoConnect(mongoConnection);
+      const c = await I.mongoGetCollection('test', 'test');
+
       await c.deleteMany({ number: 2 });
       break;
     } catch (error) {
-      if (attempt === 2) {
+      if (attempt === 10) {
         throw error;
       }
 
-      // eslint-disable-next-line no-await-in-loop
       await I.wait(10);
     }
   }
+  /* eslint-enable no-await-in-loop */
 
   await I.Authorize();
   await settingsAPI.changeSettings({ backup: true });

--- a/package_tests/pmm3-client_integration.yml
+++ b/package_tests/pmm3-client_integration.yml
@@ -49,8 +49,8 @@
       sudo apt-get update
       sudo apt-get install pmm-client
     register: apt_install_result
-    retries: 3
-    delay: 30
+    retries: 10
+    delay: 60
     until: apt_install_result.rc == 0
 
   - name: Install PMM client new rpm packages
@@ -61,8 +61,8 @@
       yum -y update
       yum -y install pmm-client
     register: yum_install_result
-    retries: 3
-    delay: 30
+    retries: 10
+    delay: 60
     until: yum_install_result.rc == 0
 
   - name: Check that PMM Client version is correct

--- a/package_tests/pmm3-client_integration_auth_config.yml
+++ b/package_tests/pmm3-client_integration_auth_config.yml
@@ -43,8 +43,8 @@
       sudo apt-get update
       sudo apt-get install pmm-client
     register: apt_install_result
-    retries: 3
-    delay: 30
+    retries: 10
+    delay: 60
     until: apt_install_result.rc == 0
 
   - name: Install PMM client new rpm packages
@@ -53,8 +53,8 @@
       sudo yum -y update
       sudo yum -y install pmm-client
     register: yum_install_result
-    retries: 3
-    delay: 30
+    retries: 10
+    delay: 60
     until: yum_install_result.rc == 0
 
   - name: check that PMM client version is correct

--- a/package_tests/pmm3-client_integration_auth_register.yml
+++ b/package_tests/pmm3-client_integration_auth_register.yml
@@ -58,8 +58,8 @@
       sudo apt-get update
       sudo apt-get install pmm-client
     register: apt_install_result
-    retries: 3
-    delay: 30
+    retries: 10
+    delay: 60
     until: apt_install_result.rc == 0
 
   - name: Install PMM client new rpm packages
@@ -68,8 +68,8 @@
       sudo yum -y update
       sudo yum -y install pmm-client
     register: yum_install_result
-    retries: 3
-    delay: 30
+    retries: 10
+    delay: 60
     until: yum_install_result.rc == 0
 
   - name: check that PMM client version is correct

--- a/package_tests/pmm3-client_integration_upgrade.yml
+++ b/package_tests/pmm3-client_integration_upgrade.yml
@@ -88,16 +88,16 @@
     when: ansible_os_family == "Debian"
     apt: name={{ pmm_client_old }} update_cache=yes state=present
     register: apt_install_result
-    retries: 3
-    delay: 30
+    retries: 10
+    delay: 60
     until: apt_install_result is succeeded
 
   - name: Install PMM client old rpm packages
     when: ansible_os_family == "RedHat"
     yum: name={{ pmm_client_old }} state=present update_cache=yes
     register: yum_install_result
-    retries: 3
-    delay: 30
+    retries: 10
+    delay: 60
     until: yum_install_result is succeeded
 
 ### Setup PMM Client
@@ -227,16 +227,16 @@
     when: ansible_os_family == "Debian"
     apt: name=pmm-client update_cache=yes state=latest
     register: apt_upgrade_result
-    retries: 3
-    delay: 30
+    retries: 10
+    delay: 60
     until: apt_upgrade_result is succeeded
 
   - name: Upgrade PMM client to the latest rpm packages
     when: ansible_os_family == "RedHat"
     yum: name=pmm-client state=latest update_cache=yes
     register: yum_upgrade_result
-    retries: 3
-    delay: 30
+    retries: 10
+    delay: 60
     until: yum_upgrade_result is succeeded
 
 ### Verifications after upgrade

--- a/package_tests/pmm3-client_integration_upgrade_custom_port.yml
+++ b/package_tests/pmm3-client_integration_upgrade_custom_port.yml
@@ -98,16 +98,16 @@
     when: ansible_os_family == "Debian"
     apt: name={{ pmm_client_old }} update_cache=yes state=present
     register: apt_install_result
-    retries: 3
-    delay: 30
+    retries: 10
+    delay: 60
     until: apt_install_result is succeeded
 
   - name: Install PMM client old rpm packages
     when: ansible_os_family == "RedHat"
     yum: name={{ pmm_client_old }} state=present update_cache=yes
     register: yum_install_result
-    retries: 3
-    delay: 30
+    retries: 10
+    delay: 60
     until: yum_install_result is succeeded
 
 ### Setup PMM Client
@@ -256,16 +256,16 @@
     when: ansible_os_family == "Debian"
     apt: name=pmm-client update_cache=yes state=latest
     register: apt_upgrade_result
-    retries: 3
-    delay: 30
+    retries: 10
+    delay: 60
     until: apt_upgrade_result is succeeded
 
   - name: Upgrade PMM client to the latest rpm packages
     when: ansible_os_family == "RedHat"
     yum: name=pmm-client state=latest update_cache=yes
     register: yum_upgrade_result
-    retries: 3
-    delay: 30
+    retries: 10
+    delay: 60
     until: yum_upgrade_result is succeeded
 
 ### Verifications after upgrade


### PR DESCRIPTION
Two independent fixes for five of `pmm3-nightly-orchestrator` #6's red suites, one commit each.

## 1. Backup `Before` hook: reconnect until mongod accepts writes

`upgrade / 3.8.1 OTHERS` (`pmm3-upgrade-test-runner` #23505) failed the `Before` hook of the MongoDB restore test:

```
"before each" hook: Before for "PMM-T862 + ... @post-mongo-backup-upgrade"
Server selection timed out after 30000 ms          (113.3 s)
```

113 s is exactly what #1374's loop allows — three `deleteMany` attempts at the driver's 30 s server-selection timeout plus two 10 s waits — so that fix was too short by construction, and it also reused the client that was connected *before* `systemctl start mongod`, which in the 3.x driver's single-host topology does not rediscover the server. The hook now disconnects, reconnects with the same credentials and retries the write, up to ten times ten seconds apart (~6.5 minutes worst case). The rest of the hook is unchanged.

## 2. Package playbooks: outlast a mirror mid-publish

All four `pkg arm64` failures (`nightly-package-testing-arm64` #34, #35, #36, #39) were the same download in `Install PMM client new rpm packages`:

```
[MIRROR] pmm-client-3.10.0-1.el8.aarch64.rpm: Interrupted by header callback:
         Server reports Content-Length: 87651880 but expected size is: 87651928
[FAILED] pmm-client-3.10.0-1.el8.aarch64.rpm: No more mirrors to try
```

`repo.percona.com` serving a package whose index promises another size — the failure #1373 addressed on the upgrade playbooks. Those tasks *had* the retry (`attempts: 3`, 30 s apart) and still failed: the window on 2026-09-09 ran from at least 17:25 to 17:29, and the one in run #4 from 19:21 to 19:27. Three attempts over a minute cannot outlast a four-to-six-minute republish. The 14 client install/upgrade tasks across the five playbooks now retry ten times a minute apart. Nothing else in `package_tests` changes; `enable_repo.yml`'s cache task keeps its own 5×.

This is still a workaround for the mirror. The durable fix — publishing the pool atomically — belongs to whoever owns `repo.percona.com`, as noted in #1373.

## Verification

- `yamllint --strict` clean on all five playbooks; 28 values changed, 14 tasks × (`retries`, `delay`), verified by diff — no task outside the `Install|Upgrade PMM client` set is touched.
- `node --check` passes on `inventory_test.js`; `eslint` with the repo's `.eslintrc` (airbnb) reports the **identical** set of findings on this branch and on `main` (28 pre-existing, all `no-undef` on CodeceptJS globals plus two unrelated style hits), so the change adds nothing.
- Not exercised end to end: the hook only matters after a mongod restart under load, and the mirror window is not reproducible on demand. Both fixes are bounded so a genuine failure still surfaces, later rather than never.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh)_