### PR TITLE
PMM-14919 Fix T1010 MongoDB TLS change-agent flags

### DIFF
--- a/e2e_tests/tests/cli/mongo/mongoProfilerChangeAgent.test.ts
+++ b/e2e_tests/tests/cli/mongo/mongoProfilerChangeAgent.test.ts
@@ -380,8 +380,7 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
 
       let commands = [
         `docker exec ${containerName} bash -c "cat /easy-rsa/easyrsa3/pki/issued/${containerName}.crt /easy-rsa/easyrsa3/pki/private/${containerName}.key > /certs/server.pem"`,
-        `docker exec ${containerName} bash -c "cat /easy-rsa/easyrsa3/pki/private/pmm-test.key > /certs/client.key"`,
-        `docker exec ${containerName} bash -c "cat /easy-rsa/easyrsa3/pki/issued/pmm-test.crt > /certs/client.crt"`,
+        `docker exec ${containerName} bash -c "cat /easy-rsa/easyrsa3/pki/issued/pmm-test.crt /easy-rsa/easyrsa3/pki/private/pmm-test.key > /certs/client.pem"`,
         `docker exec ${containerName} cp /easy-rsa/easyrsa3/pki/ca.crt /certs/ca-certs.pem`,
         `docker exec ${containerName} chown mongod:mongod /certs/server.pem /certs/ca-certs.pem`,
         `docker exec ${containerName} chmod 600 /certs/server.pem`,
@@ -400,12 +399,15 @@ pmmTest.describe('Tests to verify pmm-admin inventory change agent functionality
       await page.goto(servicesPage.url);
       await servicesPage.waitForServiceStatus(serviceName, 'Down', Timeouts.TWO_MINUTES);
 
+      // MongoDB agents take a single cert+key PEM via --tls-certificate-key-file;
+      // the MySQL-style --tls-cert-file/--tls-key-file flags do not exist here and
+      // make pmm-admin reject the whole command, leaving the agents without TLS.
       commands = [
-        `docker exec ${containerName} pmm-admin inventory change agent mongodb-exporter ${mongoExporterId} --tls-cert-file=/certs/client.crt --tls-key-file=/certs/client.key --tls-ca-file=/certs/ca-certs.pem --tls --tls-skip-verify`,
-        `docker exec ${containerName} pmm-admin inventory change agent qan-mongodb-profiler-agent ${mongoProfilerAgentId} --tls-cert-file=/certs/client.crt --tls-key-file=/certs/client.key --tls-ca-file=/certs/ca-certs.pem --tls --tls-skip-verify`,
+        `docker exec ${containerName} pmm-admin inventory change agent mongodb-exporter ${mongoExporterId} --tls-certificate-key-file=/certs/client.pem --tls-ca-file=/certs/ca-certs.pem --tls --tls-skip-verify`,
+        `docker exec ${containerName} pmm-admin inventory change agent qan-mongodb-profiler-agent ${mongoProfilerAgentId} --tls-certificate-key-file=/certs/client.pem --tls-ca-file=/certs/ca-certs.pem --tls --tls-skip-verify`,
       ];
 
-      commands.forEach((command) => cliHelper.execSilent(command));
+      commands.forEach((command) => cliHelper.execSilent(command).assertSuccess());
       await servicesPage.waitForServiceStatus(serviceName, 'Up', Timeouts.FIVE_MINUTES);
     },
   );


### PR DESCRIPTION
## What

Fixes `PMM-T1010 - Verify Change agent tls` in `mongoProfilerChangeAgent.test.ts`, which timed out at the final `waitForServiceStatus('Up')` — the `rs101` service stayed `Down` for the full 5 minutes.

## Root cause

After enabling `requireTLS` on rs101's mongod, the test reconfigured the exporter and profiler agents with **MySQL-style flags**:

```
--tls-cert-file=/certs/client.crt --tls-key-file=/certs/client.key ...
```

Those flags **do not exist** on the MongoDB change-agent commands (`change_agent_mongodb_exporter.go` / `change_agent_qan_mongodb_profiler_agent.go`). MongoDB agents expose a single **`--tls-certificate-key-file`** (cert+key in one PEM) plus `--tls-ca-file`. pmm-admin (Kong) rejected the whole command on the unknown flags, and the loop discarded exit codes (`forEach((c) => cliHelper.execSilent(c))`, no `assertSuccess`), so the failure passed silently. The agents kept their non-TLS config and could never reconnect to the now-`requireTLS` mongod → service stayed `Down`.

## Fix

- Build a combined `/certs/client.pem` (client cert + key), matching the working pattern already used in `qa-integration/pmm_psmdb_diffauth_setup/test-auth.sh`.
- Reconfigure both agents with `--tls-certificate-key-file=/certs/client.pem --tls-ca-file=/certs/ca-certs.pem --tls --tls-skip-verify`.
- Add `.assertSuccess()` to the change-agent commands so a rejected flag (or any other failure) can no longer be swallowed.

## How verified

- Root-caused against the pmm-admin source: `--tls-cert-file`/`--tls-key-file` are MySQL-only; the MongoDB commands define `TLSCertificateKeyFile`/`TLSCaFile` (→ `--tls-certificate-key-file`/`--tls-ca-file`). The mongodb exporter/QAN DSN uses `directConnection=true`, so a direct TLS connection to rs101 (and the change-agent connection check) does not depend on replica-set primary selection — the exporter comes back `Up` once it actually receives the client cert.
- Correct flag + combined-PEM pattern confirmed against existing working usages in the repo (`pmm_psmdb_diffauth_setup/test-auth.sh`, `codeceptjs-e2e/tests/verifyTLSMongoDBRemoteInstance_test.js`).
- `npx eslint` on the changed file: clean.

Base branch is `PMM-14919-pgsql`, where this MongoDB profiler change-agent suite lives (same base as the merged #1407).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013a8Z2JASpE5KhLay4YV1BP

---
_Generated by [Claude Code](https://claude.ai/code/session_013a8Z2JASpE5KhLay4YV1BP)_