### PR TITLE
Clear the Explore SQL editor from the keyboard in PMM-T2020

### DIFF
--- a/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
+++ b/codeceptjs-e2e/tests/QAN/externalClickhouse_test.js
@@ -54,8 +54,7 @@ Scenario('PMM-T2020 - Verify external clickhouse as datasource on explore page @
   explorePage.selectDataSource('ClickHouse');
   I.waitForVisible(explorePage.elements.sqlEditorButton, 30);
   I.click(explorePage.elements.sqlEditorButton);
-  I.clearField(explorePage.elements.sqlBuilder);
-  I.fillField(explorePage.elements.sqlBuilder, 'SELECT * FROM pmm.metrics LIMIT 10;');
+  await explorePage.setSqlQuery('SELECT * FROM pmm.metrics LIMIT 10;');
   I.click(explorePage.elements.runQueryButton);
   I.waitForVisible(explorePage.elements.resultRow, 10);
   I.dontSee(explorePage.messages.authError);

--- a/codeceptjs-e2e/tests/pages/explorePage.js
+++ b/codeceptjs-e2e/tests/pages/explorePage.js
@@ -1,3 +1,5 @@
+const assert = require('assert');
+
 const { I } = inject();
 
 class ExplorePage {
@@ -26,6 +28,34 @@ class ExplorePage {
     I.waitForVisible(this.elements.dataSourcePicker);
     I.fillField(this.elements.dataSourcePicker, dataSourceName);
     I.pressKey('Enter');
+  }
+
+  // The SQL editor arrives pre-filled with the query the plugin generates from
+  // the builder ('SELECT FROM  LIMIT 1000'). clearField/fillField drive it through
+  // Playwright's fill(), which here deletes a single character per call instead of
+  // emptying the editor, leaving the default behind for the typed query to be
+  // prepended to - a multi-statement the database rejects. Clearing from the
+  // keyboard empties it; the assertion stops a future regression from reaching the
+  // query as silent corruption.
+  async setSqlQuery(query) {
+    I.waitForVisible(this.elements.sqlBuilder, 30);
+
+    let content;
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      I.click(this.elements.sqlBuilder);
+      I.pressKey(['Control', 'a']);
+      I.pressKey('Backspace');
+      I.type(query);
+
+      content = await I.grabValueFrom(this.elements.sqlBuilder);
+
+      if (content === query) {
+        return;
+      }
+    }
+
+    assert.equal(content, query, `SQL editor should contain only the query under test, found '${content}'`);
   }
 }
 


### PR DESCRIPTION
## Failures fixed (investigator)

- source: Percona-Lab/pmm-submodules PR #4564 — run [34619666742](https://github.com/Percona-Lab/pmm-submodules/actions/runs/34619666742)
- tests:
  - `codeceptjs-e2e/tests/QAN/externalClickhouse_test.js` / `@docker-configuration` — PMM-T2020

## What failed

Two checks went red on that run; only one of them is a test bug.

| Check | Failure | Verdict |
| --- | --- | --- |
| `E2E / Docker configuration tests / e2e tests: @docker-configuration` (CodeceptJS, job [103330211521](https://github.com/Percona-Lab/pmm-submodules/actions/runs/34619666742/job/103330211521)) | `PMM-T2020` — `element (//div[@role="row"]) still not visible after 10 sec` at `externalClickhouse_test.js:60` | test bug — fixed here |
| `CLI / Integration tests / CLI / Integration / MySQL 8.4` (job [103330212309](https://github.com/Percona-Lab/pmm-submodules/actions/runs/34619666742/job/103330212309)) | setup, not a test: `mysql/mysql-setup.yml` task *Query Docker Hub for MySQL tags* → `Status code was -1 … <urlopen error [Errno 104] Connection reset by peer>` | transient, no change here — see the last section |

The FB build itself (`perconalab/pmm-server-fb:PR-4564-bb38861`, pmm at
`PMM-15104-improve-query-perf-on-pg-overview`) is not implicated in either. The PR moves only the
`pmm` submodule, its change is to the PostgreSQL overview dashboard, and neither failure touches it.

## PMM-T2020 — root cause

The failure screenshot shows what the test actually sent to ClickHouse:

```
SELECT * FROM pmm.metrics LIMIT 10;LECT FROM LIMIT 1000
```

```
error querying the database: code: 62, message: Syntax error (Multi-statements are not allowed):
failed at position 35 (end of query): ;LECT FROM LIMIT 1000.
```

`0 series returned`, so no `//div[@role="row"]` ever renders and the 10-second wait expires. The
product did the right thing — it rejected a malformed statement the test built.

The residue is the query the ClickHouse plugin generates into the SQL editor from the (empty) Query
Builder when the editor mode is switched. `I.clearField` and `I.fillField` drive that editor through
Playwright's `fill()`, and on this element **`fill('')` deletes a single character rather than
emptying it**. Measured on a throwaway Linode VM against the same FB image, dumping the editor's
value after each step of the exact call sequence (`I.clearField` → `I.fillField`, which itself
clears and then types):

| Step | Editor content |
| --- | --- |
| after the *SQL Editor* click | `SELECT FROM LIMIT 1000` |
| after `I.clearField` → `fill('')` | `ELECT FROM LIMIT 1000` |
| after `I.fillField`'s internal `fill('')` | *(empty on this VM)* |
| after `I.fillField`'s `type()` | `SELECT * FROM pmm.metrics LIMIT 10;` |

Identical readings idle and under twelve CPU hogs on the 6-vCPU box. On the CI runner the *second*
`fill('')` also stopped after one character, which is exactly the two characters missing from the
screenshot's `LECT FROM LIMIT 1000` — same defect, one step further along.

That makes the test latently broken rather than intermittently unlucky: it passes only while the
second `fill('')` happens to finish the job the first one left undone.

**Negative control**, same VM: typing that screenshot's content verbatim into the editor and
clicking *Run Query* produced **0 result rows within 10 s**; a clean query on the same page
produced **11**. The chain from the unreliable clear to the red test is closed end to end.

## The fix

`explorePage.setSqlQuery()` clears from the keyboard (`Ctrl+A`, `Backspace` — the same idiom
`adminPage.customClearField`/`pmmSettingsPage.customClearField` already use here) and then asserts
the editor holds only the query before it is run, so a future regression fails as visible corruption
instead of as a missing table row. On the same probe: after `Ctrl+A`+`Backspace` the editor is
empty, and after typing it holds exactly `SELECT * FROM pmm.metrics LIMIT 10;` — idle and loaded.

## Verification

- The probe above is the evidence that matters: it measures the defect and the fix on the same
  page, deterministically, instead of waiting for a race.
- `PMM-T2020` on this branch against `perconalab/pmm-server-fb:PR-4564-bb38861`: **3/3 green idle,
  2/2 green under twelve CPU hogs**.
- `eslint --ext .js tests/pages/explorePage.js tests/QAN/externalClickhouse_test.js` — clean.
- **What a green run does *not* prove:** unmodified `main` also passed 3/3 idle and 3/3 loaded on
  that VM before the fix. The defect only surfaces when both `fill('')` calls under-clear, which the
  VM would not do, so pass/fail counts on either branch are weak evidence in both directions. The
  step-by-step editor readings are the claim; the green runs only show nothing else broke.
- Unchanged and worth a reviewer's eye: `I.waitForVisible(explorePage.elements.resultRow, 10)` is a
  thin budget on a contended runner. It is not what failed here, so it is left alone rather than
  widened into this PR.

## The MySQL 8.4 failure — no change proposed

`qa-integration/pmm_qa/mysql/tasks/prepare_install_mysql.yml:55` calls `hub.docker.com` with no
`retries`/`until`, and that one request was reset (`elapsed: 0`). The endpoint answered 200 on 3/3
probes afterwards, and **re-running the failed jobs on run 34619666742 turned both green** — the
whole FB run is now green (53/53 checks success or skipped), so PR #4564 is clear.

Hardening that `uri` task (and the sibling version lookups) with `retries`/`delay` is a real
follow-up on one observation, but it is a separate change from this one and is deliberately not
bundled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqibjQULAJ4uZTdFJAFs4p


---
_Generated by [Claude Code](https://claude.ai/code/session_01JqibjQULAJ4uZTdFJAFs4p)_