### PR TITLE
PMM-7: Fix replication status check failing on MySQL 9.7 client

### DIFF
--- a/qa-integration/pmm_qa/percona_server_for_mysql/tasks/percona-server-async-replication-setup.yml
+++ b/qa-integration/pmm_qa/percona_server_for_mysql/tasks/percona-server-async-replication-setup.yml
@@ -58,13 +58,13 @@
       INSERT INTO testdb VALUES (1, 'Initial data from node mysql1');
     "
 - name: Check replication status on replica nodes
-  shell: docker exec {{ container_prefix }}{{ item }} mysql -uroot -p{{ root_password }} -e "SHOW REPLICA STATUS\G"
+  shell: docker exec {{ container_prefix }}{{ item }} mysql -uroot -p{{ root_password }} --vertical -e "SHOW REPLICA STATUS"
   loop: "{{ range(2, nodes_count | int + 1) | list }}"
   changed_when: false
   when: ps_version | replace('_', '') | int >= 80
 
 - name: Check replication status on replica nodes
-  shell: docker exec {{ container_prefix }}{{ item }} mysql -uroot -p{{ root_password }} -e "SHOW SLAVE STATUS\G"
+  shell: docker exec {{ container_prefix }}{{ item }} mysql -uroot -p{{ root_password }} --vertical -e "SHOW SLAVE STATUS"
   loop: "{{ range(2, nodes_count | int + 1) | list }}"
   changed_when: false
   when: ps_version | replace('_', '') | int < 80


### PR DESCRIPTION
The "Check replication status on replica nodes" task ran `mysql -e "SHOW REPLICA STATUS\G"`. The \G vertical terminator is only handled by the mysql client in interactive mode; in batch (-e) mode the 9.7 client rejects it with `Unknown command '\G'` (rc=1), failing `--database ps=9.7,SETUP_TYPE=replication`. Use the `--vertical` client flag instead, which produces the same vertical output across all supported versions. Fixed the 5.7 SHOW SLAVE STATUS variant identically.