### PR TITLE
perf: GitHub Pages report site + publish_report.sh

### DIFF
--- a/performance/README.md
+++ b/performance/README.md
@@ -74,5 +74,6 @@ PMM snapshot links). The report schema lives in that branch's `README.md`.
 performance/ci/publish_report.sh perf-report.json   # adds reports/<run_id>.json, rebuilds data/index.json, pushes
 ```
 
-In CI the job needs `permissions: contents: write` and a checkout that keeps its
-credentials (or `PAGES_REMOTE` set to an authenticated URL).
+In CI the job needs `permissions: contents: write` and either `PAGES_REMOTE` set to an
+authenticated URL, or `GITHUB_TOKEN` and `GITHUB_REPOSITORY` in the environment. A
+checkout's persisted token does not reach the script's separate clone.

--- a/performance/README.md
+++ b/performance/README.md
@@ -63,3 +63,16 @@ PMM_PERF_TAG=pmm-qa-perf-run:myrun-01 ./teardown_perf_linodes.sh    # delete jus
 
 Teardown deletes only instances tagged `pmm-qa-perf` (this harness's own tag),
 never the account-wide `pmm-qa-ephemeral`.
+
+## Reports (GitHub Pages)
+
+Every run publishes its report to the `gh-pages` branch, which GitHub Pages serves
+as a trend dashboard (per-scale indicator, deviation chart, runs table with shared
+PMM snapshot links). The report schema lives in that branch's `README.md`.
+
+```bash
+performance/ci/publish_report.sh perf-report.json   # adds reports/<run_id>.json, rebuilds data/index.json, pushes
+```
+
+In CI the job needs `permissions: contents: write` and a checkout that keeps its
+credentials (or `PAGES_REMOTE` set to an authenticated URL).

--- a/performance/README.md
+++ b/performance/README.md
@@ -66,9 +66,10 @@ never the account-wide `pmm-qa-ephemeral`.
 
 ## Reports (GitHub Pages)
 
-Every run publishes its report to the `gh-pages` branch, which GitHub Pages serves
-as a trend dashboard (per-scale indicator, deviation chart, runs table with shared
-PMM snapshot links). The report schema lives in that branch's `README.md`.
+Once the perf pipeline is wired into CI, each run publishes its report to the
+`gh-pages` branch, which GitHub Pages serves as a trend dashboard (per-scale indicator,
+deviation chart, runs table with shared PMM snapshot links). Nothing in this repo calls
+the script yet. The report schema lives in that branch's `README.md`.
 
 ```bash
 performance/ci/publish_report.sh perf-report.json   # adds reports/<run_id>.json, rebuilds data/index.json, pushes

--- a/performance/ci/publish_report.sh
+++ b/performance/ci/publish_report.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Publish one performance run's report to the GitHub Pages site (gh-pages branch):
+# adds reports/<run_id>.json and rebuilds data/index.json, the file the dashboard
+# reads. Needs push rights to gh-pages (in CI: `permissions: contents: write` and a
+# checkout that keeps its credentials, or PAGES_REMOTE set to an authenticated URL).
+#
+#   publish_report.sh <run.json>
+set -Eeuo pipefail
+
+RUN_JSON="${1:?usage: publish_report.sh <run.json>}"
+PAGES_BRANCH="${PAGES_BRANCH:-gh-pages}"
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+[ -s "$RUN_JSON" ] || { echo "missing or empty: $RUN_JSON" >&2; exit 1; }
+jq -e '.run_id and .date and (.status == "pass" or .status == "fail")' "$RUN_JSON" >/dev/null \
+  || { echo "run.json needs run_id, date, and status (pass|fail)" >&2; exit 1; }
+run_id="$(jq -r '.run_id' "$RUN_JSON")"
+status="$(jq -r '.status' "$RUN_JSON")"
+[[ "$run_id" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "bad run_id: $run_id" >&2; exit 1; }
+
+remote="${PAGES_REMOTE:-$(git config --get remote.origin.url)}"
+wt="$(mktemp -d)"
+trap 'rm -rf "$wt"' EXIT
+trap 'exit 143' TERM; trap 'exit 130' INT; trap 'exit 129' HUP
+git clone --quiet --depth 1 --branch "$PAGES_BRANCH" "$remote" "$wt"
+
+mkdir -p "$wt/reports" "$wt/data"
+cp "$RUN_JSON" "$wt/reports/${run_id}.json"
+jq -s 'sort_by(.date)' "$wt"/reports/*.json > "$wt/data/index.json"
+
+git -C "$wt" add "reports/${run_id}.json" data/index.json
+if git -C "$wt" diff --cached --quiet; then echo "nothing new to publish for $run_id"; exit 0; fi
+git -C "$wt" \
+  -c user.name="${GIT_AUTHOR_NAME:-pmm-perf-bot}" \
+  -c user.email="${GIT_AUTHOR_EMAIL:-pmm-perf-bot@users.noreply.github.com}" \
+  commit --quiet -m "perf: publish report ${run_id} (${status})"
+git -C "$wt" push --quiet origin "$PAGES_BRANCH"
+echo "published reports/${run_id}.json ($status) to ${PAGES_BRANCH}"

--- a/performance/ci/publish_report.sh
+++ b/performance/ci/publish_report.sh
@@ -2,7 +2,7 @@
 # Publish one performance run's report to the GitHub Pages site (gh-pages branch):
 # adds reports/<run_id>.json and rebuilds data/index.json, the file the dashboard
 # reads. Needs push rights to gh-pages (in CI: `permissions: contents: write` and a
-# checkout that keeps its credentials, or PAGES_REMOTE set to an authenticated URL).
+# either PAGES_REMOTE set to an authenticated URL, or GITHUB_TOKEN + GITHUB_REPOSITORY).
 #
 #   publish_report.sh <run.json>
 set -Eeuo pipefail
@@ -17,7 +17,18 @@ run_id="$(jq -r '.run_id' "$RUN_JSON")"
 status="$(jq -r '.status' "$RUN_JSON")"
 [[ "$run_id" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "bad run_id: $run_id" >&2; exit 1; }
 
-remote="${PAGES_REMOTE:-$(git config --get remote.origin.url)}"
+remote="${PAGES_REMOTE:-}"
+if [ -z "$remote" ] && [ -n "${GITHUB_TOKEN:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ]; then
+  remote="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+fi
+if [ -z "$remote" ]; then
+  # Outside CI the developer's credential helper authenticates origin. In CI the
+  # checkout token lives only in the workspace repo's .git/config, which a fresh
+  # clone never inherits -- so require an explicit authenticated remote instead of
+  # failing on the final push.
+  [ -z "${GITHUB_ACTIONS:-}" ] || { echo "in CI set PAGES_REMOTE, or GITHUB_TOKEN and GITHUB_REPOSITORY" >&2; exit 1; }
+  remote="$(git config --get remote.origin.url)"
+fi
 wt="$(mktemp -d)"
 trap 'rm -rf "$wt"' EXIT
 trap 'exit 143' TERM; trap 'exit 130' INT; trap 'exit 129' HUP

--- a/performance/ci/publish_report.sh
+++ b/performance/ci/publish_report.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
-# Publish one performance run's report to the GitHub Pages site (gh-pages branch):
-# adds reports/<run_id>.json and rebuilds data/index.json, the file the dashboard
-# reads. Needs push rights to gh-pages (in CI: `permissions: contents: write` and a
-# either PAGES_REMOTE set to an authenticated URL, or GITHUB_TOKEN + GITHUB_REPOSITORY).
-#
-#   publish_report.sh <run.json>
+# Publish one performance run's report to the GitHub Pages site (gh-pages branch).
+# See README.md for usage and the credentials the push needs.
 set -Eeuo pipefail
 
 RUN_JSON="${1:?usage: publish_report.sh <run.json>}"
@@ -29,20 +25,34 @@ if [ -z "$remote" ]; then
   [ -z "${GITHUB_ACTIONS:-}" ] || { echo "in CI set PAGES_REMOTE, or GITHUB_TOKEN and GITHUB_REPOSITORY" >&2; exit 1; }
   remote="$(git config --get remote.origin.url)"
 fi
+
 wt="$(mktemp -d)"
 trap 'rm -rf "$wt"' EXIT
 trap 'exit 143' TERM; trap 'exit 130' INT; trap 'exit 129' HUP
 git clone --quiet --depth 1 --branch "$PAGES_BRANCH" "$remote" "$wt"
 
-mkdir -p "$wt/reports" "$wt/data"
-cp "$RUN_JSON" "$wt/reports/${run_id}.json"
-jq -s 'sort_by(.date)' "$wt"/reports/*.json > "$wt/data/index.json"
+publish() {
+  mkdir -p "$wt/reports" "$wt/data"
+  cp "$RUN_JSON" "$wt/reports/${run_id}.json"
+  jq -s 'sort_by(.date)' "$wt"/reports/*.json > "$wt/data/index.json"
+  git -C "$wt" add "reports/${run_id}.json" data/index.json
+  if git -C "$wt" diff --cached --quiet; then echo "nothing new to publish for $run_id"; return 0; fi
+  git -C "$wt" \
+    -c user.name="${GIT_AUTHOR_NAME:-pmm-perf-bot}" \
+    -c user.email="${GIT_AUTHOR_EMAIL:-pmm-perf-bot@users.noreply.github.com}" \
+    commit --quiet -m "perf: publish report ${run_id} (${status})"
+  git -C "$wt" push --quiet origin "$PAGES_BRANCH"
+  echo "published reports/${run_id}.json ($status) to ${PAGES_BRANCH}"
+}
 
-git -C "$wt" add "reports/${run_id}.json" data/index.json
-if git -C "$wt" diff --cached --quiet; then echo "nothing new to publish for $run_id"; exit 0; fi
-git -C "$wt" \
-  -c user.name="${GIT_AUTHOR_NAME:-pmm-perf-bot}" \
-  -c user.email="${GIT_AUTHOR_EMAIL:-pmm-perf-bot@users.noreply.github.com}" \
-  commit --quiet -m "perf: publish report ${run_id} (${status})"
-git -C "$wt" push --quiet origin "$PAGES_BRANCH"
-echo "published reports/${run_id}.json ($status) to ${PAGES_BRANCH}"
+# Concurrent runs (a scale matrix, a manual run beside a scheduled one) race on the
+# push; a non-fast-forward rejection is expected, so re-sync to the branch tip and
+# rebuild the index rather than losing the run.
+for attempt in 1 2 3 4 5; do
+  if publish; then exit 0; fi
+  echo "publish attempt $attempt failed; re-syncing ${PAGES_BRANCH} and retrying" >&2
+  git -C "$wt" fetch --quiet --depth 1 origin "$PAGES_BRANCH"
+  git -C "$wt" reset --quiet --hard "origin/${PAGES_BRANCH}"
+done
+echo "failed to publish ${run_id} after 5 attempts" >&2
+exit 1


### PR DESCRIPTION
My action item from today's perf-testing meeting: **a GitHub Pages site to host and store performance reports** so we can track trends across releases.

## What's here
- **`gh-pages` branch** (pushed separately) — the site: a dashboard with a per-scale **trend indicator** (improving / stable / regressing), a deviation-over-time chart, and a runs table with each run's checks and **shared PMM snapshot links**. Backed by `reports/<run_id>.json` + a regenerated `data/index.json`. Schema documented in that branch's README.
- **`performance/ci/publish_report.sh`** (this PR) — the pipeline's reporting step: adds a run's report to `gh-pages`, rebuilds the index, pushes.

## Report shape (matches the meeting's dynamic-baseline decision)
Per check: `baseline` (5-min avg before upgrade) → `after` → `deviation_pct`, failing past `deviation_threshold_pct` (10). Plus `snapshots[]` links for human review.

## Wiring
Shruti's `perf-provision.yaml` update calls `publish_report.sh perf-report.json` as its final step (job needs `permissions: contents: write`).

## Enabling Pages (manual, one time)
The Pages API is blocked through this environment's proxy, so a repo admin flips it: **Settings → Pages → Source: Deploy from a branch → `gh-pages` / `(root)`**. The site then serves at `https://percona.github.io/pmm-qa/`.

Dashboard verified rendering locally with sample runs (table, badges, trend cards, snapshot links); the Chart.js chart needs the CDN, which the dashboard degrades gracefully without.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBhvZuEUQU8ym347Xat4Yy