### PR TITLE
Fix MongoDB TLS configuration in change agent test

### DIFF
--- a/e2e_tests/helpers/cli.helper.ts
+++ b/e2e_tests/helpers/cli.helper.ts
@@ -38,7 +38,8 @@ export default class CliHelper {
   createTlsCertificates = (containerName: string): void => {
     const prefix = `docker exec ${containerName}`;
     const commands = [
-      `${prefix} apt install -y git`,
+      // Container base OS varies by DB (Debian for MySQL/PG/Valkey, RHEL for PSMDB), so cover both package managers.
+      `${prefix} bash -c "command -v git >/dev/null 2>&1 || apt-get install -y git || dnf install -y git"`,
       `${prefix} mkdir -p /certs`,
       `${prefix} git clone https://github.com/OpenVPN/easy-rsa.git /easy-rsa`,
       `${prefix} /easy-rsa/easyrsa3/easyrsa --pki-dir=/easy-rsa/easyrsa3/pki init-pki`,

--- a/e2e_tests/tests/cli/mongo/mongoProfilerChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/mongo/mongoProfilerChangeAgent.test.ts
@@ -1,7 +1,6 @@
 import pmmTest from '@fixtures/pmmTest';
 import { Timeouts } from '@helpers/timeouts';
 import { expect } from '@playwright/test';
-import fs from 'node:fs';
 
 pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality', () => {
   pmmTest.describe.configure({ mode: 'serial' });
@@ -357,41 +356,35 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
   pmmTest(
     'PMM-T1010 - Verify Change agent tls @psmdb-profiler-integration',
     async ({ cliHelper, grafanaHelper, page, servicesPage }) => {
-      const confPath = `/etc/mysql/mysql.conf.d/mysqld.cnf`;
+      const confPath = `/etc/mongod/mongod.conf`;
 
       cliHelper.createTlsCertificates(containerName);
 
       let commands = [
-        `docker exec ${containerName} cp /easy-rsa/easyrsa3/pki/private/${containerName}.key /certs/${containerName}.key`,
-        `docker exec ${containerName} cp /easy-rsa/easyrsa3/pki/issued/${containerName}.crt /certs/${containerName}.crt`,
+        `docker exec ${containerName} bash -c "cat /easy-rsa/easyrsa3/pki/issued/${containerName}.crt /easy-rsa/easyrsa3/pki/private/${containerName}.key > /certs/server.pem"`,
         `docker exec ${containerName} bash -c "cat /easy-rsa/easyrsa3/pki/private/pmm-test.key > /certs/client.key"`,
         `docker exec ${containerName} bash -c "cat /easy-rsa/easyrsa3/pki/issued/pmm-test.crt > /certs/client.crt"`,
         `docker exec ${containerName} cp /easy-rsa/easyrsa3/pki/ca.crt /certs/ca-certs.pem`,
-        `docker exec ${containerName} chown 999:999 /certs/${containerName}.crt`,
-        `docker exec ${containerName} chown 999:999 /certs/${containerName}.key`,
-        `docker exec ${containerName} chmod 600 /certs/${containerName}.key`,
-        `docker exec ${containerName} chmod 644 /certs/${containerName}.crt`,
+        `docker exec ${containerName} chown mongod:mongod /certs/server.pem /certs/ca-certs.pem`,
+        `docker exec ${containerName} chmod 600 /certs/server.pem`,
+        `docker exec ${containerName} chmod 644 /certs/ca-certs.pem`,
       ];
 
       commands.forEach((command) => cliHelper.execSilent(command).assertSuccess());
 
-      fs.writeFileSync(
-        '/tmp/ssl.conf',
-        `ssl-ca=/certs/ca-certs.pem\nssl-cert=/certs/${containerName}.crt\nssl-key=/certs/${containerName}.key\nrequire_secure_transport=ON`,
+      cliHelper.execSilent(
+        `docker exec ${containerName} sed -i '/bindIp: 0.0.0.0/a\\  tls:\\n    mode: requireTLS\\n    certificateKeyFile: /certs/server.pem\\n    CAFile: /certs/ca-certs.pem' ${confPath}`,
       );
-
-      cliHelper.execSilent(`docker cp /tmp/ssl.conf ${containerName}:/tmp/ssl.conf`);
-      cliHelper.execSilent(`docker exec ${containerName} bash -c "cat /tmp/ssl.conf >> ${confPath}"`);
       cliHelper.execSilent(`docker exec ${containerName} cat ${confPath}`);
-      cliHelper.execSilent(`docker exec ${containerName} systemctl restart mysql`).assertSuccess();
+      cliHelper.execSilent(`docker exec ${containerName} systemctl restart mongod`).assertSuccess();
 
       await grafanaHelper.authorize();
       await page.goto(servicesPage.url);
       await servicesPage.waitForServiceStatus(serviceName, 'Down', Timeouts.TWO_MINUTES);
 
       commands = [
-        `docker exec ${containerName} pmm-admin inventory change agent mysqld-exporter ${mysqldExporterId} --tls-cert-file=/certs/client.crt --tls-key-file=/certs/client.key --tls-ca-file=/certs/ca-certs.pem --tls --tls-skip-verify`,
-        `docker exec ${containerName} pmm-admin inventory change agent qan-mysql-perfschema-agent ${mysqldPerfschemaAgentId} --tls-cert-file=/certs/client.crt --tls-key-file=/certs/client.key --tls-ca-file=/certs/ca-certs.pem --tls --tls-skip-verify`,
+        `docker exec ${containerName} pmm-admin inventory change agent mongodb-exporter ${mongoExporterId} --tls-cert-file=/certs/client.crt --tls-key-file=/certs/client.key --tls-ca-file=/certs/ca-certs.pem --tls --tls-skip-verify`,
+        `docker exec ${containerName} pmm-admin inventory change agent qan-mongodb-profiler-agent ${mongoProfilerAgentId} --tls-cert-file=/certs/client.crt --tls-key-file=/certs/client.key --tls-ca-file=/certs/ca-certs.pem --tls --tls-skip-verify`,
       ];
 
       commands.forEach((command) => cliHelper.execSilent(command));


### PR DESCRIPTION
## Summary
Updates the MongoDB change agent TLS test to use correct MongoDB configuration syntax and certificate handling, and improves TLS certificate installation to support both Debian and RHEL-based containers.

## Key Changes
- **MongoDB configuration**: Changed from MySQL config path (`/etc/mysql/mysql.conf.d/mysqld.cnf`) to MongoDB config (`/etc/mongod/mongod.conf`) with proper YAML-based TLS settings
- **Certificate handling**: Consolidated separate certificate and key files into a single PEM file (`server.pem`) as required by MongoDB's `certificateKeyFile` option
- **File permissions**: Updated ownership to `mongod:mongod` and adjusted permissions for the consolidated PEM file
- **Agent references**: Changed pmm-admin commands from MySQL agents (`mysqld-exporter`, `qan-mysql-perfschema-agent`) to MongoDB agents (`mongodb-exporter`, `qan-mongodb-profiler-agent`)
- **Package manager compatibility**: Enhanced `createTlsCertificates` helper to support both `apt-get` (Debian) and `dnf` (RHEL) package managers, since different database containers use different base OS images
- **Removed unused import**: Deleted unused `fs` import from test file

## Implementation Details
- MongoDB TLS configuration is injected via `sed` to append the TLS block to the existing config file, preserving other settings
- The certificate concatenation (CRT + KEY → PEM) is done in a single Docker command to avoid intermediate file handling
- The package manager detection uses a bash conditional to check for `git` availability before attempting installation, gracefully falling back between package managers

https://claude.ai/code/session_01XYxGLyEGmMGK3EeEda3b7p