### PR TITLE
Give @pmm-ps-integration a setup-sized job timeout

### DIFF
--- a/.github/workflows/fb-e2e-suite.yml
+++ b/.github/workflows/fb-e2e-suite.yml
@@ -349,10 +349,7 @@ jobs:
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || 'main') }}
       setup_services: '--database ps,SETUP_TYPE=replication,MY_ROCKS=true --database ps,SETUP_TYPE=gr,QUERY_SOURCE=slowlog'
       pmm_test_flag: '@pmm-ps-integration'
-      # This tag provisions two PS clusters (6 package-based MySQL installs)
-      # before the tests start. That setup has been measured at 43.8-57.2 min
-      # on GitHub runners against the 60 min default, so the job kept dying in
-      # setup with the tests never running.
+      # This tag provisions two PS clusters sequentially, so its setup alone can outrun the runner's 60 min default.
       timeout_minutes: 90
 
   rbac:

--- a/.github/workflows/fb-e2e-suite.yml
+++ b/.github/workflows/fb-e2e-suite.yml
@@ -349,6 +349,11 @@ jobs:
       pmm_qa_branch: ${{ github.event_name == 'pull_request' && github.head_ref || (inputs.pmm_qa_branch || 'main') }}
       setup_services: '--database ps,SETUP_TYPE=replication,MY_ROCKS=true --database ps,SETUP_TYPE=gr,QUERY_SOURCE=slowlog'
       pmm_test_flag: '@pmm-ps-integration'
+      # This tag provisions two PS clusters (6 package-based MySQL installs)
+      # before the tests start. That setup has been measured at 43.8-57.2 min
+      # on GitHub runners against the 60 min default, so the job kept dying in
+      # setup with the tests never running.
+      timeout_minutes: 90
 
   rbac:
     name: PS UI Role based access control

--- a/.github/workflows/runner-e2e-tests-playwright.yml
+++ b/.github/workflows/runner-e2e-tests-playwright.yml
@@ -73,6 +73,11 @@ on:
       sha:
         type: string
         required: false
+      timeout_minutes:
+        description: 'Job timeout. Raise for tags whose setup builds several DB clusters.'
+        type: number
+        required: false
+        default: 60
     secrets:
       LAUNCHABLE_TOKEN:
         required: false
@@ -82,7 +87,7 @@ jobs:
   tests:
     name: "e2e tests: ${{ inputs.pmm_test_flag || '' }}"
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.timeout_minutes || 60 }}
     env:
       SHA: ${{ inputs.sha || 'null' }}
       PMM_BASE_URL: https://127.0.0.1


### PR DESCRIPTION
## Failures fixed (investigator)

- source: Percona-Lab/pmm-submodules PR #4449 — run [34601581070](https://github.com/Percona-Lab/pmm-submodules/actions/runs/34601581070), check `E2E / Percona Server for MySQL UI integration tests / e2e tests: @pmm-ps-integration`
- tests: none individually — the job is killed in provisioning, so every test under the tag is simply never executed:
  - `e2e_tests/tests/api/mysql/mysqlApi.test.ts` / `@pmm-ps-integration`
  - `e2e_tests/tests/cli/mysql/mysqlCliIntegration.test.ts` / `@pmm-ps-integration`
  - `e2e_tests/tests/dashboards/mysql/mysqlDashboards.test.ts` / `@pmm-ps-integration`
  - `e2e_tests/tests/qan/storedMetrics/mysql/mysqlQanStoredMetrics.test.ts` / `@pmm-ps-integration`

## What failed

`Run Setup for E2E Tests` ran for 57 minutes and was then killed by the runner's
`timeout-minutes: 60`. `Run UI tests: @pmm-ps-integration with launchable` was skipped, so the
job produced no test verdict at all.

This is not specific to PR #4449. Across the ten FB runs before it, on six different branches:

| Run | Date (UTC) | Job | Job min | Setup min | Tests ran? |
| --- | --- | --- | --- | --- | --- |
| 34599636205 | 09-11 12:34 | cancelled | 60.4 | 55.9 | no |
| 34599534036 | 09-11 12:33 | cancelled | 60.4 | 57.2 | no |
| 34596772065 | 09-11 12:00 | cancelled | 60.5 | 43.8 | no |
| 34594961899 | 09-11 11:37 | cancelled | 60.4 | 56.9 | no |
| 34592871817 | 09-11 11:12 | cancelled | 60.4 | 55.4 | started, killed after 1.1 min |
| 34585278882 | 09-11 09:39 | cancelled | 60.3 | 56.9 | no |
| 34585179686 | 09-11 09:37 | cancelled | 60.4 | 45.5 | no |
| 34523660473 | 09-10 19:59 | success | 17.2 | 8.3 | yes — 5.0 min, passed |
| 34464128177 | 09-10 10:04 | success | 1.7 | 0.0 | no — empty Launchable subset |
| 34460749685 | 09-10 09:27 | success | 1.9 | 0.0 | no — empty Launchable subset |

Seven of ten were cancelled at the timeout, all between 09:37 and 12:34 UTC.

## Root cause — the setup budget on the busy-hours path

`fb-e2e-suite.yml` gives this tag two full PS clusters:

```
--database ps,SETUP_TYPE=replication,MY_ROCKS=true --database ps,SETUP_TYPE=gr,QUERY_SOURCE=slowlog
```

The framework runs them sequentially ("Running setups sequentially: two PS setups cannot run in
parallel"), and each cluster installs Percona Server from packages on three nodes, one node at a
time.

**The job definition is not the problem, and this is the key evidence.** The same `ps_integration`
job also runs on pmm-qa's own `0 2 * * *` schedule, via `e2e-tests-matrix.yml`'s `fb_tests` job, and
there it is consistently healthy — the last eight scheduled runs on `main`:

| Nightly run | Date (UTC) | Job | Job time | Setup | Tests |
| --- | --- | --- | --- | --- | --- |
| [34554353790](https://github.com/percona/pmm-qa/actions/runs/34554353790) | 09-11 02:22 | success | 16m58s | 8m50s | 4m05s |
| [34429181245](https://github.com/percona/pmm-qa/actions/runs/34429181245) | 09-10 02:22 | success | 15m13s | 7m36s | 4m14s |
| [34302870386](https://github.com/percona/pmm-qa/actions/runs/34302870386) | 09-09 02:21 | success | 17m56s | 8m55s | 4m57s |
| [34179767802](https://github.com/percona/pmm-qa/actions/runs/34179767802) | 09-08 02:21 | success | 16m42s | 8m55s | 4m17s |
| [33829234874](https://github.com/percona/pmm-qa/actions/runs/33829234874) | 09-04 02:21 | success | 19m22s | 7m32s | 5m12s |

(The 09-05/06/07 nightlies are ~2 min no-ops — empty Launchable subset, setup and tests skipped.)

**Zero nightly timeouts. Setup 7m32s–8m55s every time.** The identical job, identical playbook and
identical setup step finish in under nine minutes at 02:20 UTC and take 43.8–57.2 minutes at
09:37–12:34 UTC. The variable is the time of day — apt/mirror throughput from the runners under
peak load — not anything this repo's code does.

The per-task timings from run 34601581070's own log show where the time goes: 56.9 of the 57
minutes is package work.

| Ansible task | Time in that run |
| --- | --- |
| Install dependencies (`apt-get update` + wget/gnupg2/lsb-release/curl) | 18.8 min + 8.1 min |
| Install Percona Release (`wget` the deb + `dpkg -i`) | 8.9 min + 3.4 min |
| Install dependencies inside Debian-family container (PMM client) | 4.1 min + 2.0 min |
| Enable Percona Server repository (`percona-release enable` + `apt-get update`) | 3.9 min + 1.6 min |
| Install Percona Server for MySQL | 3.6 min |

Within that single run the same `Install dependencies` command on three identical containers took
**0:52, then 2:46, then 15:08** — same image, same command, back to back. That shape is external
throughput degrading, not work being done.

Reproduced on a throwaway Linode VM (6 vCPU) running the FB build
`perconalab/pmm-server-fb:PR-4449-273677e` with the same client tarball and the exact CI command:

| | CI (run 34601581070) | Idle Linode VM |
| --- | --- | --- |
| Both setups, end to end | **57 min, killed incomplete** | **9m37s, rc=0** |
| Install dependencies, setup 1 | 8.1 min | 23.3s |
| Install dependencies, setup 2 | 18.8 min | 39.3s |
| Install Percona Release | 3.4 / 8.9 min | 10.0s / 14.9s |
| Enable PS repository | 3.9 / 1.6 min | 9.0s / 14.0s |

To rule out CPU contention (a repro VM is less loaded than a runner), the dependency install was
timed on that box idle and under twelve spinning CPU hogs: **12s idle, 14s at `load avg 4.62`**.
CPU load is not the variable.

## Fix

`timeout-minutes` on `runner-e2e-tests-playwright.yml` becomes an input defaulting to `60`, and
`fb-e2e-suite.yml` passes `90` for this one job. Every other caller of the runner is unchanged in
behaviour, since they pass nothing and get the same 60.

90 covers the worst setup actually observed (57.2 min) plus the ~3.5 min of pre-setup steps and a
test run of ~5 min, with margin. It costs nothing in the healthy case: the nightly job finishes in
15–20 minutes and is nowhere near either limit.

This buys headroom; it does not make the setup faster. Cutting the underlying cost — running the
per-node package work concurrently instead of one node at a time, or baking the four utility
packages and percona-release into the base image — is the real follow-up, and is deliberately not
attempted here because its effect under a throttled mirror cannot be measured from outside CI.

## Verification

- Both workflow files parse (`yaml.safe_load`), and the resolved values are correct: the runner's
  `timeout-minutes` is `${{ inputs.timeout_minutes || 60 }}`, `timeout_minutes` is registered in the
  `workflow_call` inputs, and `ps_integration.with` carries `timeout_minutes: 90`. `Lint` passes but
  does not resolve `timeout-minutes` expressions or reusable-workflow inputs, so the input wiring was
  checked by hand as well as statically.
- The provisioning command itself was run to completion on the Linode VM (rc=0, 9m37s), so the setup
  this timeout is sized for is known to work.
- This PR's own CI exercises the change end to end: `e2e-tests-matrix.yml` calls `fb-e2e-suite.yml`
  on every `pull_request` to `main`, so `ps_integration` runs here under the new 90-minute timeout.
  On the head of this PR that job ([103321599356](https://github.com/percona/pmm-qa/actions/runs/34616625834/job/103321599356))
  concluded **success** at 15:51:10 UTC — setup 7m23s, tests 4m16s, job 15m01s. (Naming the job
  rather than the run: a later push to this branch cancels the run and flips its conclusion, long
  after the job itself finished green.)

**What only a busy-hours run can confirm:** whether 90 minutes is enough on the worst runner day.
The observed worst case (57.2 min setup) fits with roughly 20 minutes to spare, but the nightly and
PR paths both tend to land in the fast regime, so a green run here demonstrates the wiring is
correct rather than that the new ceiling is sufficient. The ceiling is only exercised when apt is
degraded.

The helm-tests failure in the same FB run was a separate, unrelated transient
(`500 Internal Server Error` fetching `pmm-1.4.0.tgz` from GitHub release assets); it passed on
re-run and needs no change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaD6E1PsySaavZhpASfizu


---
_Generated by [Claude Code](https://claude.ai/code)_