### PR TITLE
fix(qa-integration): pull MinIO images from quay.io

### DIFF
--- a/qa-integration/pmm_psmdb-pbm_setup/docker-compose-rs.yaml
+++ b/qa-integration/pmm_psmdb-pbm_setup/docker-compose-rs.yaml
@@ -213,7 +213,7 @@ services:
     entrypoint: bash -c "chown -R mongod:mongod /keytabs && exec /usr/sbin/init"
 
   minio:
-    image: minio/minio
+    image: quay.io/minio/minio
     profiles: ["minio"]
     container_name: minio
     ports:
@@ -235,7 +235,7 @@ services:
 
   createbucket:
     container_name: createbucket
-    image: minio/mc
+    image: quay.io/minio/mc
     profiles: ["minio"]
     networks:
       - pmm-qa

--- a/qa-integration/pmm_psmdb-pbm_setup/docker-compose-sharded-with-pmm.yaml
+++ b/qa-integration/pmm_psmdb-pbm_setup/docker-compose-sharded-with-pmm.yaml
@@ -238,7 +238,7 @@ services:
 
   minio:
     profiles: ["minio"]
-    image: minio/minio
+    image: quay.io/minio/minio
     container_name: minio
     ports:
       - "9001:9000"
@@ -253,7 +253,7 @@ services:
 
   createbucket:
     container_name: createbucket
-    image: minio/mc
+    image: quay.io/minio/mc
     profiles: ["minio"]
     networks:
       - test-network

--- a/qa-integration/pmm_psmdb-pbm_setup/docker-compose-sharded.yaml
+++ b/qa-integration/pmm_psmdb-pbm_setup/docker-compose-sharded.yaml
@@ -339,7 +339,7 @@ services:
   # docker-compose-rs.yaml; this definition is retained for standalone use.
   minio:
     profiles: ["minio"]
-    image: minio/minio
+    image: quay.io/minio/minio
     container_name: minio
     ports:
       - "9001:9000"
@@ -359,7 +359,7 @@ services:
   createbucket:
     profiles: ["minio"]
     container_name: createbucket
-    image: minio/mc
+    image: quay.io/minio/mc
     networks:
       - pmm-qa
       - pmm-ui-tests1

--- a/qa-integration/pmm_psmdb_diffauth_setup/docker-compose-pmm-psmdb.yml
+++ b/qa-integration/pmm_psmdb_diffauth_setup/docker-compose-pmm-psmdb.yml
@@ -119,7 +119,7 @@ services:
 
   minio:
     profiles: [minio]
-    image: minio/minio
+    image: quay.io/minio/minio
     container_name: minio
     ports:
       - "9001:9000"
@@ -136,7 +136,7 @@ services:
   createbucket:
     profiles: [minio]
     container_name: createbucket
-    image: minio/mc
+    image: quay.io/minio/mc
     depends_on:
       - minio
     entrypoint: >

--- a/qa-integration/pmm_qa/tasks/setup_minio_container.yml
+++ b/qa-integration/pmm_qa/tasks/setup_minio_container.yml
@@ -11,7 +11,7 @@
 - name: Remove old MinIO docker container
   community.docker.docker_container:
     name: minio
-    image: minio/minio
+    image: quay.io/minio/minio
     restart_policy: always
     state: absent
   ignore_errors: yes
@@ -29,7 +29,7 @@
 - name: Run MinIO container
   community.docker.docker_container:
     name: minio
-    image: minio/minio
+    image: quay.io/minio/minio
     restart_policy: unless-stopped
     ports: "{{ minio_ports }}"
     networks:


### PR DESCRIPTION
## Problem

Every e2e job whose setup starts a MinIO container is failing **before a single test runs**. Docker Hub no longer serves the MinIO images:

```
minio         Error pull access denied for minio/minio, repository does not exist
              or may require 'docker login': denied: requested access to the resource is denied
createbucket  Error pull access denied for minio/mc, repository does not exist
              or may require 'docker login': denied: requested access to the resource is denied
ERROR: Setup script 'start-rs-only.sh' failed.
```

MinIO moved its published images to quay.io.

## Scope of the outage

On [run 34638839201](https://github.com/percona/pmm-qa/actions/runs/34638839201) (`main`), **twelve** jobs failed. Every one died at `Run Setup for E2E Tests`, with `Run UI tests` **skipped** — so no test code executed anywhere:

`@pmm-psmdb-integration` · `@LBAC` · `@new-navigation\|@menu` · `@pmm-psmdb-replica-integration` · `@bm-mongo` · `@bm-locations` · `@mongodb-exporter` · `@user-password` (docker **and** podman) · `@pmm-psmdb-arbiter-integration` · `@rta` · `@nomad`

Those suites have nothing in common except a MinIO container in setup. Open PRs inherit the same twelve failures — that is how this was found, on #1417, whose own failing set was identical to `main`'s.

## Fix

Repoint the ten references at `quay.io/minio/minio` and `quay.io/minio/mc`. **Registry prefix only** — no tag changed, nothing else touched. None of these references is used for container matching (cleanup selects on `--label`), so prefixing is safe.

## Verification

Both registries checked from a workstation Docker daemon:

```
docker manifest inspect minio/minio:latest          -> denied
docker manifest inspect minio/mc:latest             -> denied
docker manifest inspect quay.io/minio/minio:latest  -> ok
docker manifest inspect quay.io/minio/mc:latest     -> ok
```

CI is the real proof: these jobs should get past `Run Setup for E2E Tests` and actually execute.

## Note for reviewers

`provisioning/` carries six more `minio/minio` / `minio/mc` references and is **deliberately not touched here** — that directory does not exist on `main`, so it is out of scope for this PR and needs the same prefix whenever it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
