### PR TITLE
Give PMM-T1403 a query it can show an Example for

### DIFF
--- a/codeceptjs-e2e/tests/verifyTLSMySQLRemoteInstance_test.js
+++ b/codeceptjs-e2e/tests/verifyTLSMySQLRemoteInstance_test.js
@@ -26,10 +26,14 @@ maxQueryLengthInstances.add(['mysql_8.0_ssl_service', '8.0', 'mysql_ssl_8.0', 'm
 maxQueryLengthInstances.add(['mysql_8.0_ssl_service', '8.0', 'mysql_ssl_8.0', 'mysql_ssl', 'mysql_global_status_max_used_connections', '-1']);
 maxQueryLengthInstances.add(['mysql_8.0_ssl_service', '8.0', 'mysql_ssl_8.0', 'mysql_ssl', 'mysql_global_status_max_used_connections', '']);
 
-// Nothing else running against the SSL MySQL instance reads
-// information_schema.character_sets, so a QAN search on it returns only this test's
-// own probe query.
-const exampleQueryMarker = 'character_sets';
+// The probe query below is searched for by table name, so it needs a table nothing
+// else on the SSL MySQL instance reads. One per data row: opening the Explain tab
+// re-runs the probe as EXPLAIN [FORMAT = JSON] <query>, and those land in the profile
+// under the same name, so a later row reusing a name would match three rows.
+const exampleQueryMarkers = {
+  '-1': 'character_sets',
+  '': 'collations',
+};
 
 let serviceName;
 
@@ -271,7 +275,9 @@ Data(maxQueryLengthInstances).Scenario(
       await pmmInventoryPage.checkAgentOtherDetailsSection(AGENT_NAMES.QAN_MYSQL_PERFSCHEMA_AGENT, `max_query_length=${maxQueryLength}`);
     }
 
-    if (maxQueryLength === '' || maxQueryLength === '-1') {
+    const exampleQueryMarker = exampleQueryMarkers[maxQueryLength];
+
+    if (exampleQueryMarker) {
       // QAN only has an Example for a query still present in
       // performance_schema.events_statements_history, which keeps statements of live
       // threads only. On this idle instance the profile is topped by exporter queries

--- a/codeceptjs-e2e/tests/verifyTLSMySQLRemoteInstance_test.js
+++ b/codeceptjs-e2e/tests/verifyTLSMySQLRemoteInstance_test.js
@@ -26,6 +26,11 @@ maxQueryLengthInstances.add(['mysql_8.0_ssl_service', '8.0', 'mysql_ssl_8.0', 'm
 maxQueryLengthInstances.add(['mysql_8.0_ssl_service', '8.0', 'mysql_ssl_8.0', 'mysql_ssl', 'mysql_global_status_max_used_connections', '-1']);
 maxQueryLengthInstances.add(['mysql_8.0_ssl_service', '8.0', 'mysql_ssl_8.0', 'mysql_ssl', 'mysql_global_status_max_used_connections', '']);
 
+// Nothing else running against the SSL MySQL instance reads
+// information_schema.character_sets, so a QAN search on it returns only this test's
+// own probe query.
+const exampleQueryMarker = 'character_sets';
+
 let serviceName;
 
 BeforeSuite(async ({ inventoryAPI }) => {
@@ -266,6 +271,15 @@ Data(maxQueryLengthInstances).Scenario(
       await pmmInventoryPage.checkAgentOtherDetailsSection(AGENT_NAMES.QAN_MYSQL_PERFSCHEMA_AGENT, `max_query_length=${maxQueryLength}`);
     }
 
+    if (maxQueryLength === '' || maxQueryLength === '-1') {
+      // QAN only has an Example for a query still present in
+      // performance_schema.events_statements_history, which keeps statements of live
+      // threads only. On this idle instance the profile is topped by exporter queries
+      // whose connections are gone, so run one application query from a connection held
+      // open past the agent's history poll and assert on that row instead.
+      await I.verifyCommand(`docker exec -d ${container} bash -c 'mysql -upmm -ppmm -e "SELECT COUNT(*) FROM information_schema.${exampleQueryMarker}; DO SLEEP(120);"'`);
+    }
+
     // This extra time is needed for queries to appear in QAN
     await I.wait(70);
     // Check max visible query length is less than max_query_length option
@@ -281,6 +295,8 @@ Data(maxQueryLengthInstances).Scenario(
     } else {
       // 6 is chosen because it's the length of "SELECT" any query that starts with that word should be longer
       assert.ok(queryFromRow.length >= 6, `Query length is equal to ${queryFromRow.length} which is less than minimal possible length`);
+      queryAnalyticsPage.data.searchByValue(exampleQueryMarker);
+      queryAnalyticsPage.waitForLoaded();
       queryAnalyticsPage.data.selectRow(1);
       queryAnalyticsPage.waitForLoaded();
       queryAnalyticsPage.queryDetails.checkExamplesTab();

--- a/codeceptjs-e2e/tests/verifyTLSMySQLRemoteInstance_test.js
+++ b/codeceptjs-e2e/tests/verifyTLSMySQLRemoteInstance_test.js
@@ -276,8 +276,10 @@ Data(maxQueryLengthInstances).Scenario(
       // performance_schema.events_statements_history, which keeps statements of live
       // threads only. On this idle instance the profile is topped by exporter queries
       // whose connections are gone, so run one application query from a connection held
-      // open past the agent's history poll and assert on that row instead.
-      await I.verifyCommand(`docker exec -d ${container} bash -c 'mysql -upmm -ppmm -e "SELECT COUNT(*) FROM information_schema.${exampleQueryMarker}; DO SLEEP(120);"'`);
+      // open past the agent's history poll and assert on that row instead. The client
+      // idles on stdin rather than sleeping in SQL, so the probe adds no query time of
+      // its own and leaves the profile's ranking alone.
+      await I.verifyCommand(`docker exec -d ${container} bash -c '{ echo "SELECT COUNT(*) FROM information_schema.${exampleQueryMarker};"; sleep 120; } | mysql -upmm -ppmm'`);
     }
 
     // This extra time is needed for queries to appear in QAN


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://github.com/percona/pmm-qa/actions/runs/34732860168 (`E2E tests Matrix`, scheduled, `main`)
- tests:
  - `codeceptjs-e2e/tests/verifyTLSMySQLRemoteInstance_test.js` / `@ssl-mysql` — `PMM-T1403 + PMM-T1404 + PMM-T1426 + PMM-T1431`, the `maxQueryLength: ""` data row

## What failed

One job, one test:

```
element (//*[@data-testid="highlight-code" or contains(@class, "pretty-json-container")])
  still not visible after 30 sec.
  at QueryAnalyticsQueryDetails.checkExamplesTab
     (./tests/pages/components/queryAnalytics/queryAnalyticsQueryDetails.js:100:7)
```

Byte-identical in four scheduled runs — [Aug 23](https://github.com/percona/pmm-qa/actions/runs/32613108284), [Sep 9](https://github.com/percona/pmm-qa/actions/runs/34302870386), [Sep 12](https://github.com/percona/pmm-qa/actions/runs/34667431621), [Sep 13](https://github.com/percona/pmm-qa/actions/runs/34732860168) — so it predates the recent cluster by three weeks rather than being new.

Nothing in the repo explains it. The scenario itself is unchanged since July; the only edit to `queryAnalyticsQueryDetails.js` since (`ec61e4c`, Sep 4) rewrites `compareCalculation` and the humanized-value helpers and touches nothing on the Examples path. No commit in the window touches `qa-integration/pmm_qa/tls-ssl-setup/` or anything else that runs against the SSL MySQL instance — the setup-adjacent commits are client-download resilience (#1366, #1369), a MinIO registry switch (#1418, not part of `ssl_mysql`), and #1384, which landed after that day's run and only changes the *nightly* workflow.

What settles it: **[Sep 13](https://github.com/percona/pmm-qa/actions/runs/34732860168) failed and [Sep 14](https://github.com/percona/pmm-qa/actions/runs/34799127047) passed on the same pmm-qa commit `f4f1cbc6` and the same PMM Server image digest `sha256:06f2a8fe…`.** Identical inputs, opposite outcomes.

## Why

`v1/qan/query:getExample` returned `{}` for the selected row. From the failed run's own Playwright trace, the row the test had selected was rank 1 by load:

```
rank 1  SET `lock_wait_timeout` = ?   (282 executions, from the exporter)
```

QAN can only show an Example for a digest still present in `performance_schema.events_statements_history`, which holds statements of **live threads only** (`agent/agents/mysql/perfschema/history.go:52` selects straight from that view). On the `mysql_ssl_8.0` container there is no application workload at all — `qa-integration/pmm_qa/tls-ssl-setup/mysql_tls_setup.yml` installs MySQL and pmm-client and nothing else — so almost every digest in the profile comes from a connection that is already gone.

Measured on a reproduction VM at the same commit and the same server build (`3.10.0-v3-8b6be9b8d`):

```
summary_digests  50      <- rows QAN can show
history_digests   5      <- rows that can have an Example
```

and through the QAN API for one of the scenario's own remote services:

```
total_rows: 49
  rank  1  example=YES   SELECT `EVENT_NAME`, `COUNT_STAR`, `SUM_TIMER_WAIT` FROM `performance_schema`…
  rank  2  example=YES   SELECT `performance_schema`.`events_statements_history`…
  rank  3  example=YES   SHOW GLOBAL STATUS
  rank  4  example=NO    SELECT COLUMN_NAME FROM `information_schema`.`columns`…
  rank  5  example=NO    SELECT NAME, `subsystem`, TYPE, COMMENT, `count` FROM `information_schema`…
  rank  6  example=NO    SELECT `c`.`table_schema`, `c`.`table_name`, COLUMN_NAME…
```

So the check is a lottery on which exporter query happens to rank first: ~3 of ~50 rows can satisfy it, and which one wins depends on runner contention, not on anything the repo controls. PMM is behaving as designed here — this is the test asking for data the environment never produced.

## Fix

Give the scenario a query it owns. Before the existing 70s wait, the two data rows that reach the Examples/Explain branch (`-1` and `""`) run one application query on the monitored instance from a connection held open past the QAN agent's 5s history poll, then search the profile for it and assert on that row.

The connection idles on stdin rather than sleeping in SQL. `DO SLEEP(120)` was the first attempt and it accrued 120s of query time, which made the probe itself rank 1 and left the neighbouring "query is not truncated" assertion (`queryFromRow.length >= 6`) measuring a synthetic statement — verified on the box, `DO `SLEEP` (?)` at rank 1. Idling on stdin leaves the profile's ranking untouched.

Nothing is loosened: before this change the Examples/Explain check ran against whichever exporter query topped an idle instance's profile; now it runs against a real application query, which is what the untruncated-`max_query_length` path is meant to prove. The `length >= 6` assertion still reads the unfiltered top-by-load row exactly as before.

A middle commit gave each probing row its own marker table, on the grounds that opening the Explain tab makes PMM re-run the probe as `EXPLAIN <query>` and `EXPLAIN FORMAT = JSON <query>` under the same table name. **That premise was wrong and the commit after it removes the machinery** ([thread](https://github.com/percona/pmm-qa/pull/1420#discussion_r3998778193)): the three-digest count was read off `events_statements_summary_by_digest` directly, not off a service-filtered profile. `PerfSchema.Run` seeds `summaryCache` from `getSummaries` before its first collection (`agent/agents/mysql/perfschema/perfschema.go:204-217`) and `makeBuckets` skips any digest whose `CountStar` has not moved since that baseline (`:442`), so a digest last executed before a row's own agent started never reaches QAN under that row's service. One table is enough.

## Verification

Reproduction VM: single-server Docker on Linode, the workflow's own steps (`docker compose` + `pmm3-client-setup.sh` + `pmm-framework --database ssl_mysql`), `perconalab/pmm-server:3-dev-latest` resolving to the same `3.10.0-v3-8b6be9b8d` the failed run used.

- **The failure did not reproduce there**, idle (15/15 `@ssl-mysql`) or with the box saturated (12 spinners, load average ~16; 3/3 `PMM-T1403` rows). That is expected — the box's own idle profile happens to put an example-bearing query at rank 1, which is the same coin flip, landing the other way. The mechanism above, not a repro, is what identifies the failure.
- **With the fix**, 3/3 `PMM-T1403` rows passed under the same saturation. The probe path is genuinely exercised, not passing on the old lottery: `searchByValue` + `selectRow(1)` would time out if the probe query had not landed, and the instance afterwards carries `EXPLAIN SELECT COUNT(*) FROM information_schema.collations` — PMM explained the probe query, so that is the row the test selected.
- **In CI**, this PR's own `MySQL SSL tests / @ssl-mysql` job is green on **both** heads, with the full tag actually executed (non-empty Launchable subset, ~19 min test step), against the nightly's `14 passed, 1 failed`:
  - on `1586b41` — [job 103674916207](https://github.com/percona/pmm-qa/actions/runs/34738826931/job/103674916207): **15 found, 15 passed, 0 failed, 0 quarantined**
  - on `8326344` (final head, single marker table) — [job 103679540529](https://github.com/percona/pmm-qa/actions/runs/34740601092/job/103679540529): `OK | 15 passed // 19m`, **15 found, 15 passed, 0 failed, 0 quarantined**

  The second of those is also the empirical check asked for in the marker-table thread: with one table, the `""` row's search resolves to its own probe query and both Examples and Explain pass.

The whole matrix is green on the final head ([run 34740601092](https://github.com/percona/pmm-qa/actions/runs/34740601092), attempt 2, 36/36). Attempt 1 had one unrelated failure — `FB E2E tests / PSMDB Arbiter Replica UI tests / @pmm-psmdb-arbiter-integration` died in `Setup PMM Server` on a Docker Hub `read: connection reset by peer` pulling `perconalab/percona-distribution-postgresql:15.4`, before any test body ran. That endpoint answers `200` on a direct probe, so it was transient rather than a moved tag; the single re-run cleared it.

`verifyTLSPostgresRemoteInstance_test.js` has the same shape at `:275`. `@ssl-postgres` is green and pg_stat_statements handles examples differently, so it is left alone rather than changed blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDYHRsfwPdbUyStkogpMww