### PR TITLE
Parallelize PMM client upgrades in upgrade workflow

### DIFF
--- a/.github/workflows/upgrade-pmm-runner.yml
+++ b/.github/workflows/upgrade-pmm-runner.yml
@@ -294,7 +294,9 @@ jobs:
           else
             export CLIENT_REPOSITORY=testing
           fi
-          for c in $(docker ps --format '{{.Names}}' | grep -Ev '^(pmm-server|pmm-server-old|watchtower|ldap-server|kerberos|minio|redis_container)$'); do
+
+          upgrade_client() {
+            c="$1"
             echo "== upgrading client in $c =="
             log=$(mktemp)
             set +e
@@ -316,23 +318,44 @@ jobs:
               echo "!! upgrade failed in $c, showing logs:"
               cat "$log"
               rm -f "$log"
-              exit $status
+              return $status
             fi
-              UPGRADE_VERSION=$(docker exec "$c" pmm-admin --version 2>&1 | sed -n '2p')
-              CLIENT_UPGRADE_VERSION=$(docker exec "$c" pmm-admin --version 2>&1 | sed -n '3p')
-              if [[ "$UPGRADE_VERSION" == *"$LATEST_VERSION"* ]]; then
-                echo "OK: version contains $LATEST_VERSION ($UPGRADE_VERSION)"
-              else
-                echo "FAIL: expected $LATEST_VERSION, got $UPGRADE_VERSION"
-              fi
-              if [[ "$CLIENT_UPGRADE_VERSION" == *"$LATEST_VERSION"* ]]; then
-                echo "OK: version contains $LATEST_VERSION ($CLIENT_UPGRADE_VERSION)"
-              else
-                echo "FAIL: expected $LATEST_VERSION, got $CLIENT_UPGRADE_VERSION"
-              fi
-              echo "== upgrade succeeded in $c == ($CLIENT_UPGRADE_VERSION)"
+            UPGRADE_VERSION=$(docker exec "$c" pmm-admin --version 2>&1 | sed -n '2p')
+            CLIENT_UPGRADE_VERSION=$(docker exec "$c" pmm-admin --version 2>&1 | sed -n '3p')
+            if [[ "$UPGRADE_VERSION" == *"$LATEST_VERSION"* ]]; then
+              echo "OK: version contains $LATEST_VERSION ($UPGRADE_VERSION)"
+            else
+              echo "FAIL: expected $LATEST_VERSION, got $UPGRADE_VERSION"
+            fi
+            if [[ "$CLIENT_UPGRADE_VERSION" == *"$LATEST_VERSION"* ]]; then
+              echo "OK: version contains $LATEST_VERSION ($CLIENT_UPGRADE_VERSION)"
+            else
+              echo "FAIL: expected $LATEST_VERSION, got $CLIENT_UPGRADE_VERSION"
+            fi
+            echo "== upgrade succeeded in $c == ($CLIENT_UPGRADE_VERSION)"
             rm -f "$log"
+          }
+
+          # upgrade every client container in parallel; each writes its own
+          # output so per-container logs stay contiguous when printed
+          outdir=$(mktemp -d)
+          declare -A pid_container
+          for c in $(docker ps --format '{{.Names}}' | grep -Ev '^(pmm-server|pmm-server-old|watchtower|ldap-server|kerberos|minio|redis_container)$'); do
+            upgrade_client "$c" >"$outdir/$c.out" 2>&1 &
+            pid_container[$!]="$c"
           done
+
+          rc=0
+          for pid in "${!pid_container[@]}"; do
+            wait "$pid" || rc=1
+          done
+
+          for f in "$outdir"/*.out; do
+            [ -e "$f" ] || continue
+            cat "$f"
+          done
+          rm -rf "$outdir"
+          exit $rc
 
       - name: Check client after upgrade
         env:


### PR DESCRIPTION
Refactor the PMM client upgrade loop to run upgrades concurrently rather than sequentially, improving test execution time.

**Changes:**
- Extract upgrade logic into a reusable `upgrade_client()` function that accepts a container name as parameter
- Run client upgrades in parallel by spawning background processes for each container
- Capture per-container output to separate files to maintain log contiguity
- Collect exit codes from all parallel processes and fail if any upgrade fails
- Consolidate output from all containers after all upgrades complete

**Implementation details:**
- Uses a temporary directory to store per-container output files
- Maintains a `pid_container` associative array to map process IDs back to container names
- Waits for all background processes and aggregates their exit codes
- Preserves original error handling behavior (fails on first error in sequential mode, now fails if any parallel process fails)

https://claude.ai/code/session_01EaVtY8hNTLdnP3N7ii6pDv